### PR TITLE
Include publication date in metadata

### DIFF
--- a/ci/spago.dhall
+++ b/ci/spago.dhall
@@ -40,6 +40,7 @@
   , "ordered-collections"
   , "parallel"
   , "partial"
+  , "precise-datetime"
   , "prelude"
   , "profunctor-lenses"
   , "psci-support"

--- a/ci/src/Foreign/GitHub.js
+++ b/ci/src/Foreign/GitHub.js
@@ -16,14 +16,23 @@ exports.getReleasesImpl = function (octokit, { owner, repo }) {
       owner,
       repo,
     })
-    .then((data) => {
-      return data.map((element) => {
-        return {
-          name: element.name,
-          sha: element.commit.sha,
-        };
-      });
-    });
+    .then((data) =>
+      data.map((element) => {
+        return { name: element.name, sha: element.commit.sha };
+      })
+    );
+};
+
+exports.getRefCommitImpl = function (octokit, { owner, repo }, ref) {
+  return octokit.rest.git
+    .getRef({ owner, repo, ref })
+    .then((data) => data.object.sha);
+};
+
+exports.getCommitDateImpl = function (octokit, { owner, repo }, sha) {
+  return octokit.rest.git
+    .getCommit({ owner, repo, commit_sha: sha })
+    .then(({ data }) => data.committer.date);
 };
 
 exports.closeIssueImpl = function (octokit, { owner, repo }, issue_number) {
@@ -31,9 +40,10 @@ exports.closeIssueImpl = function (octokit, { owner, repo }, issue_number) {
     owner,
     repo,
     issue_number,
-    state: "closed"
+    state: "closed",
   });
-}
+};
+
 exports.createCommentImpl = function (octokit, { owner, repo }, issue_number, body) {
   return octokit.issues.createComment({ owner, repo, issue_number, body });
 };

--- a/ci/src/Foreign/GitHub.purs
+++ b/ci/src/Foreign/GitHub.purs
@@ -46,7 +46,7 @@ type Address = { owner :: String, repo :: String }
 registryAddress :: Address
 registryAddress = { owner: "purescript", repo: "registry" }
 
-type Tag = { name :: String, sha :: String, date :: RFC3339String }
+type Tag = { name :: String, sha :: String }
 
 newtype PackageURL = PackageURL String
 
@@ -67,9 +67,9 @@ parseRepo = unwrap >>> Parser.runParser do
   let repo = fromMaybe repoWithSuffix $ String.stripSuffix (String.Pattern ".git") repoWithSuffix
   pure { owner, repo }
 
-foreign import getReleasesImpl :: EffectFn2 Octokit Address (Promise (Array { name :: String, sha :: String }))
+foreign import getReleasesImpl :: EffectFn2 Octokit Address (Promise (Array Tag))
 
-getReleases :: Octokit -> Address -> Aff (Array { name :: String, sha :: String })
+getReleases :: Octokit -> Address -> Aff (Array Tag)
 getReleases octokit address = Promise.toAffE $ runEffectFn2 getReleasesImpl octokit address
 
 foreign import getRefCommitImpl :: EffectFn3 Octokit Address String (Promise String)
@@ -85,16 +85,6 @@ getCommitDate :: Octokit -> Address -> String -> Aff RFC3339String
 getCommitDate octokit address sha = do
   date <- Promise.toAffE $ runEffectFn3 getCommitDateImpl octokit address sha
   pure $ RFC3339String date
-
-getTags :: Octokit -> Address -> Aff (Array Tag)
-getTags octokit address = do
-  releases <- getReleases octokit address
-  -- While it would be nice to use `parTraverse` here and speed things up,
-  -- this does make it extremely easy to break GitHub's API rate limiting.
-  releases # traverse \release -> do
-    log $ "  " <> release.sha
-    date <- getCommitDate octokit address release.sha
-    pure { name: release.name, sha: release.sha, date }
 
 newtype IssueNumber = IssueNumber Int
 

--- a/ci/src/Foreign/GitHub.purs
+++ b/ci/src/Foreign/GitHub.purs
@@ -6,6 +6,7 @@ import Control.Promise (Promise)
 import Control.Promise as Promise
 import Data.List as List
 import Data.Newtype (unwrap)
+import Data.RFC3339String (RFC3339String(..))
 import Data.String as String
 import Data.String.CodeUnits (fromCharArray)
 import Effect.Uncurried (EffectFn2, EffectFn3, EffectFn4, runEffectFn2, runEffectFn3, runEffectFn4)
@@ -45,7 +46,7 @@ type Address = { owner :: String, repo :: String }
 registryAddress :: Address
 registryAddress = { owner: "purescript", repo: "registry" }
 
-type Tag = { name :: String, sha :: String }
+type Tag = { name :: String, sha :: String, date :: RFC3339String }
 
 newtype PackageURL = PackageURL String
 
@@ -66,10 +67,34 @@ parseRepo = unwrap >>> Parser.runParser do
   let repo = fromMaybe repoWithSuffix $ String.stripSuffix (String.Pattern ".git") repoWithSuffix
   pure { owner, repo }
 
-foreign import getReleasesImpl :: EffectFn2 Octokit Address (Promise (Array Tag))
+foreign import getReleasesImpl :: EffectFn2 Octokit Address (Promise (Array { name :: String, sha :: String }))
 
-getReleases :: Octokit -> Address -> Aff (Array Tag)
+getReleases :: Octokit -> Address -> Aff (Array { name :: String, sha :: String })
 getReleases octokit address = Promise.toAffE $ runEffectFn2 getReleasesImpl octokit address
