### PR TITLE
Restrict maximum package size to 200kb (for now)

### DIFF
--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -162,10 +162,15 @@ type Metadata =
 type VersionMetadata =
   { ref :: String
   , hash :: String
+  , bytes :: Number
   }
 
 mkNewMetadata :: Repo -> Metadata
-mkNewMetadata location = { location, releases: mempty, unpublished: mempty }
+mkNewMetadata location =
+  { location
+  , releases: Object.empty
+  , unpublished: Object.empty
+  }
 
 addVersionToMetadata :: SemVer -> VersionMetadata -> Metadata -> Metadata
 addVersionToMetadata version versionMeta metadata =

--- a/v1/Metadata.dhall
+++ b/v1/Metadata.dhall
@@ -11,7 +11,16 @@ let Repo = ./Repo.dhall
 
 let SemVer = Text
 
-let VersionMetadata = { ref : Text, hash : Text, bytes : Natural }
+-- Information about a single published version
+let VersionMetadata =
+  {
+  -- The git ref this version points to
+  , ref : Text
+  -- The hash of the source tarball fetched from the repo
+  , hash : Text
+  -- The size in bytes of the tarball
+  , bytes : Natural
+  }
 
 in
   {

--- a/v1/Metadata.dhall
+++ b/v1/Metadata.dhall
@@ -11,7 +11,7 @@ let Repo = ./Repo.dhall
 
 let SemVer = Text
 
-let VersionMetadata = { ref : Text, hash : Text }
+let VersionMetadata = { ref : Text, hash : Text, bytes : Natural }
 
 in
   {


### PR DESCRIPTION
Fixes #287 by adding a `bytes : Natural` field to `Metadata.dhall` and guarding the API pipeline to fail if a package tarball exceeds a 200kb limit.