### PR TITLE
Add package: graphql-parser

### DIFF
--- a/new-packages.json
+++ b/new-packages.json
@@ -15,5 +15,6 @@
   "purescript-grain-router": "https://github.com/purescript-grain/purescript-grain-router.git",
   "purescript-grain-virtualized": "https://github.com/purescript-grain/purescript-grain-virtualized.git",
   "purescript-quickcheck-mbt": "https://github.com/meeshkan/purescript-quickcheck-mbt.git",
-  "purescript-openapi": "https://github.com/meeshkan/purescript-openapi.git"
+  "purescript-openapi": "https://github.com/meeshkan/purescript-openapi.git",
+  "purescript-graphql-parser": "https://github.com/meeshkan/purescript-graphql-parser.git"
 }


### PR DESCRIPTION
This is, to my knowledge, the only complete graphql parser for the June 2018 graphql spec written in purescript.