### PR TITLE
Fix use of 'bower' as a shorthand for 'legacy'

### DIFF
--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -100,21 +100,21 @@ readOperation eventPath = do
 runOperation :: Operation -> RegistryM Unit
 runOperation operation = case operation of
   -- TODO handle addToPackageSet
-  Addition { packageName, fromBower, newRef, newPackageLocation } -> do
+  Addition { packageName, legacy, newRef, newPackageLocation } -> do
     -- check that we don't have a metadata file for that package
     ifM (liftAff $ FS.exists $ metadataFile packageName)
       -- if the metadata file already exists then we steer this to be an Update instead
-      (runOperation $ Update { packageName, fromBower, updateRef: newRef })
+      (runOperation $ Update { packageName, legacy, updateRef: newRef })
       do
-        addOrUpdate { packageName, fromBower, ref: newRef } $ mkNewMetadata newPackageLocation
+        addOrUpdate { packageName, legacy, ref: newRef } $ mkNewMetadata newPackageLocation
 
-  Update { packageName, fromBower, updateRef } -> do
+  Update { packageName, legacy, updateRef } -> do
     ifM (liftAff $ FS.exists $ metadataFile packageName)
       do
         metadata <- readPackagesMetadata >>= \packages -> case Map.lookup packageName packages of
           Nothing -> throwWithComment "Couldn't read metadata file for your package"
           Just m -> pure m
-        addOrUpdate { packageName, fromBower, ref: updateRef } metadata
+        addOrUpdate { packageName, legacy, ref: updateRef } metadata
       (throwWithComment "Metadata file should exist. Did you mean to create an Addition?")
 
   Unpublish _ -> throwWithComment "Unpublish not implemented! Ask us for help!" -- TODO
@@ -128,8 +128,8 @@ metadataFile packageName = metadataDir <> "/" <> PackageName.print packageName <
 indexDir :: FilePath
 indexDir = "../registry-index"
 
-addOrUpdate :: { fromBower :: Boolean, ref :: String, packageName :: PackageName } -> Metadata -> RegistryM Unit
-addOrUpdate { ref, fromBower, packageName } metadata = do
+addOrUpdate :: { legacy :: Boolean, ref :: String, packageName :: PackageName } -> Metadata -> RegistryM Unit
+addOrUpdate { ref, legacy, packageName } metadata = do
   -- let's get a temp folder to do our stuffs
   tmpDir <- liftEffect $ Tmp.mkTmpDir
   -- fetch the repo and put it in the tempdir, returning the name of its toplevel dir
@@ -159,9 +159,8 @@ addOrUpdate { ref, fromBower, packageName } metadata = do
   let manifestPath = absoluteFolderPath <> "/purs.json"
   log $ "Package extracted in " <> absoluteFolderPath
 
-  -- If we're "importing from Bower" then we need to gather information about the
-  -- legacy package and put all of that together into a Registry Manifest
-  when fromBower do
+  -- If this is a legacy import, then we need to construct a `Manifest` for it
+  when legacy do
     address <- case metadata.location of
       Git _ -> throwWithComment "Legacy packages can only come from GitHub. Aborting."
       GitHub { owner, repo } -> pure { owner, repo }
@@ -183,7 +182,7 @@ addOrUpdate { ref, fromBower, packageName } metadata = do
 
     runManifest gatherManifest >>= case _ of
       Left err ->
-        throwWithComment $ "Unable to convert Bowerfile to a manifest: " <> err
+        throwWithComment $ "Unable to produce a manifest fir legacy package: " <> err
       Right manifest ->
         liftAff $ Json.writeJsonFile manifestPath manifest
 

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -136,7 +136,7 @@ instance RegistryJson Operation where
 
 type AdditionData =
   { addToPackageSet :: Boolean
-  , fromBower :: Boolean
+  , legacy :: Boolean
   , newPackageLocation :: Repo
   , newRef :: String
   , packageName :: PackageName
@@ -144,7 +144,7 @@ type AdditionData =
 
 type UpdateData =
   { packageName :: PackageName
-  , fromBower :: Boolean
+  , legacy :: Boolean
   , updateRef :: String
   }
 

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -34,7 +34,7 @@ import Text.Parsing.StringParser as StringParser
 
 -- | This main loop uploads legacy packages to the new Registry
 -- | In order to do this, we:
--- | - get an index of the legacy packages with their bowerfiles
+-- | - get an index of the legacy packages
 -- | - create a graph (a tree really) where a package is a node and dependencies are edges
 -- | - topologically sort this graph so that packages with no dependencies are at the root
 -- | - go through this list: if the package is in the registry index then skip, otherwise upload
@@ -89,7 +89,7 @@ main = Aff.launchAff_ do
     let
       addition = Addition
         { addToPackageSet: false -- heh, we don't have package sets until we do this import!
-        , fromBower: true
+        , legacy: true
         , newPackageLocation: manifest.repository
         , newRef: Version.rawVersion manifest.version
         , packageName: manifest.name

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -181,7 +181,7 @@ decodeEventsToOps = do
       operation = Update
         { packageName: unsafeFromRight $ PackageName.parse "something"
         , updateRef: "v1.2.3"
-        , fromBower: false
+        , legacy: false
         }
 
     res <- API.readOperation "test/fixtures/issue_comment.json"
@@ -193,7 +193,7 @@ decodeEventsToOps = do
       operation = Addition
         { packageName: unsafeFromRight $ PackageName.parse "prelude"
         , newRef: "v5.0.0"
-        , fromBower: true
+        , legacy: true
         , addToPackageSet: true
         , newPackageLocation: GitHub { subdir: Nothing, owner: "purescript", repo: "purescript-prelude" }
         }

--- a/ci/test/fixtures/issue_comment.json
+++ b/ci/test/fixtures/issue_comment.json
@@ -2,7 +2,7 @@
   "action": "created",
   "comment": {
     "author_association": "MEMBER",
-    "body": "{\"fromBower\": false,\"packageName\":\"something\",\"updateRef\":\"v1.2.3\"}",
+    "body": "{\"legacy\": false,\"packageName\":\"something\",\"updateRef\":\"v1.2.3\"}",
     "created_at": "2021-03-09T02:03:56Z",
     "html_url": "https://github.com/purescript/registry/issues/43#issuecomment-793265839",
     "id": 793265839,

--- a/ci/test/fixtures/issue_created.json
+++ b/ci/test/fixtures/issue_created.json
@@ -5,7 +5,7 @@
     "assignee": null,
     "assignees": [],
     "author_association": "CONTRIBUTOR",
-    "body": "{\"addToPackageSet\": true,\"fromBower\": true,\"newPackageLocation\": {\"githubOwner\": \"purescript\",\"githubRepo\": \"purescript-prelude\"},\"newRef\": \"v5.0.0\",\"packageName\": \"prelude\"}",
+    "body": "{\"addToPackageSet\": true,\"legacy\": true,\"newPackageLocation\": {\"githubOwner\": \"purescript\",\"githubRepo\": \"purescript-prelude\"},\"newRef\": \"v5.0.0\",\"packageName\": \"prelude\"}",
     "closed_at": null,
     "comments": 0,
     "comments_url": "https://api.github.com/repos/purescript/registry/issues/149/comments",


### PR DESCRIPTION
The initial implementation of the API and legacy importer called everything a "Bower import" because packages came from the Bower registry and we only looked at their Bowerfiles. However, over time this has expanded greatly to include packages that don't have a `purs.json` file, and so the use of "bower" to refer to a legacy package is no longer correct.

This PR updates our language in the repository to reference "legacy" packages instead of "bower" packages.