### PR TITLE
Switch to using value-based Json codecs

### DIFF
--- a/ci/spago.dhall
+++ b/ci/spago.dhall
@@ -10,6 +10,8 @@
   , "arrays"
   , "avar"
   , "bifunctors"
+  , "codec"
+  , "codec-argonaut"
   , "console"
   , "control"
   , "crypto"
@@ -42,6 +44,7 @@
   , "parallel"
   , "partial"
   , "prelude"
+  , "profunctor"
   , "profunctor-lenses"
   , "psci-support"
   , "refs"
@@ -52,6 +55,7 @@
   , "sunde"
   , "transformers"
   , "tuples"
+  , "variant"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/ci/src/Foreign/Dhall.purs
+++ b/ci/src/Foreign/Dhall.purs
@@ -2,7 +2,8 @@ module Foreign.Dhall where
 
 import Registry.Prelude
 
-import Data.Argonaut as Json
+import Data.Argonaut.Core as Json
+import Data.Codec.Argonaut as CA
 import Foreign.Jsonic as Jsonic
 import Node.ChildProcess as NodeProcess
 import Sunde as Process
@@ -28,5 +29,5 @@ dhallToJson { dhall, cwd } = do
   let args = []
   result <- Process.spawn { cmd, stdin, args } (NodeProcess.defaultSpawnOptions { cwd = cwd })
   pure $ case result.exit of
-    NodeProcess.Normally 0 -> lmap Json.printJsonDecodeError $ Jsonic.parseJson result.stdout
+    NodeProcess.Normally 0 -> lmap CA.printJsonDecodeError $ Jsonic.parseJson result.stdout
     _ -> Left result.stderr

--- a/ci/src/Foreign/Jsonic.purs
+++ b/ci/src/Foreign/Jsonic.purs
@@ -1,16 +1,17 @@
 module Foreign.Jsonic (parseJson) where
 
-import Data.Argonaut (Json)
-import Data.Argonaut as Json
+import Data.Argonaut.Core (Json)
+import Data.Argonaut.Core as Json
 import Data.Bifunctor (lmap)
+import Data.Codec.Argonaut as CA
 import Data.Either (Either(..))
 import Data.Function.Uncurried (Fn3, runFn3)
 
 -- | A drop-in replacement for `Data.Argonaut.parseJson` that uses a lenient
 -- | JSON parser.
-parseJson :: String -> Either Json.JsonDecodeError Json
+parseJson :: String -> Either CA.JsonDecodeError Json
 parseJson input = do
-  let toJsonError e = Json.Named "Malformed JSON" (Json.UnexpectedValue (Json.fromString e))
+  let toJsonError e = CA.Named "Malformed JSON" (CA.UnexpectedValue (Json.fromString e))
   lmap toJsonError (parseJsonic input)
 
 foreign import parseJsonicImpl :: forall r. Fn3 (String -> r) (Json -> r) String r

