### PR TITLE
Centralize use of unsafeFromRight

### DIFF
--- a/ci/src/Registry/Prelude.purs
+++ b/ci/src/Registry/Prelude.purs
@@ -9,6 +9,8 @@ module Registry.Prelude
   , stripPureScriptPrefix
   , newlines
   , fromJust'
+  , unsafeFromJust
+  , unsafeFromRight
   ) where
 
 import Prelude
@@ -46,7 +48,7 @@ import Foreign.Object (Object) as Extra
 import Node.Buffer (Buffer) as Extra
 import Node.Encoding (Encoding(..)) as Extra
 import Node.Path (FilePath) as Extra
-import Partial.Unsafe (unsafePartial, unsafeCrashWith) as Extra
+import Partial.Unsafe (unsafeCrashWith) as Extra
 import Registry.Json (Json, class RegistryJson) as Registry.Json
 import Registry.Types (RawPackageName(..), RawVersion(..)) as Registry.Types
 
@@ -81,3 +83,9 @@ newlines n = Array.fold $ Array.replicate n "\n"
 fromJust' :: forall a. (Unit -> a) -> Maybe.Maybe a -> a
 fromJust' _ (Maybe.Just a) = a
 fromJust' failed _ = failed unit
+
+unsafeFromJust :: forall a. Maybe.Maybe a -> a
+unsafeFromJust = fromJust' (\_ -> Extra.unsafeCrashWith "Unexpected Nothing")
+
+unsafeFromRight :: forall e a. Either.Either e a -> a
+unsafeFromRight = Either.fromRight' (\_ -> Extra.unsafeCrashWith "Unexpected Left")

--- a/ci/src/Registry/Scripts/LegacyImport/Process.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Process.purs
@@ -210,9 +210,9 @@ withCache { encode, decode } path maybeDuration action = do
         _, Nothing -> pure false
         false, _ -> pure false
         true, Just duration -> do
-          lastModified <- FS.stat objectPath <#> unsafePartial fromJust <<< JSDate.toDateTime <<< _.mtime <<< (\(Stats s) -> s)
+          lastModified <- FS.stat objectPath <#> unsafeFromJust <<< JSDate.toDateTime <<< _.mtime <<< (\(Stats s) -> s)
           now <- liftEffect $ Time.nowDateTime
-          let expiryTime = unsafePartial fromJust $ Time.adjust duration lastModified
+          let expiryTime = unsafeFromJust $ Time.adjust duration lastModified
           pure (now > expiryTime)
       pure (exists && not expired)
 

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -179,7 +179,7 @@ decodeEventsToOps = do
     let
       issueNumber = IssueNumber 43
       operation = Update
-        { packageName: fromRight' (\_ -> unsafeCrashWith "Expected Right") (PackageName.parse "something")
+        { packageName: unsafeFromRight $ PackageName.parse "something"
         , updateRef: "v1.2.3"
         , fromBower: false
         }
@@ -191,7 +191,7 @@ decodeEventsToOps = do
     let
       issueNumber = IssueNumber 149
       operation = Addition
-        { packageName: fromRight' (\_ -> unsafeCrashWith "Expected Right") (PackageName.parse "prelude")
+        { packageName: unsafeFromRight $ PackageName.parse "prelude"
         , newRef: "v5.0.0"
         , fromBower: true
         , addToPackageSet: true

--- a/ci/test/Registry/Scripts/LegacyImport/Stats.purs
+++ b/ci/test/Registry/Scripts/LegacyImport/Stats.purs
@@ -84,9 +84,6 @@ exampleFailures = PackageFailures $ Map.fromFoldable
 exampleStats :: Stats.Stats
 exampleStats = Stats.errorStats mockStats
   where
-  unsafeFromRight :: forall e a. Either e a -> a
-  unsafeFromRight = fromRight' (\_ -> unsafeCrashWith "Unexpected Left")
-
   mockLicense :: License
   mockLicense = unsafeFromRight $ License.parse "MIT"
 

--- a/ci/test/Support/Manifest.purs
+++ b/ci/test/Support/Manifest.purs
@@ -89,6 +89,3 @@ abcd = { name, v1, v2 }
   description = Just "some description"
   v1 = Manifest { name, version: version1, license, repository, targets: targets1, description }
   v2 = Manifest { name, version: version2, license, repository, targets: targets2, description }
-
-unsafeFromRight :: forall e a. Either e a -> a
-unsafeFromRight = fromRight' (\_ -> unsafeCrashWith "Unexpected Left")


### PR DESCRIPTION
In https://github.com/purescript/registry/pull/305#discussion_r793866804 @colinwahl noted that we've got scattered implementations of `unsafeFromRight` all over the place. This PR adds this function to the prelude and uses that across the board.