### PR TITLE
Fix insertManifest function when writing a registry index

### DIFF
--- a/ci/.gitignore
+++ b/ci/.gitignore
@@ -14,3 +14,4 @@ generated-docs/
 
 # Files generated as part of the Bower import process
 bower-exclusions.json
+registry-index

--- a/ci/src/Foreign/Node/FS.js
+++ b/ci/src/Foreign/Node/FS.js
@@ -1,0 +1,3 @@
+const fs = require("fs");
+
+exports.mkdirSyncImpl = (path) => fs.mkdirSync(path, { recursive: true });

--- a/ci/src/Foreign/Node/FS.purs
+++ b/ci/src/Foreign/Node/FS.purs
@@ -1,0 +1,13 @@
+module Foreign.Node.FS
+  ( mkdirSync
+  ) where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Uncurried (EffectFn1, runEffectFn1)
+
+foreign import mkdirSyncImpl :: EffectFn1 String Unit
+
+mkdirSync :: String -> Effect Unit
+mkdirSync = runEffectFn1 mkdirSyncImpl

--- a/ci/src/Registry/Scripts/BowerImport.purs
+++ b/ci/src/Registry/Scripts/BowerImport.purs
@@ -29,7 +29,7 @@ import Foreign.SemVer (SemVer)
 import Foreign.SemVer as SemVer
 import Node.FS.Aff as FS
 import Node.FS.Stats (Stats(..))
-import Registry.Index (RegistryIndex)
+import Registry.Index (RegistryIndex, insertManifest)
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Schema (Repo(..), Manifest)
@@ -49,6 +49,8 @@ main :: Effect Unit
 main = Aff.launchAff_ do
   log "Starting import from legacy registries..."
   _registry <- downloadBowerRegistry
+  for_ _registry \semVer -> for_ semVer \manifest ->
+    insertManifest "registry-index" manifest
   log "Done!"
 
 downloadBowerRegistry :: Aff RegistryIndex


### PR DESCRIPTION
I finally got around to writing the registry index when we complete the Bower import script. This PR implements a few tweaks to ensure that writing the index actually works, as I found the untested code had some issues. Partially addresses #212, but these aren't actually _tests_, just some work to ensure the code is working.

Testable by:

1. Creating a `registry-index` directory
2. Running the Bower import script
3. Inspecting the resulting directories inserted into `registry-index`

An example file stored at `ar/go/argonaut-aeson-generic`:

```jsonl
{"version":"0.1.0","targets":{"lib":{"sources":["src/**/*.purs"],"dependencies":{"argonaut-generic":">=1.2.0 <2.0.0-0","argonaut-codecs":">=3.2.0 <4.0.0-0","argonaut":">=3.1.0 <4.0.0-0","generics-rep":">=5.3.0 <6.0.0-0","console":">=3.0.0 <4.0.0-0","prelude":">=3.1.0 <4.0.0-0"}},"test":{"sources":["src/**/*.purs","test/**/*.purs"],"dependencies":{"argonaut-generic":">=1.2.0 <2.0.0-0","argonaut-codecs":">=3.2.0 <4.0.0-0","argonaut":">=3.1.0 <4.0.0-0","generics-rep":">=5.3.0 <6.0.0-0","console":">=3.0.0 <4.0.0-0","prelude":">=3.1.0 <4.0.0-0","test-unit":">=13.0.0 <14.0.0-0","psci-support":">=3.0.0 <4.0.0-0"}}},"repository":{"githubOwner":"coot","githubRepo":"purescript-argonaut-aeson-generic"},"name":"argonaut-aeson-generic","license":"MPL-2.0"}
{"version":"0.2.0","targets":{"lib":{"sources":["src/**/*.purs"],"dependencies":{"typelevel-prelude":">=5.0.2 <6.0.0-0","foreign-object":">=2.0.3 <3.0.0-0","argonaut-generic":">=5.0.0 <6.0.0-0","argonaut-codecs":">=6.0.2 <7.0.0-0","argonaut":">=6.0.0 <7.0.0-0","generics-rep":">=6.1.1 <7.0.0-0","console":">=4.2.0 <5.0.0-0","prelude":">=4.1.0 <5.0.0-0"}},"test":{"sources":["src/**/*.purs","test/**/*.purs"],"dependencies":{"typelevel-prelude":">=5.0.2 <6.0.0-0","foreign-object":">=2.0.3 <3.0.0-0","argonaut-generic":">=5.0.0 <6.0.0-0","argonaut-codecs":">=6.0.2 <7.0.0-0","argonaut":">=6.0.0 <7.0.0-0","generics-rep":">=6.1.1 <7.0.0-0","console":">=4.2.0 <5.0.0-0","prelude":">=4.1.0 <5.0.0-0","test-unit":">=15.0.0 <16.0.0-0","psci-support":">=4.0.0 <5.0.0-0"}}},"repository":{"githubOwner":"coot","githubRepo":"purescript-argonaut-aeson-generic"},"name":"argonaut-aeson-generic","license":"MPL-2.0"}
{"version":"0.3.0","targets":{"lib":{"sources":["src/**/*.purs"],"dependencies":{"typelevel-prelude":">=5.0.2 <6.0.0-0","foreign-object":">=2.0.3 <3.0.0-0","argonaut-generic":">=5.0.0 <6.0.0-0","argonaut-codecs":">=6.0.2 <7.0.0-0","argonaut":">=6.0.0 <7.0.0-0","generics-rep":">=6.1.1 <7.0.0-0","console":">=4.2.0 <5.0.0-0","prelude":">=4.1.0 <5.0.0-0"}},"test":{"sources":["src/**/*.purs","test/**/*.purs"],"dependencies":{"typelevel-prelude":">=5.0.2 <6.0.0-0","foreign-object":">=2.0.3 <3.0.0-0","argonaut-generic":">=5.0.0 <6.0.0-0","argonaut-codecs":">=6.0.2 <7.0.0-0","argonaut":">=6.0.0 <7.0.0-0","generics-rep":">=6.1.1 <7.0.0-0","console":">=4.2.0 <5.0.0-0","prelude":">=4.1.0 <5.0.0-0","test-unit":">=15.0.0 <16.0.0-0","psci-support":">=4.0.0 <5.0.0-0"}}},"repository":{"githubOwner":"coot","githubRepo":"purescript-argonaut-aeson-generic"},"name":"argonaut-aeson-generic","license":"MPL-2.0"}
```