### PR TITLE
Bower Import: Defer license check

### DIFF
--- a/ci/src/Registry/Scripts/BowerImport.purs
+++ b/ci/src/Registry/Scripts/BowerImport.purs
@@ -254,16 +254,9 @@ toManifest package repository version (BowerFile bowerfile) = do
             { fail, success } = partitionEithers parsed
 
           case fail, success of
-            -- Technically this shouldn't be a possible case because of the
-            -- NonEmptyArray, but we lose that type when using partitionEithers
-            [],
-            [] -> mkError MissingLicense
-            -- If there are no failures, then we can join the successful licenses.
-            [],
-            _ -> Right $ SPDX.joinWith SPDX.Or success
-            -- If there are any failures, then we throw an exception.
-            _,
-            _ -> mkError $ BadLicense fail
+            [], [] -> mkError MissingLicense
+            [], _ -> Right $ SPDX.joinWith SPDX.Or success
+            _, _ -> mkError $ BadLicense fail
 
     eitherTargets = do
       let

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -3,6 +3,7 @@ module Test.Main where
 import Registry.Prelude
 
 import Data.Argonaut as Json
+import Data.Array.NonEmpty as NEA
 import Foreign.GitHub (IssueNumber(..))
 import Foreign.Object as Object
 import Foreign.SPDX as SPDX
@@ -201,16 +202,17 @@ badBowerFiles = do
       BowerFile.parse str `Assert.shouldNotSatisfy` isRight
     failParseBowerFile = failParseBowerFile' <<< Json.stringify
 
-    missingNameFile = Json.encodeJson {}
-    wrongLicenseFormat = Json.encodeJson { version: "", license: true }
+    wrongLicenseFormat =
+      Json.encodeJson { version: "", license: true }
+
     wrongDependenciesFormat =
       Json.encodeJson
         { version: "", license: "", dependencies: ([] :: Array Int) }
+
     wrongDevDependenciesFormat =
       Json.encodeJson
         { version: "", license: "", devDependencies: ([] :: Array Int) }
 
-  failParseBowerFile missingNameFile
   failParseBowerFile wrongLicenseFormat
   failParseBowerFile wrongDependenciesFormat
   failParseBowerFile wrongDevDependenciesFormat
@@ -230,6 +232,6 @@ bowerFileEncoding = do
           , Tuple "devdependency-second" "v0.0.2"
           ]
       bowerFile =
-        BowerFile { license: [ "MIT" ], dependencies, devDependencies }
+        BowerFile { license: NEA.fromArray [ "MIT" ], dependencies, devDependencies }
     (Json.decodeJson $ Json.encodeJson bowerFile) `Assert.shouldContain` bowerFile
 


### PR DESCRIPTION
In #221, @YanikCeulemans implemented better parsing for Bower JSON files.

One consequence was that packages could fail with a `MalformedBowerJson` error when they're missing a license field. However, we should defer this check until we try to convert a package into a manifest where we already have existing license parsing checks. It's also important to do this to support #220.

This PR updates the `BowerFile` type to produce a `Maybe (NonEmptyArray String)` type for the license key in a bower file instead of the existing `Array String`. It also relaxes the check so that it is acceptable for the license field to be missing.