### PR TITLE
Add a documentation comment to SemVer.validRange

### DIFF
--- a/ci/src/Foreign/SemVer.js
+++ b/ci/src/Foreign/SemVer.js
@@ -7,9 +7,13 @@ exports.parseRangeImpl = (rangeString) =>
   // range is not valid, and the converted range if it is.
   //
   // For example:
-  // > validRange("^1.0.0") -> (">=1.0.0 <2.0.0")
+  //
+  // > validRange("^1.0.0")
+  // ">=1.0.0 <2.0.0"
   //
   // In loose mode `validRange` will also fix common errors like including a 'v' prefix
   // or extra spaces:
-  // > validRange(" = v 2.1.5-foo") -> "2.1.5-foo"
+  //
+  // > validRange(" = v 2.1.5-foo")
+  // "2.1.5-foo"
   semver.validRange(rangeString, { loose: true, includePrerelease: false });

--- a/ci/src/Foreign/SemVer.js
+++ b/ci/src/Foreign/SemVer.js
@@ -16,4 +16,7 @@ exports.parseRangeImpl = (rangeString) =>
   //
   // > validRange(" = v 2.1.5-foo")
   // "2.1.5-foo"
+  //
+  // We set these options because we should only be using this function to clean up ranges,
+  // not to validate them.
   semver.validRange(rangeString, { loose: true, includePrerelease: false });

--- a/ci/src/Foreign/SemVer.js
+++ b/ci/src/Foreign/SemVer.js
@@ -1,4 +1,15 @@
 const semver = require("semver");
 
 exports.parseRangeImpl = (rangeString) =>
+  // `validRange` cleans the input string (in loose mode) and converts it into a range
+  // using only comparative operators (no ^, ~, -, or other range operators), and then
+  // checks whether the result is a valid SemVer range. It then returns `null` if the
+  // range is not valid, and the converted range if it is.
+  //
+  // For example:
+  // > validRange("^1.0.0") -> (">=1.0.0 <2.0.0")
+  //
+  // In loose mode `validRange` will also fix common errors like including a 'v' prefix
+  // or extra spaces:
+  // > validRange(" = v 2.1.5-foo") -> "2.1.5-foo"
   semver.validRange(rangeString, { loose: true, includePrerelease: false });


### PR DESCRIPTION
We use specific options to control the behavior of the `node-semver` validRange function, and we mostly use it for its ability to convert ranges using operators like `^` and `~` into simpler ranges like `>=X.Y.Z <X.Y.Z`. This PR adds a documentation comment that more fully describes how we're using this function and what the options mean.