### PR TITLE
Rename Bower Import script to Legacy Import

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -19,5 +19,5 @@ $ nix-shell
 You can execute the legacy registry import script with the following command:
 
 ```console
-$ spago run -m Registry.Scripts.BowerImport
+$ spago run -m Registry.Scripts.LegacyImport
 ```

--- a/ci/src/Foreign/SemVer.purs
+++ b/ci/src/Foreign/SemVer.purs
@@ -97,7 +97,7 @@ parseRange original = do
   converted <- case toMaybe (parseRangeImpl original) of
     Just c -> pure c
     Nothing ->
-      -- when parsing a version from a BowerFile it could be that it's specified
+      -- when parsing a version from a Bowerfile it could be that it's specified
       -- in the https://giturl#version, or owner/repo#version, so we try to parse that here.
       case String.split (String.Pattern "#") original of
         [ _url, version ] -> case toMaybe (parseRangeImpl version) of

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -27,8 +27,8 @@ import Registry.PackageName as PackageName
 import Registry.PackageUpload as Upload
 import Registry.RegistryM (Env, RegistryM, closeIssue, comment, commitToTrunk, readPackagesMetadata, runRegistryM, throwWithComment, updatePackagesMetadata, uploadPackage)
 import Registry.Schema (Manifest, Metadata, Operation(..), Repo(..), addVersionToMetadata, mkNewMetadata)
-import Registry.Scripts.BowerImport as BowerImport
-import Registry.Scripts.BowerImport.Bowerfile as Bowerfile
+import Registry.Scripts.LegacyImport as LegacyImport
+import Registry.Scripts.LegacyImport.Bowerfile as Bowerfile
 import Sunde as Process
 import Text.Parsing.StringParser as StringParser
 
@@ -188,7 +188,7 @@ addOrUpdate { ref, fromBower, packageName } metadata = do
           Nothing -> throwWithComment $ "Not a valid SemVer version: " <> ref
           Just result -> pure result
 
-        runManifest (BowerImport.toManifest packageName metadata.location semVer manifestFields) >>= case _ of
+        runManifest (LegacyImport.toManifest packageName metadata.location semVer manifestFields) >>= case _ of
           Left err ->
             throwWithComment $ "Unable to convert Bowerfile to a manifest: " <> err
           Right manifest ->

--- a/ci/src/Registry/Scripts/BowerImport.purs
+++ b/ci/src/Registry/Scripts/BowerImport.purs
@@ -36,7 +36,7 @@ import Registry.Index (RegistryIndex, insertManifest)
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Schema (Repo(..), Manifest)
-import Registry.Scripts.BowerImport.BowerFile as BowerFile
+import Registry.Scripts.BowerImport.Bowerfile as Bowerfile
 import Registry.Scripts.BowerImport.Error (APIResource(..), FileResource(..), ImportError(..), ManifestError(..), PackageFailures(..), RawPackageName(..), RawVersion(..), RemoteResource(..), RequestError(..), fileResourcePath)
 import Registry.Scripts.BowerImport.ManifestFields (ManifestFields)
 import Registry.Scripts.BowerImport.Process as Process
@@ -212,7 +212,7 @@ toManifest package repository version manifest = do
     eitherTargets = do
       let
         -- We trim out packages that don't begin with `purescript-`, as these
-        -- are JavaScript dependencies being specified in the BowerFile.
+        -- are JavaScript dependencies being specified in the Bowerfile.
         filterNames = catMaybes <<< map \(Tuple packageName versionRange) ->
           case String.take 11 packageName of
             "purescript-" -> Just $ Tuple (String.drop 11 packageName) versionRange
@@ -361,7 +361,7 @@ constructManifestFields package version address = do
           log result
           throwError $ ResourceError { resource: FileResource BowerJson, error: DecodeError printed }
         Right bowerfile ->
-          pure $ BowerFile.toManifestFields bowerfile
+          pure $ Bowerfile.toManifestFields bowerfile
 
     spagoJson <- liftAff $ Except.runExceptT requestSpagoJson
     let spagoManifest = map SpagoJson.toManifestFields spagoJson

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -1,4 +1,4 @@
-module Registry.Scripts.BowerImport where
+module Registry.Scripts.LegacyImport where
 
 import Registry.Prelude
 
