### PR TITLE
Adds purescript painting

### DIFF
--- a/new-packages.json
+++ b/new-packages.json
@@ -104,5 +104,6 @@
   "purescript-kafkajs": "https://github.com/HivemindTechnologies/purescript-kafkajs.git",
   "purescript-sytc": "https://github.com/mikesol/purescript-sytc.git",
   "purescript-typelevel-graph": "https://github.com/mikesol/purescript-typelevel-graph.git",
-  "purescript-barlow-lens": "https://github.com/sigma-andex/purescript-barlow-lens.git"
+  "purescript-barlow-lens": "https://github.com/sigma-andex/purescript-barlow-lens.git",
+  "purescript-painting": "https://github.com/mikesol/purescript-painting.git"
 }


### PR DESCRIPTION
Purescript painting is more or less a fork of purescript-drawing. It was an internal package in purescript-audio-behaviors but, with the recent read-only-mode-ification of purescript drawing, it felt like it made sense to split this out into its own package.