### PR TITLE
Use SPDX.And when parsing manifests

### DIFF
--- a/ci/src/Registry/Scripts/LegacyImport/Manifest.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Manifest.purs
@@ -225,7 +225,7 @@ toManifest package repository version manifest = do
 
           case fail, success of
             [], [] -> mkError MissingLicense
-            [], _ -> Right $ SPDX.joinWith SPDX.Or success
+            [], _ -> Right $ SPDX.joinWith SPDX.And success
             _, _ -> mkError $ BadLicense fail
 
     eitherTargets = do


### PR DESCRIPTION
In #79 we've discussed the need to join package licenses with the SPDX `AND` conjunctive when producing new manifest files during the legacy import process. During an unrelated code review I noticed we are currently using the much less restrictive `OR`. This PR updates our code to use `AND` instead.