### PR TITLE
Introduce purs-tidy

### DIFF
--- a/ci/.tidyrc.json
+++ b/ci/.tidyrc.json
@@ -1,0 +1,5 @@
+{
+  "indent": 2,
+  "typeArrowPlacement": "first",
+  "unicode": "never"
+}

--- a/ci/src/Foreign/Dhall.purs
+++ b/ci/src/Foreign/Dhall.purs
@@ -9,7 +9,7 @@ jsonToDhallManifest :: String -> Aff (Either String String)
 jsonToDhallManifest jsonStr = do
   let cmd = "json-to-dhall"
   let stdin = Just jsonStr
-  let args = ["--records-loose", "--unions-strict", "../v1/Manifest.dhall"]
+  let args = [ "--records-loose", "--unions-strict", "../v1/Manifest.dhall" ]
   result <- Process.spawn { cmd, stdin, args } NodeProcess.defaultSpawnOptions
   pure $ case result.exit of
     NodeProcess.Normally 0 -> Right jsonStr

--- a/ci/src/Foreign/GitHub.purs
+++ b/ci/src/Foreign/GitHub.purs
@@ -48,7 +48,7 @@ parseRepo = Parser.runParser do
     <|> Parse.string "git://github.com/"
     <|> Parse.string "git@github.com:"
   owner <- map (fromCharArray <<< List.toUnfoldable)
-    $ ParseC.manyTill (ParseC.choice [Parse.alphaNum, Parse.char '-']) (Parse.char '/')
+    $ ParseC.manyTill (ParseC.choice [ Parse.alphaNum, Parse.char '-' ]) (Parse.char '/')
   repoWithSuffix <- map (fromCharArray <<< List.toUnfoldable)
     $ ParseC.many Parse.anyChar
   let repo = fromMaybe repoWithSuffix $ String.stripSuffix (String.Pattern ".git") repoWithSuffix

--- a/ci/src/Foreign/S3.purs
+++ b/ci/src/Foreign/S3.purs
@@ -1,11 +1,11 @@
-module Foreign.S3 (
-  connect,
-  listObjects,
-  putObject,
-  S3,
-  Space,
-  ACL(..)
-) where
+module Foreign.S3
+  ( connect
+  , listObjects
+  , putObject
+  , S3
+  , Space
+  , ACL(..)
+  ) where
 
 import Registry.Prelude
 
@@ -13,7 +13,6 @@ import Control.Promise (Promise)
 import Control.Promise as Promise
 import Data.Function.Uncurried (Fn1, Fn2, runFn1, runFn2)
 import Data.JSDate (JSDate)
-
 
 foreign import data S3 :: Type
 
@@ -24,7 +23,6 @@ connect :: String -> String -> Aff Space
 connect region bucket = do
   conn <- liftEffect $ runFn1 connectImpl region
   pure { bucket, conn }
-
 
 -- Add more params as needed:
 -- https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#listObjectsV2-property
@@ -51,7 +49,6 @@ listObjects space params = do
   (jsObjs :: Array JSListResponse) <- Promise.toAffE (runFn2 listObjectsImpl space.conn jsParams)
   for jsObjs \obj -> pure { key: obj."Key", size: obj."Size", eTag: obj."ETag" } -- TODO: pull more props if needed
 
-
 -- Add more params as needed:
 -- https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property
 type JSPutParams =
@@ -64,15 +61,16 @@ type JSPutParams =
 type JSPutResponse = { "ETag" :: String }
 
 data ACL = Private | PublicRead
-type PutParams = { key :: String,  body :: Buffer, acl :: ACL }
+type PutParams = { key :: String, body :: Buffer, acl :: ACL }
 type PutResponse = { eTag :: String }
 
 foreign import putObjectImpl :: Fn2 S3 JSPutParams (Effect (Promise JSPutResponse))
 putObject :: Space -> PutParams -> Aff PutResponse
 putObject space params = do
-  let jsACL = case params.acl of
-        Private -> "private"
-        PublicRead -> "public-read"
+  let
+    jsACL = case params.acl of
+      Private -> "private"
+      PublicRead -> "public-read"
   let jsParams = { "Bucket": space.bucket, "Key": params.key, "Body": params.body, "ACL": jsACL }
   res <- Promise.toAffE (runFn2 putObjectImpl space.conn jsParams)
   pure { eTag: res."ETag" }

--- a/ci/src/Registry/PackageName.purs
+++ b/ci/src/Registry/PackageName.purs
@@ -43,7 +43,7 @@ parse = Parser.runParser do
     manyDashesErr = "Package names cannot contain consecutive dashes"
 
   let