--- a/ci/src/Foreign/SPDX.purs
+++ b/ci/src/Foreign/SPDX.purs
@@ -1,5 +1,6 @@
 module Foreign.SPDX
   ( License
+  , licenseCodec
   , parse
   , print
   , SPDXConjunction(..)
@@ -8,7 +9,9 @@ module Foreign.SPDX
 
 import Registry.Prelude
 
-import Data.Argonaut (class DecodeJson, class EncodeJson, JsonDecodeError(..), decodeJson, encodeJson)
+import Data.Codec (basicCodec, decode, encode)
+import Data.Codec.Argonaut (JsonCodec, JsonDecodeError(..))
+import Data.Codec.Argonaut as CA
 import Data.Function.Uncurried (Fn3, runFn3)
 import Data.String as String
 import Safe.Coerce (coerce)
@@ -18,11 +21,11 @@ newtype License = License String
 
 derive newtype instance eqLicense :: Eq License
 
-instance decodeJsonSPDXLicense :: DecodeJson License where
-  decodeJson = lmap TypeMismatch <<< parse <=< decodeJson
-
-instance encodeJsonSPDXLicense :: EncodeJson License where
-  encodeJson = encodeJson <<< print
+licenseCodec :: JsonCodec License
+licenseCodec = basicCodec dec enc
+  where
+  enc = encode CA.string <<< print
+  dec = lmap TypeMismatch <<< parse <=< decode CA.string
 
 instance Show License where
   show = print

--- a/ci/src/Registry/Codec.purs
+++ b/ci/src/Registry/Codec.purs
@@ -1,0 +1,47 @@
+module Registry.Codec where
+
+import Prelude
+
+import Data.Argonaut.Core (Json)
+import Data.Argonaut.Parser (jsonParser)
+import Data.Array.NonEmpty as NEA
+import Data.Array.NonEmpty.Internal (NonEmptyArray)
+import Data.Bifunctor (bimap, lmap)
+import Data.Codec (basicCodec, decode, encode)
+import Data.Codec.Argonaut (JsonCodec, JsonDecodeError(..))
+import Data.Codec.Argonaut as CA
+import Data.Either (Either, note)
+import Data.Newtype (class Newtype, unwrap, wrap)
+import Data.String.NonEmpty.Internal (NonEmptyString)
+import Data.String.NonEmpty.Internal as NES
+
+-- | Codec for newtyped strings where the error message
+-- | includes the constructor's name
+newtypeStringCodec :: forall a. Newtype a String => String -> JsonCodec a
+newtypeStringCodec ctorName = basicCodec dec enc
+  where
+  enc = encode CA.string <<< unwrap
+  dec = bimap (Named ctorName) wrap <<< decode CA.string
+
+neArray :: forall a. JsonCodec a -> JsonCodec (NonEmptyArray a)
+neArray elemCodec = basicCodec dec enc
+  where
+  enc = encode (CA.array elemCodec) <<< NEA.toArray
+  dec j = do
+    arr <- lmap (Named "NonEmptyArray") $ decode (CA.array elemCodec) j
+    note (Named "NonEmptyArray" $ UnexpectedValue j)
+      $ NEA.fromArray arr
+
+neString :: JsonCodec NonEmptyString
+neString = basicCodec dec enc
+  where
+  enc = encode CA.string <<< NES.toString
+  dec j = do
+    s <- decode CA.string j
+    note (Named "NonEmptyString" $ UnexpectedValue j) $ NES.fromString s
+
+-- | Attempt to parse a string as `Json`, failing with a typed error if the
+-- | JSON string is malformed.
+-- Needed because it's not defined in `purescript-codec-argonaut`
+parseJson :: String -> Either JsonDecodeError Json
+parseJson = lmap (\_ -> TypeMismatch "JSON") <<< jsonParser

--- a/ci/src/Registry/Scripts/LegacyImport/Bowerfile.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Bowerfile.purs
@@ -1,17 +1,14 @@
 module Registry.Scripts.LegacyImport.Bowerfile
   ( Bowerfile(..)
   , toManifestFields
+  , bowerfileCodec
   ) where
 
 import Registry.Prelude
 
-import Data.Argonaut (Json, (.:?))
-import Data.Argonaut as Json
-import Data.Array as Array
-import Data.Array.NonEmpty as NEA
-import Data.String.NonEmpty (NonEmptyString)
-import Data.String.NonEmpty as NES
-import Registry.Scripts.LegacyImport.ManifestFields (ManifestFields)
+import Data.Codec.Argonaut (JsonCodec)
+import Data.Profunctor (dimap)
+import Registry.Scripts.LegacyImport.ManifestFields (ManifestFields, manifestFieldsCodec)
 
 toManifestFields :: Bowerfile -> ManifestFields
 toManifestFields (Bowerfile fields) = fields
@@ -20,27 +17,6 @@ newtype Bowerfile = Bowerfile ManifestFields
 
 derive newtype instance Eq Bowerfile
 derive newtype instance Show Bowerfile
-derive newtype instance Json.EncodeJson Bowerfile
 
-instance Json.DecodeJson Bowerfile where
-  decodeJson json = do
-    obj <- Json.decodeJson json
-    description <- obj .:? "description"
-    license <- decodeStringOrStringArray obj "license"
-    dependencies <- fromMaybe mempty <$> obj .:? "dependencies"
-    devDependencies <- fromMaybe mempty <$> obj .:? "devDependencies"
-    pure $ Bowerfile { description, license, dependencies, devDependencies }
-
-decodeStringOrStringArray
-  :: Object Json
-  -> String
-  -> Either Json.JsonDecodeError (Maybe (NonEmptyArray NonEmptyString))
-decodeStringOrStringArray obj fieldName = do
-  let typeError = const $ Json.AtKey fieldName $ Json.TypeMismatch "String or Array"
-  lmap typeError do
-    value <- obj .:? fieldName
-    case value of
-      Nothing -> pure Nothing
-      Just v -> do
-        decoded <- (Json.decodeJson v <#> Array.singleton) <|> Json.decodeJson v
-        pure $ NEA.fromArray $ Array.catMaybes $ map NES.fromString decoded
+bowerfileCodec :: JsonCodec Bowerfile
+bowerfileCodec = dimap (\(Bowerfile a) -> a) Bowerfile manifestFieldsCodec

--- a/ci/src/Registry/Scripts/LegacyImport/ManifestFields.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/ManifestFields.purs
@@ -2,7 +2,12 @@ module Registry.Scripts.LegacyImport.ManifestFields where
 
 import Registry.Prelude
 
+import Data.Codec.Argonaut (JsonCodec)
+import Data.Codec.Argonaut as CA
+import Data.Codec.Argonaut.Compat as Compat
+import Data.Codec.Argonaut.Record as CAR
 import Data.String.NonEmpty (NonEmptyString)
+import Registry.Codec (neArray, neString)
 
 type ManifestFields =
   { license :: Maybe (NonEmptyArray NonEmptyString)
@@ -10,3 +15,46 @@ type ManifestFields =
   , dependencies :: Object String
   , devDependencies :: Object String
   }
+
+manifestFieldsCodec :: JsonCodec ManifestFields
+manifestFieldsCodec = CAR.object "ManifestFields"
+  { license: Compat.maybe (neArray neString)
+  , description: Compat.maybe CA.string
+  , dependencies: Compat.foreignObject CA.string
+  , devDependencies: Compat.foreignObject CA.string
+  }
+
+-- derive newtype instance Json.EncodeJson Bowerfile
+
+-- instance Json.DecodeJson Bowerfile where
+--   decodeJson json = do
+--     obj <- Json.decodeJson json
+--     description <- obj .:? "description"
+--     license <- decodeStringOrStringArray obj "license"
+--     dependencies <- fromMaybe mempty <$> obj .:? "dependencies"
+--     devDependencies <- fromMaybe mempty <$> obj .:? "devDependencies"
+--     pure $ Bowerfile { description, license, dependencies, devDependencies }
+
+-- decodeStringOrStringArray :: JsonCodec (Maybe (NonEmptyArray NonEmptyString))
+-- decodeStringOrStringArray = basicCodec dec enc
+--   where
+--   enc = encode (Compat.maybe (neArray neString))
+--   dec j = do
+--     value <- decode (Compat.maybe (neString <|> ))
+
+--   decNEString = decode neString
+--   decArrNeString = map Array.cat
+
+-- decodeStringOrStringArray
+--   :: Object Json
+--   -> String
+--   -> Either Json.JsonDecodeError (Maybe (NonEmptyArray NonEmptyString))
+-- decodeStringOrStringArray obj fieldName = do
+--   let typeError = const $ Json.AtKey fieldName $ Json.TypeMismatch "String or Array"
+--   lmap typeError do
+--     value <- obj .:? fieldName
+--     case value of
+--       Nothing -> pure Nothing
+--       Just v -> do
+--         decoded <- (Json.decodeJson v <#> Array.singleton) <|> Json.decodeJson v
+--         pure $ NEA.fromArray $ Array.catMaybes $ map NES.fromString decoded


### PR DESCRIPTION
Updates the codebase to use `purescript-codec-argonaut`.

In ce1c8bdcbc66d168821680af86e06f605b193e50, there are a few codecs I wasn't sure how to port properly. The others are likely correct, but a few migration may still have issues due to the usage of optional fields.

I haven't tested this out yet, but it should be good enough for an initial review.