### PR TITLE
Add manifest fixtures & manifest json encoding round-trip test

### DIFF
--- a/ci/src/Foreign/SPDX.purs
+++ b/ci/src/Foreign/SPDX.purs
@@ -16,6 +16,8 @@ import Safe.Coerce (coerce)
 -- | An SPDX license identifier such as 'MIT' or 'Apache-2.0'.
 newtype License = License String
 
+derive newtype instance eqLicense :: Eq License
+
 instance decodeJsonSPDXLicense :: DecodeJson License where
   decodeJson = lmap TypeMismatch <<< parse <=< decodeJson
 

--- a/ci/src/Foreign/SemVer.purs
+++ b/ci/src/Foreign/SemVer.purs
@@ -78,7 +78,7 @@ build (SemVer v) = v.build
 printSemVer :: SemVer -> String
 printSemVer (SemVer v) = v.version
 
-newtype Range = Range { original :: String, converted :: String }
+newtype Range = Range String
 
 derive newtype instance eqRange :: Eq Range
 
@@ -104,7 +104,7 @@ parseRange original = do
           Just c -> pure c
           _ -> Nothing
         _ -> Nothing
-  pure $ Range { converted, original }
+  pure $ Range converted
 
 printRange :: Range -> String
-printRange (Range r) = _.converted r
+printRange (Range r) = r

--- a/ci/test/Fixtures/Manifest.purs
+++ b/ci/test/Fixtures/Manifest.purs
@@ -1,0 +1,90 @@
+module Test.Fixtures.Manifest where
+
+import Registry.Prelude
+import Foreign.Object as Object
+import Foreign.SPDX as SPDX
+import Foreign.SemVer as SemVer
+import Partial.Unsafe as Partial.Unsafe
+import Registry.PackageName (PackageName)
+import Registry.PackageName as PackageName
+import Registry.Schema (Manifest)
+import Registry.Schema as Schema
+
+ab ::
+  { name :: PackageName
+  , v1a :: Manifest
+  , v1b :: Manifest
+  , v2 :: Manifest
+  }
+ab = { name, v1a, v1b, v2 }
+  where
+  name = unsafeFromJust $ hush $ PackageName.parse "ab"
+  version1 = unsafeFromJust $ SemVer.parseSemVer "1.0.0"
+  targets = Object.singleton "lib"
+    { dependencies: Object.empty
+    , sources: [ "src/**/*.purs" ]
+    }
+  version2 = unsafeFromJust $ SemVer.parseSemVer "2.0.0"
+  license = unsafeFromJust $ hush $ SPDX.parse "MIT"
+  repositoryWrong = Schema.GitHub
+    { owner: "ab-wrong-user"
+    , repo: "ab"
+    , subdir: Nothing
+    }
+  repository = Schema.GitHub
+    { owner: "abc-user"
+    , repo: "abc"
+    , subdir: Nothing
+    }
+  v1a = { name, version: version1, license, repository: repositoryWrong, targets }
+  v1b = { name, version: version1, license, repository, targets }
+  v2 = { name, version: version2, license, repository, targets }
+
+abc :: { name :: PackageName, v1 :: Manifest, v2 :: Manifest }
+abc = { name, v1, v2}
+  where
+  name = unsafeFromJust $ hush $ PackageName.parse "abc"
+  version1 = unsafeFromJust $ SemVer.parseSemVer "1.0.0"
+  targets1 = Object.singleton "lib"
+    { dependencies: Object.singleton "ab" (unsafeFromJust (SemVer.parseRange "^1.0.0"))
+    , sources: [ "src/**/*.purs" ]
+    }
+  version2 = unsafeFromJust $ SemVer.parseSemVer "2.0.0"
+  targets2 = Object.singleton "lib"
+    { dependencies: Object.singleton "ab" (unsafeFromJust (SemVer.parseRange "^2.0.0"))
+    , sources: [ "src/**/*.purs" ]
+    }
+  license = unsafeFromJust $ hush $ SPDX.parse "MIT"
+  repository = Schema.GitHub
+    { owner: "abc-user"
+    , repo: "abc"
+    , subdir: Nothing
+    }
+  v1 = { name, version: version1, license, repository, targets: targets1 }
+  v2 = { name, version: version2, license, repository, targets: targets2 }
+
+abcd :: { name :: PackageName, v1 :: Manifest, v2 :: Manifest }
+abcd = { name, v1, v2 }
+  where
+  name = unsafeFromJust $ hush $ PackageName.parse "abcd"
+  version1 = unsafeFromJust $ SemVer.parseSemVer "1.0.0"
+  targets1 = Object.singleton "lib"
+    { dependencies: Object.singleton "abc" (unsafeFromJust (SemVer.parseRange "^1.0.0"))
+    , sources: [ "src/**/*.purs" ]
+    }
+  version2 = unsafeFromJust $ SemVer.parseSemVer "2.0.0"
+  targets2 = Object.singleton "lib"
+    { dependencies: Object.singleton "abc" (unsafeFromJust (SemVer.parseRange "^2.0.0"))
+    , sources: [ "src/**/*.purs" ]
+    }
+  license = unsafeFromJust $ hush $ SPDX.parse "MIT"
+  repository = Schema.GitHub
+    { owner: "abcd-user"
+    , repo: "abcd"
+    , subdir: Nothing
+    }
+  v1 = { name, version: version1, license, repository, targets: targets1 }
+  v2 = { name, version: version2, license, repository, targets: targets2 }
+
+unsafeFromJust :: forall a. Maybe a -> a
+unsafeFromJust = Partial.Unsafe.unsafePartial fromJust

