### PR TITLE
Add link to the top-level nix-shell

### DIFF
--- a/ci/shell.nix
+++ b/ci/shell.nix
@@ -1,0 +1,1 @@
+../shell.nix


### PR DESCRIPTION
..so that we can just type `nix-shell` when in the `ci` directory to make all the dependencies available