### PR TITLE
Update `purescript-halogen-svg` to point to statebox fork

### DIFF
--- a/bower-packages.json
+++ b/bower-packages.json
@@ -569,7 +569,7 @@
   "purescript-halogen-select": "https://github.com/citizennet/purescript-halogen-select.git",
   "purescript-halogen-selects": "https://github.com/slamdata/purescript-halogen-selects.git",
   "purescript-halogen-storybook": "https://github.com/rnons/purescript-halogen-storybook.git",
-  "purescript-halogen-svg": "https://github.com/AidanDelaney/purescript-halogen-svg.git",
+  "purescript-halogen-svg": "https://github.com/statebox/purescript-halogen-svg.git",
   "purescript-halogen-vdom": "https://github.com/slamdata/purescript-halogen-vdom.git",
   "purescript-halogen-vdom-string-renderer": "https://github.com/slamdata/purescript-halogen-vdom-string-renderer.git",
   "purescript-halogen-virtual-dom": "https://github.com/slamdata/purescript-halogen-virtual-dom.git",


### PR DESCRIPTION
See #38 for more context.

Erik from Statebox was on the PS Meetup yesterday. Their fork isn't inactive as I thought. Also, it was my understanding that he would like to push their fork to the package set. I guess he hadn't been notified about the issue I opened in their corresponding fork. So, I thought I'd help out by updating the name to use their fork since Thomas had mentioned doing that in the PR linked above.