--- a/ci/test/Fixtures/Manifest.purs
+++ b/ci/test/Fixtures/Manifest.purs
@@ -41,7 +41,7 @@ ab = { name, v1a, v1b, v2 }
   v2 = { name, version: version2, license, repository, targets }
 
 abc :: { name :: PackageName, v1 :: Manifest, v2 :: Manifest }
-abc = { name, v1, v2}
+abc = { name, v1, v2 }
   where
   name = unsafeFromJust $ hush $ PackageName.parse "abc"
   version1 = unsafeFromJust $ SemVer.parseSemVer "1.0.0"

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -13,6 +13,7 @@ import Registry.PackageName as PackageName
 import Registry.Schema (Operation(..), Repo(..))
 import Registry.Scripts.BowerImport.BowerFile (BowerFile(..))
 import Registry.Scripts.BowerImport.BowerFile as BowerFile
+import Test.Fixtures.Manifest as Fixtures
 import Test.Foreign.Jsonic (jsonic)
 import Test.Spec as Spec
 import Test.Spec.Assertions as Assert
@@ -38,6 +39,27 @@ main = launchAff_ $ runSpec [ consoleReporter ] do
       Spec.describe "Bad bower files" badBowerFiles
     Spec.describe "Encoding" bowerFileEncoding
   Spec.describe "Jsonic" jsonic
+  Spec.describe "Manifest" do
+    Spec.describe "Encoding" manifestEncoding
+
+manifestEncoding :: Spec
+manifestEncoding = do
+  let
+    checkRoundtrip manifest str = case Json.parseJson str >>= Json.decodeJson of
+      Left _ -> false
+      Right manifest' -> manifest == manifest'
+
+    roundTrip manifest =
+      Spec.it (PackageName.print manifest.name <> " v" <> SemVer.printSemVer manifest.version) do
+        Json.stringify (Json.encodeJson manifest) `Assert.shouldSatisfy` checkRoundtrip manifest
+
+  roundTrip Fixtures.ab.v1a
+  roundTrip Fixtures.ab.v1b
+  roundTrip Fixtures.ab.v2
+  roundTrip Fixtures.abc.v1
+  roundTrip Fixtures.abc.v2
+  roundTrip Fixtures.abcd.v1
+  roundTrip Fixtures.abcd.v2
 
 goodPackageName :: Spec
 goodPackageName = do


### PR DESCRIPTION
This morning @thomashoneyman and I were working on adding more comprehensive tests for the `Registry.Index` module, when we noticed that the `Manifest` type's JSON encoding/decoding doesn't roundtrip into an equivalent value. 

We expected it would, so I put this test together to get to the root cause.

I've isolated the cause to our handling of the `Range` type - specifically, when we encode it, we use the `converted` entry, which may not be the same as the `original` entry.

Swapping `printRange` to print the `original` entry makes these tests pass, but makes the existing `Parse Range "^1.3.4" into ">=1.3.4 <2.0.0-0"` fail.

For now I haven't applied any changes to the implementation of `printRange`, as I wanted to double check with @f-f and @thomashoneyman about what the expected behavior is.