### PR TITLE
Add purescript-google-apps

### DIFF
--- a/new-packages.json
+++ b/new-packages.json
@@ -139,5 +139,6 @@
   "purescript-batteries-json": "https://github.com/purescript-polyform/batteries-json.git",
   "purescript-batteries-urlencoded": "https://github.com/purescript-polyform/batteries-urlencoded.git",
   "purescript-typelevel-codec-json": "https://github.com/JordanMartinez/purescript-typelevel-codec-json.git",
-  "purescript-dexie": "https://github.com/mushishi78/purescript-dexie.git"
+  "purescript-dexie": "https://github.com/mushishi78/purescript-dexie.git",
+  "purescript-google-apps": "https://github.com/BBVA/purescript-google-apps.git"
 }


### PR DESCRIPTION
A library to build Google App Scripts with Purescript.