### PR TITLE
Split polyform-validators into mutliple libs

### DIFF
--- a/bower-packages.json
+++ b/bower-packages.json
@@ -931,7 +931,7 @@
   "purescript-plottable": "https://github.com/atomicits/purescript-plottable.git",
   "purescript-pointed-list": "https://github.com/paluh/purescript-pointed-list.git",
   "purescript-polyform": "https://github.com/purescript-polyform/polyform.git",
-  "purescript-polyform-validators": "https://github.com/purescript-polyform/batteries-core.git",
+  "purescript-polyform-validators": "https://github.com/lambdaterms/purescript-polyform-validators.git",
   "purescript-polymorphic-vectors": "https://github.com/artemisSystem/purescript-polymorphic-vectors.git",
   "purescript-polynomials": "https://github.com/hdgarrood/purescript-polynomials.git",
   "purescript-posix-types": "https://github.com/purescript-node/purescript-posix-types.git",

--- a/new-packages.json
+++ b/new-packages.json
@@ -133,5 +133,9 @@
   "purescript-options-extra": "https://github.com/PureFunctor/purescript-options-extra.git",
   "purescript-halogen-store": "https://github.com/thomashoneyman/purescript-halogen-store.git",
   "purescript-elasticsearch": "https://github.com/ConnorDillon/purescript-elasticsearch.git",
-  "purescript-read-generic": "https://github.com/Swordlash/purescript-read-generic.git"
+  "purescript-read-generic": "https://github.com/Swordlash/purescript-read-generic.git",
+  "purescript-batteries-core": "https://github.com/purescript-polyform/batteries-core.git",
+  "purescript-batteries-env": "https://github.com/purescript-polyform/batteries-env.git",
+  "purescript-batteries-json": "https://github.com/purescript-polyform/batteries-json.git",
+  "purescript-batteries-urlencoded": "https://github.com/purescript-polyform/batteries-urlencoded.git"
 }


### PR DESCRIPTION
I made a proper release of the old lib with deprecation warning.