### PR TITLE
Handle pagination in `getReleasesImpl`

### DIFF
--- a/ci/src/Foreign/GitHub.js
+++ b/ci/src/Foreign/GitHub.js
@@ -11,12 +11,12 @@ exports.mkOctokit = function () {
 };
 
 exports.getReleasesImpl = function (octokit, { owner, repo }) {
-  return octokit.repos
-    .listTags({
+  return octokit
+    .paginate(octokit.repos.listTags, {
       owner,
       repo,
     })
-    .then(({ data }) => {
+    .then((data) => {
       return data.map((element) => {
         return {
           name: element.name,


### PR DESCRIPTION
Fixes #262 by properly handling pagination in the `getReleasesImpl` FFI definition. See https://octokit.github.io/rest.js/v18#pagination for docs on pagination handling, this change is taken basically directly from there.

In https://github.com/purescript/registry/pull/248, this was the result of running `LegacyImport`: 

```
Packages: 1,575 total (1,214 totally succeeded, 236 partially succeeded, 125 totally failed)
Versions: 11,521 total (10,350 totally succeeded, 1,171 totally failed)
Failures by error:
  manifestError: 1104 versions across 300 packages
    missingLicense: 455 versions across 143 packages
    badLicense: 362 versions across 53 packages
```

Now, here is the result:

```
Packages: 1582 total (1126 totally succeeded, 307 partially succeeded, 149 totally failed)
Versions: 12479 total (10820 totally succeeded, 0 partially succeeded, 1659 totally failed)
Failures by error:
  manifestError: 1591 versions across 396 packages
    missingLicense: 1273 versions across 297 packages
    badDependencyVersions: 328 versions across 116 packages
    badVersion: 61 versions across 40 packages
    badLicense: 10 versions across 3 packages
  noDependencyFiles: 67 versions across 35 packages
  resourceError: 0 versions across 33 packages
  malformedPackageName: 1 versions across 1 packages
```

Where we now check ~1000 more versions than before.

Note: for this to take affect, you'll need to clear out your `.cache` directory, or at least clear out the `releases` entries within the cache.

Note: I believe the difference in package counts here is because of packages that were recently added to the registry - I didn't run it on `master` because it takes a long time, but I could if needed.