-    char = ParseC.choice [Parse.lowerCaseChar, Parse.anyDigit] <?> charErr
+    char = ParseC.choice [ Parse.lowerCaseChar, Parse.anyDigit ] <?> charErr
     dash = void $ Parse.char '-'
     chunk = ParseC.many1 char
 

--- a/ci/src/Registry/RegistryM.purs
+++ b/ci/src/Registry/RegistryM.purs
@@ -47,7 +47,6 @@ comment body = do
 closeIssue :: RegistryM Unit
 closeIssue = asks _.closeIssue >>= liftAff
 
-
 -- | Post an error to the user's issue and then throw an exception
 throwWithComment :: forall a. String -> RegistryM a
 throwWithComment body = comment body *> Aff.throwError (Aff.error body)
@@ -55,8 +54,8 @@ throwWithComment body = comment body *> Aff.throwError (Aff.error body)
 -- | Commit a change to the default branch of the registry repository
 commitToTrunk :: PackageName -> FilePath -> RegistryM (Either String Unit)
 commitToTrunk packageName path = do
- f <- asks _.commitToTrunk
- liftAff $ f packageName path
+  f <- asks _.commitToTrunk
+  liftAff $ f packageName path
 
 -- | Upload a package to the backend storage provider
 uploadPackage :: Upload.PackageInfo -> FilePath -> RegistryM Unit

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -27,7 +27,6 @@ type Target =
   , sources :: Array String
   }
 
-
 type RepoData d =
   { subdir :: Maybe String
   | d
@@ -38,7 +37,7 @@ type GitHubData = RepoData
   , repo :: String
   )
 
-type GitData = RepoData ( url :: String )
+type GitData = RepoData (url :: String)
 
 data Repo
   = Git GitData
@@ -54,27 +53,29 @@ instance showRepo :: Show Repo where
 -- | We encode it this way so that json-to-dhall can read it
 instance repoEncodeJson :: Json.EncodeJson Repo where
   encodeJson = case _ of
-    Git { subdir, url }
-      -> "url" := url
-      ~> "subdir" :=? subdir
-      ~>? jsonEmptyObject
-    GitHub { repo, owner, subdir }
-      -> "githubRepo" := repo
-      ~> "githubOwner" := owner
-      ~> "subdir" :=? subdir
-      ~>? jsonEmptyObject
+    Git { subdir, url } ->
+      "url" := url
+        ~> "subdir" :=? subdir
+        ~>? jsonEmptyObject
+    GitHub { repo, owner, subdir } ->
+      "githubRepo" := repo
+        ~> "githubOwner" := owner
+        ~> "subdir" :=? subdir
+        ~>? jsonEmptyObject
 
 instance repoDecodeJson :: Json.DecodeJson Repo where
   decodeJson json = do
     obj <- Json.decodeJson json
     subdir <- obj .:? "subdir" .!= mempty
-    let parseGitHub = do
-          owner <- obj .: "githubOwner"
-          repo <- obj .: "githubRepo"
-          pure $ GitHub { owner, repo, subdir }
-    let parseGit = do
-          url <- obj .: "url"
-          pure $ Git { url, subdir }
+    let
+      parseGitHub = do
+        owner <- obj .: "githubOwner"
+        repo <- obj .: "githubRepo"
+        pure $ GitHub { owner, repo, subdir }
+    let
+      parseGit = do
+        url <- obj .: "url"
+        pure $ Git { url, subdir }
     parseGitHub <|> parseGit
 
 -- | PureScript encoding of ../v1/Operation.dhall
@@ -101,20 +102,23 @@ instance operationDecodeJson :: Json.DecodeJson Operation where
   decodeJson json = do
     o <- Json.decodeJson json
     packageName <- o .: "packageName"
