### PR TITLE
Always remove some files from packages prior to compression

### DIFF
--- a/ci/package-lock.json
+++ b/ci/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@octokit/rest": "^18.12.0",
         "aws-sdk": "^2.1050.0",
+        "fs-extra": "^10.0.0",
         "fuse.js": "^6.5.3",
         "jsonrepair": "^2.2.1",
         "semver": "^7.3.5",
@@ -211,6 +212,19 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "license": "ISC",
@@ -250,6 +264,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+    },
     "node_modules/ieee754": {
       "version": "1.1.13",
       "license": "BSD-3-Clause"
@@ -281,6 +300,17 @@
       "version": "0.15.0",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonrepair": {
@@ -463,6 +493,14 @@
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
       "license": "ISC"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/url": {
       "version": "0.10.3",
@@ -661,6 +699,16 @@
     "events": {
       "version": "1.1.1"
     },
+    "fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs-minipass": {
       "version": "2.1.0",
       "requires": {
@@ -684,6 +732,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
+    },
     "ieee754": {
       "version": "1.1.13"
     },
@@ -705,6 +758,15 @@
     },
     "jmespath": {
       "version": "0.15.0"
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
     },
     "jsonrepair": {
       "version": "2.2.1",
@@ -812,6 +874,11 @@
     },
     "universal-user-agent": {
       "version": "6.0.0"
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "url": {
       "version": "0.10.3",

--- a/ci/package.json
+++ b/ci/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@octokit/rest": "^18.12.0",
     "aws-sdk": "^2.1050.0",
+    "fs-extra": "^10.0.0",
     "fuse.js": "^6.5.3",
     "jsonrepair": "^2.2.1",
     "semver": "^7.3.5",

--- a/ci/src/Foreign/Node/FS.js
+++ b/ci/src/Foreign/Node/FS.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
+const fs = require("fs-extra");
 
-exports.mkdirSyncImpl = (path) => fs.mkdirSync(path, { recursive: true });
+exports.ensureDirectoryImpl = (path) => () => fs.ensureDir(path);
 
-exports.rmdirSyncImpl = (path) => fs.rmdirSync(path, { recursive: true });
+exports.removeImpl = (path) => () => fs.remove(path);

--- a/ci/src/Foreign/Node/FS.purs
+++ b/ci/src/Foreign/Node/FS.purs
@@ -1,19 +1,26 @@
 module Foreign.Node.FS
-  ( mkdirSync
-  , rmdirSync
+  ( ensureDirectory
+  , remove
   ) where
 
 import Prelude
 
+import Control.Promise (Promise)
+import Control.Promise as Promise
 import Effect (Effect)
-import Effect.Uncurried (EffectFn1, runEffectFn1)
+import Effect.Aff (Aff)
+import Node.Path (FilePath)
 
-foreign import mkdirSyncImpl :: EffectFn1 String Unit
+foreign import ensureDirectoryImpl :: String -> Effect (Promise Unit)
 
-mkdirSync :: String -> Effect Unit
-mkdirSync = runEffectFn1 mkdirSyncImpl
+-- | Ensures that the directory exists. If the directory structure does not
+-- | exist, it is created.
+ensureDirectory :: FilePath -> Aff Unit
+ensureDirectory = ensureDirectoryImpl >>> Promise.toAffE
 
-foreign import rmdirSyncImpl :: EffectFn1 String Unit
+foreign import removeImpl :: String -> Effect (Promise Unit)
 
-rmdirSync :: String -> Effect Unit
-rmdirSync = runEffectFn1 mkdirSyncImpl
+-- | Removes a file or directory. The directory can have contents. If the
+-- | path does not exist, silently does nothing.
+remove :: FilePath -> Aff Unit
+remove = removeImpl >>> Promise.toAffE

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -5,8 +5,10 @@ import Registry.Prelude
 import Control.Monad.Except as Except
 import Data.Argonaut.Parser as JsonParser
 import Data.Array as Array
+import Data.Foldable (traverse_)
 import Data.Generic.Rep as Generic
 import Data.Map as Map
+import Data.Set as Set
 import Data.String as String
 import Effect.Aff as Aff
 import Effect.Exception (throw)
@@ -14,12 +16,14 @@ import Effect.Ref as Ref
 import Foreign.Dhall as Dhall
 import Foreign.GitHub (IssueNumber)
 import Foreign.GitHub as GitHub
+import Foreign.Node.FS as FS.Extra
 import Foreign.Object as Object
 import Foreign.Tar as Tar
 import Foreign.Tmp as Tmp
 import Node.ChildProcess as NodeProcess
 import Node.FS.Aff as FS
 import Node.FS.Stats as FS.Stats
+import Node.Glob.Basic as Glob.Basic
 import Node.Process as Env
 import Registry.Hash as Hash
 import Registry.Index as Index
@@ -204,8 +208,11 @@ addOrUpdate { ref, legacy, packageName } metadata = do
   -- We need the version number to upload the package
   let newVersion = manifestRecord.version
   let newDirname = PackageName.print packageName <> "-" <> Version.printVersion newVersion
-  liftAff $ FS.rename absoluteFolderPath (tmpDir <> "/" <> newDirname)
-  let tarballPath = tmpDir <> "/" <> newDirname <> ".tar.gz"
+  let tarballDirname = tmpDir <> "/" <> newDirname
+  liftAff do
+    FS.rename absoluteFolderPath tarballDirname
+    removeIgnoredTarballFiles tarballDirname
+  let tarballPath = tarballDirname <> ".tar.gz"
   liftEffect $ Tar.create { cwd: tmpDir, folderName: newDirname, archiveName: tarballPath }
   log "Checking the tarball size..."
   FS.Stats.Stats { size: bytes } <- liftAff $ FS.stat tarballPath
@@ -355,3 +362,38 @@ runGit args = ExceptT do
 
 maxPackageBytes :: Number
 maxPackageBytes = 200_000.0
+
+-- We always ignore some files and directories when packaging a tarball, such as
+-- version control directories. See also:
+-- https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files
+removeIgnoredTarballFiles :: FilePath -> Aff Unit
+removeIgnoredTarballFiles path = do
+  globMatches <- Glob.Basic.expandGlobs path globFiles
+  traverse_ FS.Extra.remove (exactFiles <> Set.toUnfoldable globMatches)
+  where
+  exactFiles :: Array FilePath
+  exactFiles =
+    [ ".psci"
+    , ".psci_modules"
+    , ".spago"
+    , "node_modules"
+    , "bower_components"
+    -- These files and directories are ignored by the NPM CLI and we are
+    -- following their lead in ignoring them as well.
+    , ".git"
+    , "CVS"
+    , ".svn"
+    , ".hg"
+    , ".DS_Store"
+    , "package-lock.json"
+    -- These are lockfiles used by alternate JS package managers and we also
+    -- ignore them.
+    , "yarn.lock"
+    , "pnpm-lock.yaml"
+    ]
+
+  globFiles :: Array String
+  globFiles =
+    [ ".*.swp"
+    , "._*"
+    ]

--- a/ci/src/Registry/Index.purs
+++ b/ci/src/Registry/Index.purs
@@ -13,7 +13,7 @@ import Data.Map as Map
 import Data.Set as Set
 import Data.String as String
 import Data.String.Pattern (Pattern(..))
-import Foreign.Node.FS as Foreign.Node
+import Foreign.Node.FS as FS.Extra
 import Node.FS.Aff as FS
 import Node.FS.Stats as Stats
 import Node.Glob.Basic as Glob
@@ -134,8 +134,5 @@ insertManifest directory manifest@(Manifest { name, version }) = do
         $ Array.sortBy (comparing (un Manifest >>> _.version))
         $ Array.fromFoldable modifiedManifests
 
-  dirExists <- FS.exists manifestDirectory
-  unless dirExists do
-    liftEffect $ Foreign.Node.mkdirSync manifestDirectory
-
+  FS.Extra.ensureDirectory manifestDirectory
   FS.writeTextFile ASCII manifestPath contents

--- a/ci/src/Registry/Scripts/LegacyImport/Process.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Process.purs
@@ -17,6 +17,7 @@ import Effect.Aff.AVar as AVar
 import Effect.Now (nowDateTime) as Time
 import Foreign.GitHub (PackageURL)
 import Foreign.GitHub as GitHub
+import Foreign.Node.FS as FS.Extra
 import Node.FS.Aff as FS
 import Node.FS.Stats (Stats(..))
 import Registry.Json as Json
@@ -216,7 +217,7 @@ withCache { encode, decode } path maybeDuration action = do
           pure (now > expiryTime)
       pure (exists && not expired)
 
-  lift $ unlessM (FS.exists cacheFolder) (FS.mkdir cacheFolder)
+  liftAff $ FS.Extra.ensureDirectory cacheFolder
 
   isCacheHit >>= case _ of
     true -> do


### PR DESCRIPTION
Fixes #292 (at least partially) by always removing some files from packages before creating a tarball for the package. This is intended as a replacement for #309.

In #309 we tried to only include some required files (like a `purs.json` file), and otherwise only include files explicitly listed in a manifest's targets. However, there is a big issue with using the targets to decide what files to include.

A target defines sources, where sources are intended for the PureScript compiler to know what files to compile. These sources are included as globs, ie. `src/**/*.purs`. Sources are thus not suitable for knowing all files that need to be included in a package, because they are purely considering PureScript sources and not other possibly required files, like FFI files for various backends. Even if we do a best-effort fixup to the globs to take in all files regardless of their extension, we still run some risk of not including files that are meant to be included, and therefore breaking a package.

There is another possible solution: sources could list directories, not globs, and package managers etc. that rely on the manifest can presume that a directory like `src` means you can do `src/**/*.purs` to pass things to the PureScript compiler.

That's a much bigger conversation, though, so I wanted to put this up as an alternative to #309, as that PR is not usable unless we change the way sources are handled.