### PR TITLE
Run CI on push to master or pull request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 name: tests
 
 on:
+  push: 
+    branches: [master]
   pull_request:
-  push:
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This minor tweak updates CI so that it runs on any push to master, and on any push to a pull request (including opening the pull request), but not both. Running on any push / pull request will trigger CI twice on pull requests, which unnecessarily wastes resources.