### PR TITLE
Initial Sourcehut support

### DIFF
--- a/v1/Repo.dhall
+++ b/v1/Repo.dhall
@@ -2,10 +2,10 @@
 
 Coordinates for a package, i.e. "some kind of Git place".
 
-We have special support for GitHub because it's easier for us if packages are
-there, as we use their API to do things, e.g. to fetch commit tarballs.
-However, we should always be able to support a "generic git thing", so that
-we can allow hosting packages on other providers too.
+We have special support for GitHub & Sourcehut because it's easier for us if
+packages are there, as we use their API to do things, e.g. to fetch commit 
+tarballs.  However, we should always be able to support a "generic git thing",
+so that we can allow hosting packages on other providers too.
 
 -}
 
@@ -18,7 +18,12 @@ let GitHubData = CommonData //\\
   , githubRepo : Text
   }
 
+let SourcehutData = CommonData //\\
+  { sourcehutOwnerCanonicalName : Text
+  , sourcehutRepositoryName : Text
+  }
+
 let GitData = CommonData //\\
   { url : Text }
 
-in < GitHub : GitHubData | Git : GitData >
+in < GitHub : GitHubData | Sourcehut : SourcehutData | Git : GitData >


### PR DESCRIPTION
Looking for feedback. Could open up #203. I'm adding Sourcehut-specific code in here for the same reason it is in Nixpkgs ([`fetchFromSourcehut`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchsourcehut/default.nix)) and GitHub in this package: access to the tarball downloads which are faster.

---

## Context

```graphql
query {
 repositoryByName(name: "purescript-web-page-visibility") {
    name
    owner { id canonicalName }
    description
  }
  user(username: "toastal") { id username }
}
```

cURLing Sourcehut's API that gets you

```json
{
  "data": {
    "repositoryByName": {
      "name": "purescript-web-page-visibility",
      "owner": {
        "id": 11755,
        "canonicalName": "~toastal"
      },
      "description": "Type definitions and low level interface implementations for W3C Page Visibility API"
    },
    "user": {
      "id": 11755,
      "username": "toastal"
    }
  }
}
```

`v1.0.1` ref: https://git.sr.ht/~toastal/purescript-web-page-visibility/refs/v1.0.1
tarball from that ref: https://git.sr.ht/~toastal/purescript-web-page-visibility/archive/v1.0.1.tar.gz

Canonical name is used for users and groups and such and is separate kinda from username and id as far as repo URLs are concerned.

There is duplicate wget+untar commands going on, but I don't know the proper way to refactor than in the context of this project. Currently there are no tests since nothing has been approved yet for Sourcehut (though #203 is open), but also it _is_ duplicated tarball code.

The Dhall names are longer, not matching `GitHubData` or nixpkgs, to more closely resemble Sourcehut's [schema](https://git.sr.ht/~sircmpwn/git.sr.ht/tree/master/item/api/graph/schema.graphqls) to be more clear to users of that platform (although I don't really agree with how some of the current Dhall is organized having built some bigger Dhall projects myself (e.g. not using `Type` + `default` to get access to `::` operator), I don't want to diverge from what's here already).

I'm willing to refactor anything. I'm very much in full support of at least one GitHub alternative. I could look into GitLab after. I think these may require a little extra care though as self-hosted Sourcehuts and GitLabs and Giteas and cgits will have different URLs despite the same tarball and other APIs.