### PR TITLE
Add halogen-svg-elems

### DIFF
--- a/new-packages.json
+++ b/new-packages.json
@@ -20,5 +20,5 @@
   "purescript-http-types-basic": "https://github.com/meeshkan/purescript-http-types.git",
   "purescript-graphql-gen": "https://github.com/meeshkan/purescript-graphql-gen.git",
   "purescript-graphql-validator": "https://github.com/meeshkan/purescript-graphql-validator.git",
-  "purescript-halogen-svg": "https://github.com/JordanMartinez/purescript-halogen-svg.git"
+  "purescript-halogen-svg-elems": "https://github.com/JordanMartinez/purescript-halogen-svg-elems.git"
 }

--- a/new-packages.json
+++ b/new-packages.json
@@ -19,5 +19,6 @@
   "purescript-graphql-parser": "https://github.com/meeshkan/purescript-graphql-parser.git",
   "purescript-http-types-basic": "https://github.com/meeshkan/purescript-http-types.git",
   "purescript-graphql-gen": "https://github.com/meeshkan/purescript-graphql-gen.git",
-  "purescript-graphql-validator": "https://github.com/meeshkan/purescript-graphql-validator.git"
+  "purescript-graphql-validator": "https://github.com/meeshkan/purescript-graphql-validator.git",
+  "purescript-halogen-svg": "https://github.com/JordanMartinez/purescript-halogen-svg.git"
 }


### PR DESCRIPTION
This is a fork of [Statebox](https://github.com/statebox/purescript-halogen-svg)'s repo, which is a fork of the [original repo](https://github.com/kwohlfahrt/purescript-halogen-svg). I'm adding my fork here, so i can implement the next few Elm Examples in the cookbook repo. 

If Statebox wants to push their fork here in the future in place of mine, by all means, please do.