### PR TITLE
Bower Import: Filter out non-PS dependencies

### DIFF
--- a/ci/src/Registry/Scripts/BowerImport/BowerFile.purs
+++ b/ci/src/Registry/Scripts/BowerImport/BowerFile.purs
@@ -13,12 +13,11 @@ import Data.Argonaut as Json
 import Data.Array as Array
 import Foreign.Jsonic as Jsonic
 
-newtype BowerFile =
-  BowerFile
-    { license :: Array String
-    , dependencies :: Object String
-    , devDependencies :: Object String
-    }
+newtype BowerFile = BowerFile
+  { license :: Array String
+  , dependencies :: Object String
+  , devDependencies :: Object String
+  }
 
 derive newtype instance Eq BowerFile
 derive newtype instance Show BowerFile
@@ -58,4 +57,3 @@ parse =
   Jsonic.parse
     >>> lmap JsonParseError
     >=> (Json.decodeJson >>> lmap JsonDecodeError)
-


### PR DESCRIPTION
Fixes #219 by filtering out dependencies that don't begin with `purescript-` in Bowerfiles. This should be safe because all packages in the `bower-packages.json` and `new-packages.json` files have the `purescript-` prefix.

The example badly-formed package from #219, `c3`, now has this (correct) manifest:

```json
{
  "name": "c3",
  "license": "MIT",
  "version": "0.1.1",
  "targets": {
    "lib": {
      "sources": [
        "src/**/*.purs"
      ],
      "dependencies": {
        "dom": ">=0.1.0 <0.2.0-0"
      }
    }
  },
  "repository": {
    "githubOwner": "joneshf",
    "githubRepo": "purescript-c3"
  }
}
```