### PR TITLE
Support multiple package versions in monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ let Manifest =
       { name : Text
       -- The SPDX code for the license under which the code is released
       , license : Text
+      -- The version of this package
+      , version : Text
       -- The git repo the package is published at
       , repository : ./Repo.dhall
       -- Compilation targets for the Package
@@ -180,9 +182,10 @@ is an example of such link.
 
 Once the issue is open, the [CI in this repo](#The-Registry-CI) will:
 - detect if this is an `Addition`, and continue running if so
-- fetch all the releases for the package being added (looking at the `location` value in the metadata)
-- fetch the source of the last one, and run the [checks for package admission](#Checks-on-new-packages).
-  Note: package managers are expected to run the same checks locally as well, to tighten the feedback time for authors.
+- fetch the git repo the `Repo` refers to, checking out the `ref` it specifies,
+  and considering the package directory to be `subdir` if specified, or the root of the repo if not
+- run the [checks for package admission](#Checks-on-new-packages) on the package source we just checked out
+  Note: package managers are generally expected to run the same checks locally as well, to tighten the feedback time for authors.
 - if all is well, upload the tarball to the [storages](#Storage-backends).
   Note: if any of the Storage Backends is down we fail here, so that the problem can be addressed.
 - generate the [package's `Metadata` file](#Package-metadata):

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ is an example of such link.
 
 Once the issue is open, the [CI in this repo](#The-Registry-CI) will:
 - detect if this is an `Addition`, and continue running if so
-- fetch the git repo the `Repo` refers to, checking out the `ref` it specifies,
+- fetch the git repo the `Repo` refers to, checking out the `ref` specified in the `Addition`,
   and considering the package directory to be `subdir` if specified, or the root of the repo if not
 - run the [checks for package admission](#Checks-on-new-packages) on the package source we just checked out
   Note: package managers are generally expected to run the same checks locally as well, to tighten the feedback time for authors.

--- a/ci/src/BowerImport.purs
+++ b/ci/src/BowerImport.purs
@@ -129,17 +129,17 @@ main = Aff.launchAff_ do
 
 -- | Convert a Bowerfile into a Registry Manifest
 toManifest :: Bower.PackageMeta -> String -> GitHub.Address -> Manifest
-toManifest (Bower.PackageMeta bowerfile) version address
-  = { name, license, repository, targets }
+toManifest (Bower.PackageMeta bowerfile) ref address
+  = { name, license, repository, targets, version: ref }
   where
     subdir = Nothing
     name = stripPurescriptPrefix bowerfile.name
     license = String.joinWith " OR " bowerfile.license
     repository = case _.url <$> bowerfile.repository of
-      Nothing -> GitHub { repo: address.repo, owner: address.owner, version, subdir }
+      Nothing -> GitHub { repo: address.repo, owner: address.owner, ref, subdir }
       Just url -> case GitHub.parseRepo url of
-        Left _err -> Git { url, version, subdir }
-        Right { repo, owner } -> GitHub { repo, owner, version, subdir }
+        Left _err -> Git { url, ref, subdir }
+        Right { repo, owner } -> GitHub { repo, owner, ref, subdir }
     toDepPair { packageName, versionRange } = Tuple packageName versionRange
     deps = map toDepPair $ unwrap bowerfile.dependencies
     devDeps = map toDepPair $ unwrap bowerfile.devDependencies

--- a/ci/src/BowerImport.purs
+++ b/ci/src/BowerImport.purs
@@ -136,10 +136,10 @@ toManifest (Bower.PackageMeta bowerfile) ref address
     name = stripPurescriptPrefix bowerfile.name
     license = String.joinWith " OR " bowerfile.license
     repository = case _.url <$> bowerfile.repository of
-      Nothing -> GitHub { repo: address.repo, owner: address.owner, ref, subdir }
+      Nothing -> GitHub { repo: address.repo, owner: address.owner, subdir }
       Just url -> case GitHub.parseRepo url of
-        Left _err -> Git { url, ref, subdir }
-        Right { repo, owner } -> GitHub { repo, owner, ref, subdir }
+        Left _err -> Git { url, subdir }
+        Right { repo, owner } -> GitHub { repo, owner, subdir }
     toDepPair { packageName, versionRange } = Tuple packageName versionRange
     deps = map toDepPair $ unwrap bowerfile.dependencies
     devDeps = map toDepPair $ unwrap bowerfile.devDependencies

--- a/ci/src/BowerImport.purs
+++ b/ci/src/BowerImport.purs
@@ -129,8 +129,8 @@ main = Aff.launchAff_ do
 
 -- | Convert a Bowerfile into a Registry Manifest
 toManifest :: Bower.PackageMeta -> String -> GitHub.Address -> Manifest
-toManifest (Bower.PackageMeta bowerfile) ref address
-  = { name, license, repository, targets, version: ref }
+toManifest (Bower.PackageMeta bowerfile) version address
+  = { name, license, repository, targets, version }
   where
     subdir = Nothing
     name = stripPurescriptPrefix bowerfile.name

--- a/ci/src/RegistrySchema.purs
+++ b/ci/src/RegistrySchema.purs
@@ -12,6 +12,7 @@ import Foreign.Object as Foreign
 -- | PureScript encoding of ../v1/Manifest.dhall
 type Manifest =
   { name :: String
+  , version :: String -- TODO: we should have a newtype for this
   , license :: String
   , repository :: Repo
   , targets :: Foreign.Object Target
@@ -24,7 +25,7 @@ type Target =
 
 
 type RepoData d =
-  { version :: String
+  { ref :: String
   , subdir :: Maybe String
   | d
   }
@@ -43,28 +44,28 @@ data Repo
 -- | We encode it this way so that json-to-dhall can read it
 instance repoEncodeJson :: Json.EncodeJson Repo where
   encodeJson = case _ of
-    Git { subdir, url, version }
+    Git { subdir, url, ref }
       -> "url" := url
-      ~> "version" := version
+      ~> "ref" := ref
       ~> "subdir" :=? subdir
       ~>? jsonEmptyObject
-    GitHub { repo, owner, version, subdir }
+    GitHub { repo, owner, ref, subdir }
       -> "githubRepo" := repo
       ~> "githubOwner" := owner
-      ~> "version" := version
+      ~> "ref" := ref
       ~> "subdir" :=? subdir
       ~>? jsonEmptyObject
 
 instance repoDecodeJson :: Json.DecodeJson Repo where
   decodeJson json = do
     obj <- Json.decodeJson json
-    version <- obj .: "version"
+    ref <- obj .: "ref"
     subdir <- obj .:? "subdir" .!= mempty
     let parseGitHub = do
           owner <- obj .: "githubOwner"
           repo <- obj .: "githubRepo"
-          pure $ GitHub { owner, repo, version, subdir }
+          pure $ GitHub { owner, repo, ref, subdir }
     let parseGit = do
           url <- obj .: "url"
-          pure $ Git { url, version, subdir }
+          pure $ Git { url, ref, subdir }
     parseGitHub <|> parseGit

--- a/ci/src/RegistrySchema.purs
+++ b/ci/src/RegistrySchema.purs
@@ -25,8 +25,7 @@ type Target =
 
 
 type RepoData d =
-  { ref :: String
-  , subdir :: Maybe String
+  { subdir :: Maybe String
   | d
   }
 
@@ -46,26 +45,23 @@ instance repoEncodeJson :: Json.EncodeJson Repo where
   encodeJson = case _ of
     Git { subdir, url, ref }
       -> "url" := url
-      ~> "ref" := ref
       ~> "subdir" :=? subdir
       ~>? jsonEmptyObject
     GitHub { repo, owner, ref, subdir }
       -> "githubRepo" := repo
       ~> "githubOwner" := owner
-      ~> "ref" := ref
       ~> "subdir" :=? subdir
       ~>? jsonEmptyObject
 
 instance repoDecodeJson :: Json.DecodeJson Repo where
   decodeJson json = do
     obj <- Json.decodeJson json
-    ref <- obj .: "ref"
     subdir <- obj .:? "subdir" .!= mempty
     let parseGitHub = do
           owner <- obj .: "githubOwner"
           repo <- obj .: "githubRepo"
-          pure $ GitHub { owner, repo, ref, subdir }
+          pure $ GitHub { owner, repo, subdir }
     let parseGit = do
           url <- obj .: "url"
-          pure $ Git { url, ref, subdir }
+          pure $ Git { url, subdir }
     parseGitHub <|> parseGit

--- a/ci/src/RegistrySchema.purs
+++ b/ci/src/RegistrySchema.purs
@@ -43,11 +43,11 @@ data Repo
 -- | We encode it this way so that json-to-dhall can read it
 instance repoEncodeJson :: Json.EncodeJson Repo where
   encodeJson = case _ of
-    Git { subdir, url, ref }
+    Git { subdir, url }
       -> "url" := url
       ~> "subdir" :=? subdir
       ~>? jsonEmptyObject
-    GitHub { repo, owner, ref, subdir }
+    GitHub { repo, owner, subdir }
       -> "githubRepo" := repo
       ~> "githubOwner" := owner
       ~> "subdir" :=? subdir

--- a/examples/aff/v5.1.2.json
+++ b/examples/aff/v5.1.2.json
@@ -37,7 +37,6 @@
     }
   },
   "repository": {
-    "ref": "v5.1.2",
     "githubOwner": "slamdata",
     "githubRepo": "purescript-aff"
   },

--- a/examples/aff/v5.1.2.json
+++ b/examples/aff/v5.1.2.json
@@ -1,4 +1,5 @@
 {
+  "version": "v5.1.2",
   "targets": {
     "lib": {
       "sources": [
@@ -41,6 +42,5 @@
     "githubRepo": "purescript-aff"
   },
   "name": "aff",
-  "version": "v5.1.2",
   "license": "Apache-2.0"
 }

--- a/examples/aff/v5.1.2.json
+++ b/examples/aff/v5.1.2.json
@@ -36,10 +36,11 @@
     }
   },
   "repository": {
-    "version": "v5.1.2",
+    "ref": "v5.1.2",
     "githubOwner": "slamdata",
     "githubRepo": "purescript-aff"
   },
   "name": "aff",
+  "version": "v5.1.2",
   "license": "Apache-2.0"
 }

--- a/examples/mysql/v4.1.1.json
+++ b/examples/mysql/v4.1.1.json
@@ -25,10 +25,11 @@
     }
   },
   "repository": {
-    "version": "v4.1.1",
+    "ref": "v4.1.1",
     "githubOwner": "oreshinya",
     "githubRepo": "purescript-mysql"
   },
   "name": "mysql",
+  "version": "v4.1.1",
   "license": "MIT"
 }

--- a/examples/mysql/v4.1.1.json
+++ b/examples/mysql/v4.1.1.json
@@ -26,7 +26,6 @@
     }
   },
   "repository": {
-    "ref": "v4.1.1",
     "githubOwner": "oreshinya",
     "githubRepo": "purescript-mysql"
   },

--- a/examples/mysql/v4.1.1.json
+++ b/examples/mysql/v4.1.1.json
@@ -1,4 +1,5 @@
 {
+  "version": "v4.1.1",
   "targets": {
     "lib": {
       "sources": [
@@ -30,6 +31,5 @@
     "githubRepo": "purescript-mysql"
   },
   "name": "mysql",
-  "version": "v4.1.1",
   "license": "MIT"
 }

--- a/examples/prelude/v4.1.1.json
+++ b/examples/prelude/v4.1.1.json
@@ -8,10 +8,11 @@
     }
   },
   "repository": {
-    "version": "v4.1.1",
+    "ref": "v4.1.1",
     "githubOwner": "purescript",
     "githubRepo": "purescript-prelude"
   },
   "name": "prelude",
+  "version": "v4.1.1",
   "license": "BSD-3-Clause"
 }

--- a/examples/prelude/v4.1.1.json
+++ b/examples/prelude/v4.1.1.json
@@ -1,4 +1,5 @@
 {
+  "version": "v4.1.1",
   "targets": {
     "lib": {
       "sources": [
@@ -13,6 +14,5 @@
     "githubRepo": "purescript-prelude"
   },
   "name": "prelude",
-  "version": "v4.1.1",
   "license": "BSD-3-Clause"
 }

--- a/examples/prelude/v4.1.1.json
+++ b/examples/prelude/v4.1.1.json
@@ -9,7 +9,6 @@
     }
   },
   "repository": {
-    "ref": "v4.1.1",
     "githubOwner": "purescript",
     "githubRepo": "purescript-prelude"
   },

--- a/v1/Manifest.dhall
+++ b/v1/Manifest.dhall
@@ -15,6 +15,8 @@ let Manifest =
       { name : Text
       -- The SPDX code for the license under which the code is released
       , license : Text
+      -- The version of this package
+      , version : Text
       -- The git repo the package is published at
       , repository : ./Repo.dhall
       -- Compilation targets for the Package

--- a/v1/Metadata.dhall
+++ b/v1/Metadata.dhall
@@ -9,12 +9,16 @@ let Map = (./Prelude.dhall).Map.Type
 
 let Repo = ./Repo.dhall
 
+let Version = { version : Text, revision : Natural }
+
+let Release = { ref : Text, hash : Text }
+
 in
   {
   -- The pointer to where the code lives
   , location : Repo
-  -- A mapping between version number and the hash of its tarball
-  , versions : Map Text Text
+  -- A mapping between versions and info about a release
+  , releases : Map Version Release
   -- A mapping between a version number and the reason for unpublishing
   , unpublished : Map Text Text
   -- The list of maintainers of a package (note: these are GitHub usernames)

--- a/v1/Operation.dhall
+++ b/v1/Operation.dhall
@@ -7,7 +7,7 @@ A type describing all the possible operations for the Registry API.
 let Repo = ./Repo.dhall
 
 in
-  < Addition : { packageName : Text, newPackageLocation : Repo, addToPackageSet: Bool }
-  | Update : { packageName : Text, newVersion : Text }
+  < Addition : { packageName : Text, newPackageLocation : Repo, newRef : Text, addToPackageSet: Bool }
+  | Update : { packageName : Text, updateRef : Text }
   | Unpublish : { packageName : Text, unpublishVersion : Text, unpublishReason: Text }
   >

--- a/v1/Repo.dhall
+++ b/v1/Repo.dhall
@@ -1,6 +1,6 @@
 {-
 
-Coordinates for a package, i.e. "some kind of Git thing".
+Coordinates for a package, i.e. "some kind of Git place".
 
 We have special support for GitHub because it's easier for us if packages are
 there, as we use their API to do things, e.g. to fetch commit tarballs.
@@ -10,8 +10,7 @@ we can allow hosting packages on other providers too.
 -}
 
 let CommonData =
-  { ref : Text
-  , subdir : Optional Text
+  { subdir : Optional Text
   }
 
 let GitHubData = CommonData //\\

--- a/v1/Repo.dhall
+++ b/v1/Repo.dhall
@@ -10,7 +10,7 @@ we can allow hosting packages on other providers too.
 -}
 
 let CommonData =
-  { version : Text
+  { ref : Text
   , subdir : Optional Text
   }
 


### PR DESCRIPTION
..by specifying the `version` field inside the `Manifest`, and not relying anymore on the assumption "one git tag == one release", but instead using any ref to fetch the sources.

This is related to #16 