-    let parseAddition = do
-          addToPackageSet <- o .: "addToPackageSet"
-          fromBower <- o .: "fromBower"
-          newPackageLocation <- o .: "newPackageLocation"
-          newRef <- o .: "newRef"
-          pure $ Addition { newRef, packageName, addToPackageSet, fromBower, newPackageLocation }
-    let parseUpdate = do
-          fromBower <- o .: "fromBower"
-          updateRef <- o .: "updateRef"
-          pure $ Update { packageName, fromBower, updateRef }
-    let parseUnpublish = do
-          unpublishVersion <- o .: "unpublishVersion"
-          unpublishReason <- o .: "unpublishReason"
-          pure $ Unpublish { packageName, unpublishVersion, unpublishReason }
+    let
+      parseAddition = do
+        addToPackageSet <- o .: "addToPackageSet"
+        fromBower <- o .: "fromBower"
+        newPackageLocation <- o .: "newPackageLocation"
+        newRef <- o .: "newRef"
+        pure $ Addition { newRef, packageName, addToPackageSet, fromBower, newPackageLocation }
+    let
+      parseUpdate = do
+        fromBower <- o .: "fromBower"
+        updateRef <- o .: "updateRef"
+        pure $ Update { packageName, fromBower, updateRef }
+    let
+      parseUnpublish = do
+        unpublishVersion <- o .: "unpublishVersion"
+        unpublishReason <- o .: "unpublishReason"
+        pure $ Unpublish { packageName, unpublishVersion, unpublishReason }
     parseAddition <|> parseUpdate <|> parseUnpublish
 
 type AdditionData =
@@ -123,7 +127,7 @@ type AdditionData =
   , newPackageLocation :: Repo
   , newRef :: String
   , packageName :: PackageName
-}
+  }
 
 type UpdateData =
   { packageName :: PackageName

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -17,7 +17,7 @@ import Test.Spec.Runner (runSpec)
 type Spec = Spec.SpecT Aff Unit Identity Unit
 
 main :: Effect Unit
-main = launchAff_ $ runSpec [consoleReporter] do
+main = launchAff_ $ runSpec [ consoleReporter ] do
   Spec.describe "API" do
     Spec.describe "Checks" do
       Spec.describe "Good package names" goodPackageName
@@ -29,18 +29,20 @@ main = launchAff_ $ runSpec [consoleReporter] do
 
 goodPackageName :: Spec
 goodPackageName = do
-  let parseName str res = Spec.it str do
-        (PackageName.print <$> PackageName.parse str) `Assert.shouldEqual` (Right res)
+  let
+    parseName str res = Spec.it str do
+      (PackageName.print <$> PackageName.parse str) `Assert.shouldEqual` (Right res)
 
   parseName "a" "a"
   parseName "some-dash" "some-dash"
 
 badPackageName :: Spec
 badPackageName = do
-  let failParse str err = Spec.it str do
-        (PackageName.print <$> PackageName.parse str) `Assert.shouldSatisfy` case _ of
-          Right _ -> false
-          Left { error } -> error == err
+  let
+    failParse str err = Spec.it str do
+      (PackageName.print <$> PackageName.parse str) `Assert.shouldSatisfy` case _ of
+        Right _ -> false
+        Left { error } -> error == err
   let startErr = "Package name should start with a lower case char or a digit"
   let midErr = "Package name can contain lower case chars, digits and non-consecutive dashes"
   let endErr = "Package name should end with a lower case char or digit"
@@ -125,16 +127,18 @@ decodeEventsToOps = do
 
 semVer :: Spec
 semVer = do
-  let parseSemVer str = Spec.it ("Parse SemVer " <> str) do
-        (SemVer.printSemVer <$> SemVer.parseSemVer str) `Assert.shouldSatisfy` isJust
+  let
+    parseSemVer str = Spec.it ("Parse SemVer " <> str) do
+      (SemVer.printSemVer <$> SemVer.parseSemVer str) `Assert.shouldSatisfy` isJust
 
   parseSemVer "v1.2.3"
   parseSemVer "1.2.3-rc2"
   parseSemVer "0.1.2+r2"
 
-  let parseRange range expected = Spec.it ("Parse Range " <> show range <> " into " <> show expected) do
-        (SemVer.printRange <$> SemVer.parseRange range) `Assert.shouldSatisfy` case _ of
-          Just parsed -> parsed == expected
-          Nothing -> false
+  let
+    parseRange range expected = Spec.it ("Parse Range " <> show range <> " into " <> show expected) do
+      (SemVer.printRange <$> SemVer.parseRange range) `Assert.shouldSatisfy` case _ of
+        Just parsed -> parsed == expected
+        Nothing -> false
 
   parseRange "^1.3.4" ">=1.3.4 <2.0.0-0"


### PR DESCRIPTION
This commit introduces the purs-tidy formatter to keep consistent formatting as multiple developers work on the `ci` tree. It runs the formatter on the current code without otherwise making changes, and adds a check to CI that looks for consistent formatting. For reference, see also similar changes made in related projects:

- https://github.com/natefaubion/purescript-language-cst-parser/pull/21
- https://github.com/purescript-halogen/purescript-halogen/pull/765