### PR TITLE
Add web-page-visibility

### DIFF
--- a/new-packages.json
+++ b/new-packages.json
@@ -184,5 +184,6 @@
   "purescript-unlift": "https://github.com/tweag/purescript-unlift.git",
   "purescript-affjax-node": "https://github.com/purescript-contrib/purescript-affjax-node.git",
   "purescript-affjax-web": "https://github.com/purescript-contrib/purescript-affjax-web.git",
-  "purescript-foreign-readwrite": "https://github.com/artemisSystem/purescript-foreign-readwrite.git"
+  "purescript-foreign-readwrite": "https://github.com/artemisSystem/purescript-foreign-readwrite.git",
+  "purescript-web-page-visibility": "https://git.sr.ht/~toastal/purescript-web-page-visibility"
 }


### PR DESCRIPTION
[`purescript-web-page-visibility`](https://git.sr.ht/~toastal/purescript-web-page-visibility) is a wrapper for the W3C Page Visibility spec. `v2.0.0` tag [build passed](https://builds.sr.ht/~toastal/job/576410) (Nix + Flakes + Cachix, merely builds as there is not much to test).

[![builds.sr.ht status](https://builds.sr.ht/~toastal/purescript-web-page-visibility/commits/.build.yml.svg)](https://builds.sr.ht/~toastal/purescript-web-page-visibility/commits/.build.yml?)

I have a future plans with this library, but one thing I really wanted to test is the Registry handling non-GitHub git repository—this will be the first repository. Sourcehut’s read-only Git cloning URI is `https://git.sr.ht/ownerCanonicalName/repositoryName` _without_ `.git` (in fact, putting `.git` will return a `403`). As Git is distributed, I will be excited to see what will happen in the future as others see examples of packages on multiple platforms.

Pursuit doc upload though will be blocked by [Pursuit #422](https://github.com/purescript/pursuit/issues/422) and whatever happens there. This may be blocked by #204 which I opened for Sourcehut-specific support or #15 which allows arbitrary git repo support.