+
+foreign import getRefCommitImpl :: EffectFn3 Octokit Address String (Promise String)
+
+getRefCommit :: Octokit -> Address -> String -> Aff String
+getRefCommit octokit address ref = do
+  commitSha <- Promise.toAffE $ runEffectFn3 getRefCommitImpl octokit address ref
+  pure commitSha
+
+foreign import getCommitDateImpl :: EffectFn3 Octokit Address String (Promise String)
+
+getCommitDate :: Octokit -> Address -> String -> Aff RFC3339String
+getCommitDate octokit address sha = do
+  date <- Promise.toAffE $ runEffectFn3 getCommitDateImpl octokit address sha
+  pure $ RFC3339String date
+
+getTags :: Octokit -> Address -> Aff (Array Tag)
+getTags octokit address = do
+  releases <- getReleases octokit address
+  -- While it would be nice to use `parTraverse` here and speed things up,
+  -- this does make it extremely easy to break GitHub's API rate limiting.
+  releases # traverse \release -> do
+    log $ "  " <> release.sha
+    date <- getCommitDate octokit address release.sha
+    pure { name: release.name, sha: release.sha, date }
 
 newtype IssueNumber = IssueNumber Int
 

--- a/ci/src/Registry/Json.purs
+++ b/ci/src/Registry/Json.purs
@@ -51,6 +51,8 @@ import Data.Int as Int
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), maybe)
+import Data.Newtype (un)
+import Data.RFC3339String (RFC3339String(..))
 import Data.String.NonEmpty (NonEmptyString)
 import Data.String.NonEmpty as NES
 import Data.Symbol (class IsSymbol)
@@ -185,6 +187,10 @@ instance RegistryJson NonEmptyString where
 instance RegistryJson a => RegistryJson (NonEmptyArray a) where
   encode = encode <<< NEA.toArray
   decode = decode >=> NEA.fromArray >>> note "Expected NonEmptyArray"
+
+instance RegistryJson RFC3339String where
+  encode = encode <<< un RFC3339String
+  decode = decode >=> map RFC3339String
 
 instance (Ord k, Coercible k String, RegistryJson v) => RegistryJson (Map k v) where
   encode = encode <<< Object.fromFoldable <<< toTupleArray

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -3,6 +3,7 @@ module Registry.Schema where
 import Registry.Prelude
 
 import Data.Generic.Rep as Generic
+import Data.RFC3339String (RFC3339String)
 import Foreign.Object as Object
 import Foreign.SPDX (License)
 import Registry.Hash (Sha256)
@@ -163,6 +164,7 @@ type Metadata =
 type VersionMetadata =
   { ref :: String
   , hash :: Sha256
+  , published :: RFC3339String
   , bytes :: Number
   }
 

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -133,14 +133,14 @@ downloadLegacyRegistry = do
       repoCache = Array.fold [ "releases__", address.owner, "__", address.repo ]
       mkError = ResourceError <<< { resource: APIResource GitHubReleases, error: _ }
 
-    tags <- Process.withCache Process.jsonSerializer repoCache (Just $ Hours 24.0) do
-      log $ "Fetching tags for package " <> un RawPackageName name
-      result <- lift $ try $ GitHub.getTags octokit address
+    releases <- Process.withCache Process.jsonSerializer repoCache (Just $ Hours 24.0) do
+      log $ "Fetching releases for package " <> un RawPackageName name
+      result <- lift $ try $ GitHub.getReleases octokit address
       case result of
         Left err -> logShow err *> throwError (mkError $ DecodeError $ Aff.message err)
         Right v -> pure v
 
-    versions <- case NEA.fromArray tags of
+    versions <- case NEA.fromArray releases of
       Nothing -> throwError $ mkError $ DecodeError "No releases returned from the GitHub API."
       Just arr -> pure $ Map.fromFoldable $ map (\tag -> Tuple (RawVersion tag.name) unit) arr
 

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -133,14 +133,14 @@ downloadLegacyRegistry = do
       repoCache = Array.fold [ "releases__", address.owner, "__", address.repo ]
       mkError = ResourceError <<< { resource: APIResource GitHubReleases, error: _ }
 
-    releases <- Process.withCache Process.jsonSerializer repoCache (Just $ Hours 24.0) do
-      log $ "Fetching releases for package " <> un RawPackageName name
-      result <- lift $ try $ GitHub.getReleases octokit address
+    tags <- Process.withCache Process.jsonSerializer repoCache (Just $ Hours 24.0) do
+      log $ "Fetching tags for package " <> un RawPackageName name
+      result <- lift $ try $ GitHub.getTags octokit address
       case result of
         Left err -> logShow err *> throwError (mkError $ DecodeError $ Aff.message err)
         Right v -> pure v
 
-    versions <- case NEA.fromArray releases of
+    versions <- case NEA.fromArray tags of
       Nothing -> throwError $ mkError $ DecodeError "No releases returned from the GitHub API."
       Just arr -> pure $ Map.fromFoldable $ map (\tag -> Tuple (RawVersion tag.name) unit) arr
 


### PR DESCRIPTION
Closes #304 by adding the publication date as an `RFC3339String` to the metadata. This is done by fetching the date associated with a particular commit SHA from the GitHub API.

In the main API we do this by first fetching the commit associated with a particular ref, and then fetching the date associated with that commit. There is no date information associated with a ref directly.

I tested this by fetching the dates associated with particular releases in the legacy importer. It works there, returning the correct `RFC3339String`s associated with each commit. However, it's not necessary to include this in the legacy importer because we don't produce metadata there; I haven't verified it is working in the API pipeline as I wasn't sure how to test that without actually executing the pipeline.