### PR TITLE
Add owoify

### DIFF
--- a/new-packages.json
+++ b/new-packages.json
@@ -144,6 +144,6 @@
   "purescript-peregrine": "https://github.com/maxdeviant/peregrine.git",
   "purescript-datetime-parsing": "https://github.com/flounders/purescript-datetime-parsing.git",
   "purescript-run-external-state": "https://github.com/Mateiadrielrafael/purescript-run-external-state.git",
-  "purescript-ask": "https://github.com/Mateiadrielrafael/purescript-ask.git"
+  "purescript-ask": "https://github.com/Mateiadrielrafael/purescript-ask.git",
   "purescript-owoify": "https://github.com/deadshot465/purescript-owoify.git"
 }

--- a/new-packages.json
+++ b/new-packages.json
@@ -145,4 +145,5 @@
   "purescript-datetime-parsing": "https://github.com/flounders/purescript-datetime-parsing.git",
   "purescript-run-external-state": "https://github.com/Mateiadrielrafael/purescript-run-external-state.git",
   "purescript-ask": "https://github.com/Mateiadrielrafael/purescript-ask.git"
+  "purescript-owoify": "https://github.com/deadshot465/purescript-owoify.git"
 }


### PR DESCRIPTION
A port of [owoify-js](https://github.com/mohan-cao/owoify-js) library that turns texts to nonsensical texts, used in my PureScript bot (using Eris) and *possibly* useful for anyone who wants to write a Discord bot in PureScript.