### PR TITLE
Add Nix shell and licensee package

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -7,3 +7,17 @@ Create a `.env` file based off [`.env.example`](./.env.example) and fill in the 
 ```sh
 cp .env.example .env
 ```
+
+If you are running scripts in the repository, such as the legacy registry import script, then you may wish to use the provided Nix shell to make sure you have all necessary dependencies available.
+
+```console
+$ nix-shell
+```
+
+## Bower Import
+
+You can execute the legacy registry import script with the following command:
+
+```console
+$ spago run -m Registry.Scripts.BowerImport
+```

--- a/ci/package.json
+++ b/ci/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "SPACES_KEY='' SPACES_SECRET='' GITHUB_TOKEN='' spago test"
+    "test": "spago test"
   },
   "author": "",
   "license": "MIT",

--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -1,0 +1,26 @@
+let
+  pkgs = import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/21.05.tar.gz";
+  }) {};
+
+  # To update to a newer version of easy-purescript-nix, run:
+  # nix-prefetch-git https://github.com/justinwoo/easy-purescript-nix
+  #
+  # Then, copy the resulting rev and sha256 here.
+  pursPkgs = import (pkgs.fetchFromGitHub {
+    owner = "justinwoo";
+    repo = "easy-purescript-nix";
+    rev = "d9a37c75ed361372e1545f6efbc08d819b3c28c8";
+    sha256 = "1fklhnddy5pzzbxfyrlprsq1p8b6y9v0awv1a1z0vkwqsd8y68yp";
+  }) { inherit pkgs; };
+
+in pkgs.stdenv.mkDerivation {
+  name = "ci";
+  buildInputs = with pursPkgs; [
+    purs spago psa purs-tidy
+
+    pkgs.nodejs-14_x
+
+    pkgs.licensee
+  ];
+}


### PR DESCRIPTION
This PR provides an initial step towards #220 by adding a Nix shell and the `licensee` package for parsing licenses. The shell also provides `purs`, `purs-tidy`, `psa`, `spago`, and `node`, so any dev dropping in to the project can get good versions for working on the source code.

@maxdeviant -- in a brief test, I saw that `licensee` does try to read the license out of the `package.json` file as well as the root file, so that's something to consider if you're working on using licenses out of `package.json` files.