### PR TITLE
Find packages that will be dropped from the package set

### DIFF
--- a/ci/.gitignore
+++ b/ci/.gitignore
@@ -18,3 +18,6 @@ generated-docs/
 # Files generated as part of the legacy import process.
 bower-exclusions.json
 registry-index
+
+# A copy of the package set's `packages.json`, for the legacy import process.
+package-set-packages.json

--- a/ci/README.md
+++ b/ci/README.md
@@ -21,3 +21,21 @@ You can execute the legacy registry import script with the following command:
 ```console
 $ spago run -m Registry.Scripts.LegacyImport
 ```
+
+## Find Dropped Packages
+
+This script reports packages that will be dropped from the package set
+
+### Setup
+
+Before running this script you will need to have a `bower-exclusions.json` file (from running the [Legacy Import](#legacy-import)) and a `package-set-packages.json` file:
+
+```console
+$ wget https://raw.githubusercontent.com/purescript/package-sets/master/packages.json -O package-set-packages.json
+```
+
+With those files present, run the script with the following command:
+
+```console
+$ spago run -m Registry.Scripts.FindDroppedPackages
+```

--- a/ci/spago.dhall
+++ b/ci/spago.dhall
@@ -47,6 +47,7 @@
   , "spec"
   , "string-parsers"
   , "strings"
+  , "stringutils"
   , "sunde"
   , "transformers"
   , "tuples"

--- a/ci/src/Registry/Scripts/FindDroppedPackages.purs
+++ b/ci/src/Registry/Scripts/FindDroppedPackages.purs
@@ -5,10 +5,35 @@ import Registry.Prelude
 import Effect.Console (logShow)
 import Data.Argonaut as Json
 import Data.Array as Array
+import Data.Interpolate (i)
 import Data.List as List
 import Data.Map as Map
 import Effect.Aff as Aff
-import Registry.Scripts.LegacyImport.Error (ImportError, PackageFailures(..), RawPackageName(..), RawVersion(..))
+import Registry.Scripts.LegacyImport.Error (ImportError, ImportErrorKey(..), PackageFailures(..), RawPackageName(..), RawVersion(..))
+import Registry.Scripts.LegacyImport.Error as Error
+
+newtype PackageSet = PackageSet (Map RawPackageName PackageSetPackage)
+
+derive instance Newtype PackageSet _
+
+instance Json.DecodeJson PackageSet where
+  decodeJson json = do
+    packagesObject :: Object PackageSetPackage <- Json.decodeJson json
+    pure
+      $ PackageSet
+      $ objectToMap (Just <<< RawPackageName) packagesObject
+
+type PackageSetPackage =
+  { version :: RawVersion
+  }
+
+type DroppedPackage =
+  { name :: RawPackageName
+  , version :: RawVersion
+  , reason :: ImportError
+  }
+
+type ExcludedPackages = Map RawPackageName (Either ImportError (Map RawVersion ImportError))
 
 main :: Effect Unit
 main = Aff.launchAff_ do
@@ -27,24 +52,17 @@ main = Aff.launchAff_ do
           let
             packagesThatWillBeDropped = findPackagesThatWillBeDropped packages $ dropImportErrorKeys bowerExclusions
           in
-            liftEffect $ logShow $ map (un RawPackageName) packagesThatWillBeDropped
+            liftEffect $ packagesThatWillBeDropped
+              # traverse printMessage
 
-newtype PackageSet = PackageSet (Map RawPackageName PackageSetPackage)
-
-derive instance Newtype PackageSet _
-
-instance Json.DecodeJson PackageSet where
-  decodeJson json = do
-    packagesObject :: Object PackageSetPackage <- Json.decodeJson json
-    pure
-      $ PackageSet
-      $ objectToMap (Just <<< RawPackageName) packagesObject
-
-type PackageSetPackage =
-  { version :: RawVersion
-  }
-
-type ExcludedPackages = Map RawPackageName (Either ImportError (Map RawVersion ImportError))
+printMessage :: DroppedPackage -> Effect Unit
+printMessage droppedPackage = log message
+  where
+  name = un RawPackageName droppedPackage.name
+  version = un RawVersion droppedPackage.version
+  reason = un ImportErrorKey $ Error.printImportErrorKey droppedPackage.reason
+  packageIdentifier = name <> " " <> version
+  message = i packageIdentifier " will be dropped from the package set due to: " <> reason
 
 dropImportErrorKeys :: PackageFailures -> ExcludedPackages
 dropImportErrorKeys =
@@ -52,7 +70,7 @@ dropImportErrorKeys =
     >>> Map.values
     >>> List.foldl Map.union Map.empty
 
-findPackagesThatWillBeDropped :: PackageSet -> ExcludedPackages -> Array RawPackageName
+findPackagesThatWillBeDropped :: PackageSet -> ExcludedPackages -> Array DroppedPackage
 findPackagesThatWillBeDropped packageSet bowerExclusions =
   packageSet
     # un PackageSet
@@ -61,9 +79,9 @@ findPackagesThatWillBeDropped packageSet bowerExclusions =
   where
   willBeDropped name version =
     case Map.lookup name bowerExclusions of
-      Just (Left _) -> Just name
+      Just (Left reason) -> Just { name, version, reason }
       Just (Right excludedVersions) ->
         case Map.lookup version excludedVersions of
-          Just _ -> Just name
+          Just reason -> Just { name, version, reason }
           Nothing -> Nothing
       Nothing -> Nothing

--- a/ci/src/Registry/Scripts/FindDroppedPackages.purs
+++ b/ci/src/Registry/Scripts/FindDroppedPackages.purs
@@ -20,6 +20,7 @@ import Registry.Scripts.LegacyImport.Error
   , RawVersion(..)
   )
 
+-- | A PureScript package set.
 newtype PackageSet = PackageSet (Map RawPackageName PackageSetPackage)
 
 derive instance Newtype PackageSet _
@@ -31,10 +32,12 @@ instance Json.DecodeJson PackageSet where
       $ PackageSet
       $ objectToMap (Just <<< RawPackageName) packagesObject
 
+-- | A package in the package set.
 type PackageSetPackage =
   { version :: RawVersion
   }
 
+-- | A package that will be dropped from the package set.
 type DroppedPackage =
   { name :: RawPackageName
   , version :: RawVersion
@@ -111,12 +114,16 @@ printManifestError = case _ of
   printBadDependencyVersion { dependency, failedBounds } =
     i "Dependency: " (PackageName.print dependency) "\nFailed bounds: " failedBounds
 
+-- | Drops the import keys from the `PackageFailures` collection, as we don't
+-- | need the groupings.
 dropImportErrorKeys :: PackageFailures -> ExcludedPackages
 dropImportErrorKeys =
   un PackageFailures
     >>> Map.values
     >>> List.foldl Map.union Map.empty
 
+-- | Returns an array of all packages that will be dropped from the package set
+-- | based on the packages currently excluded from the registry.
 findPackagesThatWillBeDropped :: PackageSet -> ExcludedPackages -> Array DroppedPackage
 findPackagesThatWillBeDropped packageSet bowerExclusions =
   packageSet

--- a/ci/src/Registry/Scripts/FindDroppedPackages.purs
+++ b/ci/src/Registry/Scripts/FindDroppedPackages.purs
@@ -1,0 +1,55 @@
+module Registry.Scripts.FindDroppedPackages where
+
+import Registry.Prelude
+
+import Effect.Console (logShow)
+import Data.Argonaut as Json
+import Effect.Aff as Aff
+import Registry.Scripts.LegacyImport.Error (PackageFailures(..), RawPackageName(..), RawVersion(..))
+
+main :: Effect Unit
+main = Aff.launchAff_ do
+  bowerExclusionsFile <- readJsonFile "bower-exclusions.json"
+  case bowerExclusionsFile of
+    Left err -> do
+      let decodeError = "Decoding bower-exlusions.json failed with error:\n\n" <> Json.printJsonDecodeError err
+      throwError $ Aff.error decodeError
+    Right bowerExclusions -> do
+      packageSetPackagesFile <- readJsonFile "../../package-sets/packages.json"
+      case packageSetPackagesFile of
+        Left err -> do
+          let decodeError = "Decoding packages.json failed with error:\n\n" <> Json.printJsonDecodeError err
+          throwError $ Aff.error decodeError
+        Right packages ->
+          let
+            packagesThatWillBeDropped = findPackagesThatWillBeDropped packages bowerExclusions
+          in
+            pure unit
+
+-- pure unit
+
+newtype PackageSet = PackageSet (Map RawPackageName PackageSetPackage)
+
+instance Json.DecodeJson PackageSet where
+  decodeJson json = do
+    packagesObject :: Object PackageSetPackage <- Json.decodeJson json
+    pure
+      $ PackageSet
+      $ objectToMap (Just <<< RawPackageName) packagesObject
+
+-- type PackageSetJson = Map String { version :: String }
+
+-- type PackageSetJson = Map RawPackageName PackageSetPackage
+
+type PackageSetPackage =
+  { version :: RawVersion
+  }
+
+findPackagesThatWillBeDropped :: PackageSet -> PackageFailures -> Array String
+findPackagesThatWillBeDropped packageSet bowerExclusions = []
+-- bowerExclusions
+--   # un PackageFailures
+--   # Map.values
+--   # List.filter \package
+
+-- willBeDropped :: PackageSetJson -> Either RawPackageName

--- a/ci/src/Registry/Scripts/FindDroppedPackages.purs
+++ b/ci/src/Registry/Scripts/FindDroppedPackages.purs
@@ -54,7 +54,7 @@ main = Aff.launchAff_ do
       let decodeError = "Decoding bower-exclusions.json failed with error:\n\n" <> Json.printJsonDecodeError err
       throwError $ Aff.error decodeError
     Right bowerExclusions -> do
-      packageSetPackagesFile <- readJsonFile "../../package-sets/packages.json"
+      packageSetPackagesFile <- readJsonFile "package-set-packages.json"
       case packageSetPackagesFile of
         Left err -> do
           let decodeError = "Decoding packages.json failed with error:\n\n" <> Json.printJsonDecodeError err


### PR DESCRIPTION
As described in #250, this PR adds a script to find packages that will be dropped from the package set.

The script will output a report of the packages that will be dropped, as well the reason for them being dropped.