@@ -36,13 +36,13 @@ import Registry.Index (RegistryIndex, insertManifest)
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Schema (Repo(..), Manifest)
-import Registry.Scripts.BowerImport.Bowerfile as Bowerfile
-import Registry.Scripts.BowerImport.Error (APIResource(..), FileResource(..), ImportError(..), ManifestError(..), PackageFailures(..), RawPackageName(..), RawVersion(..), RemoteResource(..), RequestError(..), fileResourcePath)
-import Registry.Scripts.BowerImport.ManifestFields (ManifestFields)
-import Registry.Scripts.BowerImport.Process as Process
-import Registry.Scripts.BowerImport.SpagoJson (SpagoJson)
-import Registry.Scripts.BowerImport.SpagoJson as SpagoJson
-import Registry.Scripts.BowerImport.Stats as Stats
+import Registry.Scripts.LegacyImport.Bowerfile as Bowerfile
+import Registry.Scripts.LegacyImport.Error (APIResource(..), FileResource(..), ImportError(..), ManifestError(..), PackageFailures(..), RawPackageName(..), RawVersion(..), RemoteResource(..), RequestError(..), fileResourcePath)
+import Registry.Scripts.LegacyImport.ManifestFields (ManifestFields)
+import Registry.Scripts.LegacyImport.Process as Process
+import Registry.Scripts.LegacyImport.SpagoJson (SpagoJson)
+import Registry.Scripts.LegacyImport.SpagoJson as SpagoJson
+import Registry.Scripts.LegacyImport.Stats as Stats
 import Safe.Coerce (coerce)
 import Text.Parsing.StringParser as StringParser
 

--- a/ci/src/Registry/Scripts/LegacyImport/Bowerfile.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Bowerfile.purs
@@ -1,5 +1,5 @@
-module Registry.Scripts.BowerImport.BowerFile
-  ( BowerFile(..)
+module Registry.Scripts.LegacyImport.Bowerfile
+  ( Bowerfile(..)
   , toManifestFields
   ) where
 
@@ -10,24 +10,24 @@ import Data.Argonaut (Json, (.:?))
 import Data.Argonaut as Json
 import Data.Array as Array
 import Data.Array.NonEmpty as NEA
-import Registry.Scripts.BowerImport.ManifestFields (ManifestFields)
+import Registry.Scripts.LegacyImport.ManifestFields (ManifestFields)
 
-toManifestFields :: BowerFile -> ManifestFields
-toManifestFields (BowerFile fields) = fields
+toManifestFields :: Bowerfile -> ManifestFields
+toManifestFields (Bowerfile fields) = fields
 
-newtype BowerFile = BowerFile ManifestFields
+newtype Bowerfile = Bowerfile ManifestFields
 
-derive newtype instance Eq BowerFile
-derive newtype instance Show BowerFile
-derive newtype instance Json.EncodeJson BowerFile
+derive newtype instance Eq Bowerfile
+derive newtype instance Show Bowerfile
+derive newtype instance Json.EncodeJson Bowerfile
 
-instance Json.DecodeJson BowerFile where
+instance Json.DecodeJson Bowerfile where
   decodeJson json = do
     obj <- Json.decodeJson json
     license <- decodeStringOrStringArray obj "license"
     dependencies <- fromMaybe mempty <$> obj .:? "dependencies"
     devDependencies <- fromMaybe mempty <$> obj .:? "devDependencies"
-    pure $ BowerFile { license, dependencies, devDependencies }
+    pure $ Bowerfile { license, dependencies, devDependencies }
 
 decodeStringOrStringArray
   :: Object Json

--- a/ci/src/Registry/Scripts/LegacyImport/Error.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Error.purs
@@ -1,4 +1,4 @@
-module Registry.Scripts.BowerImport.Error where
+module Registry.Scripts.LegacyImport.Error where
 
 import Registry.Prelude
 

--- a/ci/src/Registry/Scripts/LegacyImport/ManifestFields.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/ManifestFields.purs
@@ -1,4 +1,4 @@
-module Registry.Scripts.BowerImport.ManifestFields where
+module Registry.Scripts.LegacyImport.ManifestFields where
 
 import Registry.Prelude
 

--- a/ci/src/Registry/Scripts/LegacyImport/Process.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Process.purs
@@ -1,4 +1,4 @@
-module Registry.Scripts.BowerImport.Process where
+module Registry.Scripts.LegacyImport.Process where
 
 import Registry.Prelude
 
@@ -19,8 +19,8 @@ import Effect.Now (nowDateTime) as Time
 import Foreign.Jsonic as Jsonic
 import Node.FS.Aff as FS
 import Node.FS.Stats (Stats(..))
-import Registry.Scripts.BowerImport.Error (ImportError(..), ImportErrorKey, PackageFailures(..), RawPackageName, RawVersion, RequestError(..), ResourceError)
-import Registry.Scripts.BowerImport.Error as BowerImport.Error
+import Registry.Scripts.LegacyImport.Error (ImportError(..), ImportErrorKey, PackageFailures(..), RawPackageName, RawVersion, RequestError(..))
+import Registry.Scripts.LegacyImport.Error as LegacyImport.Error
 
 type ProcessedPackages k a =
   { failures :: PackageFailures
@@ -45,7 +45,7 @@ forPackage input keyToPackageName f = do
     Except.runExceptT (f key value) >>= case _ of
       Left err -> do
         let
-          errorType = BowerImport.Error.printImportErrorKey err
+          errorType = LegacyImport.Error.printImportErrorKey err
           name = keyToPackageName key
           failure = Map.singleton name (Left err)
         var # modifyAVar \state -> state { failures = insertFailure errorType failure state.failures }
@@ -73,7 +73,7 @@ forPackageVersion input keyToPackageName keyToTag f = do
       Except.runExceptT (f k1 k2 value) >>= case _ of
         Left err -> do
           let
-            errorType = BowerImport.Error.printImportErrorKey err
+            errorType = LegacyImport.Error.printImportErrorKey err
             name = keyToPackageName k1
             tag = keyToTag k2
             failure = Map.singleton name $ Right $ Map.singleton tag err
@@ -103,7 +103,7 @@ forPackageVersionKeys input keyToPackageName keyToTag f = do
       Except.runExceptT (f k1 k2) >>= case _ of
         Left err -> do
           let
-            errorType = BowerImport.Error.printImportErrorKey err
+            errorType = LegacyImport.Error.printImportErrorKey err
             name = keyToPackageName k1
             tag = keyToTag k2
             failure = Map.singleton name $ Right $ Map.singleton tag err

--- a/ci/src/Registry/Scripts/LegacyImport/SpagoJson.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/SpagoJson.purs
@@ -1,4 +1,4 @@
-module Registry.Scripts.BowerImport.SpagoJson
+module Registry.Scripts.LegacyImport.SpagoJson
   ( SpagoJson
   , toManifestFields
   ) where
@@ -11,8 +11,8 @@ import Data.Array as Array
 import Data.Array.NonEmpty as NEA
 import Data.Map as Map
 import Foreign.Object as Object
-import Registry.Scripts.BowerImport.Error (RawPackageName(..), RawVersion(..))
-import Registry.Scripts.BowerImport.ManifestFields (ManifestFields)
+import Registry.Scripts.LegacyImport.Error (RawPackageName(..), RawVersion(..))
+import Registry.Scripts.LegacyImport.ManifestFields (ManifestFields)
 
 toManifestFields :: SpagoJson -> ManifestFields
 toManifestFields spago@(SpagoJson { license }) =

--- a/ci/src/Registry/Scripts/LegacyImport/Stats.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Stats.purs
@@ -1,4 +1,4 @@
-module Registry.Scripts.BowerImport.Stats
+module Registry.Scripts.LegacyImport.Stats
   ( errorStats
   , prettyPrintStats
   , logStats
@@ -19,8 +19,8 @@ import Data.Map (SemigroupMap(..))
 import Data.Map as Map
 import Data.Monoid.Additive (Additive(..))
 import Data.Set as Set
-import Registry.Scripts.BowerImport.Error (ImportError(..), ImportErrorKey(..), ManifestError, ManifestErrorKey(..), PackageFailures(..), RawPackageName, RawVersion, manifestErrorKey, printManifestErrorKey)
-import Registry.Scripts.BowerImport.Process (ProcessedPackageVersions)
+import Registry.Scripts.LegacyImport.Error (ImportError(..), ImportErrorKey(..), ManifestError, ManifestErrorKey(..), PackageFailures(..), RawPackageName, RawVersion, manifestErrorKey, printManifestErrorKey)
+import Registry.Scripts.LegacyImport.Process (ProcessedPackageVersions)
 import Safe.Coerce (coerce)
 
 newtype ErrorCounts = ErrorCounts

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -13,7 +13,7 @@ import Foreign.SemVer as SemVer
 import Registry.API as API
 import Registry.PackageName as PackageName
 import Registry.Schema (Operation(..), Repo(..))
-import Registry.Scripts.BowerImport.BowerFile (BowerFile(..))
+import Registry.Scripts.BowerImport.Bowerfile (Bowerfile(..))
 import Test.Foreign.Jsonic (jsonic)
 import Test.Foreign.Licensee (licensee)
 import Test.Registry.Scripts.BowerImport.Stats (errorStats)
@@ -33,11 +33,11 @@ main = launchAff_ $ runSpec' (defaultConfig { timeout = Just $ Milliseconds 10_0
       Spec.describe "Bad SPDX licenses" badSPDXLicense
       Spec.describe "Decode GitHub event to Operation" decodeEventsToOps
       Spec.describe "SemVer" semVer
-  Spec.describe "BowerFile" do
+  Spec.describe "Bowerfile" do
     Spec.describe "Parses" do
-      Spec.describe "Good bower files" goodBowerFiles
+      Spec.describe "Good bower files" goodBowerfiles
     Spec.describe "Does not parse" do
-      Spec.describe "Bad bower files" badBowerFiles
+      Spec.describe "Bad bower files" badBowerfiles
     Spec.describe "Encoding" bowerFileEncoding
   Spec.describe "Jsonic" jsonic
   Spec.describe "Licensee" licensee
@@ -180,33 +180,33 @@ semVer = do
 
   parseRange "^1.3.4" ">=1.3.4 <2.0.0-0"
 
-goodBowerFiles :: Spec.Spec Unit
-goodBowerFiles = do
+goodBowerfiles :: Spec.Spec Unit
+goodBowerfiles = do
   let
-    parse :: String -> Either Json.JsonDecodeError BowerFile
+    parse :: String -> Either Json.JsonDecodeError Bowerfile
     parse = Jsonic.parseJson >=> Json.decodeJson
 
-    parseBowerFile' str = Spec.it str do
+    parseBowerfile' str = Spec.it str do
       parse str `Assert.shouldSatisfy` isRight
 
-    parseBowerFile = parseBowerFile' <<< Json.stringify
+    parseBowerfile = parseBowerfile' <<< Json.stringify
 
     simpleFile = Json.encodeJson { version: "v1.0.0", license: "MIT" }
-    goodBowerFile = Json.encodeJson { version: "v1.0.0", license: "", dependencies: {} }
-    extraPropsBowerFile =
+    goodBowerfile = Json.encodeJson { version: "v1.0.0", license: "", dependencies: {} }
+    extraPropsBowerfile =
       Json.encodeJson
         { extra: "value"
         , license: "not a license"
         , version: "v1.1.1"
         }
-    nonSemverBowerFile =
+    nonSemverBowerfile =
       Json.encodeJson
         { version: "notsemver"
         , license: ""
         , dependencies: { also: "not semver" }
         , devDependencies: { lastly: "🍝" }
         }
-    completeBowerFile =
+    completeBowerfile =
       Json.encodeJson
         { version: "v1.0.1"
         , license: [ "license" ]
@@ -218,22 +218,22 @@ goodBowerFiles = do
             { "dev-dep": "v2.0.0" }
         }
 
-  parseBowerFile goodBowerFile
-  parseBowerFile simpleFile
-  parseBowerFile extraPropsBowerFile
-  parseBowerFile nonSemverBowerFile
-  parseBowerFile completeBowerFile
+  parseBowerfile goodBowerfile
+  parseBowerfile simpleFile
+  parseBowerfile extraPropsBowerfile
+  parseBowerfile nonSemverBowerfile
+  parseBowerfile completeBowerfile
 
-badBowerFiles :: Spec.Spec Unit
-badBowerFiles = do
+badBowerfiles :: Spec.Spec Unit
+badBowerfiles = do
   let
-    parse :: String -> Either Json.JsonDecodeError BowerFile
+    parse :: String -> Either Json.JsonDecodeError Bowerfile
     parse = Jsonic.parseJson >=> Json.decodeJson
 
-    failParseBowerFile' str = Spec.it str do
+    failParseBowerfile' str = Spec.it str do
       parse str `Assert.shouldNotSatisfy` isRight
 
-    failParseBowerFile = failParseBowerFile' <<< Json.stringify
+    failParseBowerfile = failParseBowerfile' <<< Json.stringify
 
     wrongLicenseFormat =
       Json.encodeJson { version: "", license: true }
@@ -246,9 +246,9 @@ badBowerFiles = do
       Json.encodeJson
         { version: "", license: "", devDependencies: ([] :: Array Int) }
 
-  failParseBowerFile wrongLicenseFormat
-  failParseBowerFile wrongDependenciesFormat
-  failParseBowerFile wrongDevDependenciesFormat
+  failParseBowerfile wrongLicenseFormat
+  failParseBowerfile wrongDependenciesFormat
+  failParseBowerfile wrongDevDependenciesFormat
 
 bowerFileEncoding :: Spec.Spec Unit
 bowerFileEncoding = do
@@ -265,6 +265,6 @@ bowerFileEncoding = do
           , Tuple "devdependency-second" "v0.0.2"
           ]
       bowerFile =
-        BowerFile { license: NEA.fromArray [ "MIT" ], dependencies, devDependencies }
+        Bowerfile { license: NEA.fromArray [ "MIT" ], dependencies, devDependencies }
     (Json.decodeJson $ Json.encodeJson bowerFile) `Assert.shouldContain` bowerFile
 

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -13,10 +13,10 @@ import Foreign.SemVer as SemVer
 import Registry.API as API
 import Registry.PackageName as PackageName
 import Registry.Schema (Operation(..), Repo(..))
-import Registry.Scripts.BowerImport.Bowerfile (Bowerfile(..))
+import Registry.Scripts.LegacyImport.Bowerfile (Bowerfile(..))
 import Test.Foreign.Jsonic (jsonic)
 import Test.Foreign.Licensee (licensee)
-import Test.Registry.Scripts.BowerImport.Stats (errorStats)
+import Test.Registry.Scripts.LegacyImport.Stats (errorStats)
 import Test.Spec as Spec
 import Test.Spec.Assertions as Assert
 import Test.Spec.Reporter.Console (consoleReporter)

--- a/ci/test/Registry/Scripts/BowerImport/Stats.purs
+++ b/ci/test/Registry/Scripts/BowerImport/Stats.purs
@@ -1,14 +1,14 @@
-module Test.Registry.Scripts.BowerImport.Stats where
+module Test.Registry.Scripts.LegacyImport.Stats where
 
 import Registry.Prelude
 
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Foldable as Foldable
 import Data.Map as Map
-import Registry.Scripts.BowerImport.Error (ImportError(..), ManifestError(..), PackageFailures(..), RawPackageName(..), RawVersion(..), manifestErrorKey, printImportErrorKey, printManifestErrorKey)
-import Registry.Scripts.BowerImport.Process (ProcessedPackageVersions)
-import Registry.Scripts.BowerImport.Stats (ErrorCounts(..))
-import Registry.Scripts.BowerImport.Stats as Stats
+import Registry.Scripts.LegacyImport.Error (ImportError(..), ManifestError(..), PackageFailures(..), RawPackageName(..), RawVersion(..), manifestErrorKey, printImportErrorKey, printManifestErrorKey)
+import Registry.Scripts.LegacyImport.Process (ProcessedPackageVersions)
+import Registry.Scripts.LegacyImport.Stats (ErrorCounts(..))
+import Registry.Scripts.LegacyImport.Stats as Stats
 import Test.Spec as Spec
 import Test.Spec.Assertions as Assert
 


### PR DESCRIPTION
As discussed in #240, "bower import" is no longer a proper name for the script to import from the old Bower and PureScript registries. We look at more than the Bower registry, and we rely on more than just the Bowerfile, so I've renamed it to "legacy import" to make things a bit truer to what's going on.