### PR TITLE
Ensure all packages are included in registry index, even if they have no versions

### DIFF
--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -232,7 +232,7 @@ addOrUpdate { ref, legacy, packageName } metadata = do
   log $ "Hash for ref " <> show ref <> " was " <> show hash
   let newMetadata = addVersionToMetadata newVersion { hash, ref, published, bytes } metadata
   let metadataFilePath = metadataFile packageName
-  liftAff $ Json.stringifyJsonFile metadataFilePath newMetadata
+  liftAff $ Json.writeJsonFile metadataFilePath newMetadata
   updatePackagesMetadata manifestRecord.name newMetadata
   commitToTrunk packageName metadataFilePath >>= case _ of
     Left _err ->

--- a/ci/src/Registry/Json.purs
+++ b/ci/src/Registry/Json.purs
@@ -14,6 +14,7 @@ module Registry.Json
   , stringifyJson
   , parseJson
   , writeJsonFile
+  , stringifyJsonFile
   , readJsonFile
   , encodeObject
   , insert
@@ -84,9 +85,13 @@ stringifyJson = Core.stringify <<< encode
 parseJson :: forall a. RegistryJson a => String -> Either String a
 parseJson = decode <=< Parser.jsonParser
 
--- | Encode data as JSON and write it to the provided filepath
+-- | Encode data as formatted JSON and write it to the provided filepath
 writeJsonFile :: forall a. RegistryJson a => FilePath -> a -> Aff Unit
 writeJsonFile path = FS.writeTextFile UTF8 path <<< printJson
+
+-- | Encode data as an unformatted JSON string and write it to the provided filepath
+stringifyJsonFile :: forall a. RegistryJson a => FilePath -> a -> Aff Unit
+stringifyJsonFile path = FS.writeTextFile UTF8 path <<< stringifyJson
 
 -- | Decode data from a JSON file at the provided filepath
 readJsonFile :: forall a. RegistryJson a => FilePath -> Aff (Either String a)

--- a/ci/src/Registry/Json.purs
+++ b/ci/src/Registry/Json.purs
@@ -14,7 +14,6 @@ module Registry.Json
   , stringifyJson
   , parseJson
   , writeJsonFile
-  , stringifyJsonFile
   , readJsonFile
   , encodeObject
   , insert
@@ -88,10 +87,6 @@ parseJson = decode <=< Parser.jsonParser
 -- | Encode data as formatted JSON and write it to the provided filepath
 writeJsonFile :: forall a. RegistryJson a => FilePath -> a -> Aff Unit
 writeJsonFile path = FS.writeTextFile UTF8 path <<< printJson
-
--- | Encode data as an unformatted JSON string and write it to the provided filepath
-stringifyJsonFile :: forall a. RegistryJson a => FilePath -> a -> Aff Unit
-stringifyJsonFile path = FS.writeTextFile UTF8 path <<< stringifyJson
 
 -- | Decode data from a JSON file at the provided filepath
 readJsonFile :: forall a. RegistryJson a => FilePath -> Aff (Either String a)

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -50,7 +50,13 @@ main = Aff.launchAff_ do
 
   log "Temporary: we filter packages to only deal with the ones in core and other orgs we control"
   let
+    emptyPackages :: Array PackageName
+    emptyPackages = Set.toUnfoldable $ Map.keys $ Map.filter Map.isEmpty registry
+
+    sortedPackages :: Array Manifest
     sortedPackages = Graph.topologicalSort registry
+
+    isCorePackage :: Manifest -> Maybe _
     isCorePackage (Manifest manifest) = case manifest.repository of
       -- core
       GitHub { owner: "purescript" } -> Just manifest
@@ -74,6 +80,8 @@ main = Aff.launchAff_ do
       GitHub { repo: "purescript-aff-promise" } -> Just manifest
       GitHub { repo: "purescript-naturals" } -> Just manifest
       _ -> Nothing
+
+    corePackages :: Array _
     corePackages = Array.mapMaybe isCorePackage sortedPackages
 
   log "Creating a Metadata Ref"

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -2,18 +2,18 @@ module Registry.Scripts.LegacyImport where
 
 import Registry.Prelude
 
+import Control.Alternative (guard)
 import Control.Monad.Except as Except
 import Data.Array as Array
 import Data.Array.NonEmpty as NEA
 import Data.Map as Map
-import Data.Set as Set
 import Data.String as String
 import Data.Time.Duration (Hours(..))
 import Dotenv as Dotenv
 import Effect.Aff as Aff
-import Effect.Ref as Ref
 import Foreign.GitHub as GitHub
 import Foreign.Object as Object
+import Registry.API (metadataFile)
 import Registry.API as API
 import Registry.Index (RegistryIndex)
 import Registry.Json as Json
@@ -21,7 +21,7 @@ import Registry.PackageGraph as Graph
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.PackageUpload as Upload
-import Registry.RegistryM (Env, runRegistryM)
+import Registry.RegistryM (Env, readPackagesMetadata, runRegistryM, updatePackagesMetadata)
 import Registry.Schema (Manifest(..), Metadata, Operation(..), Repo(..))
 import Registry.Scripts.LegacyImport.Error (APIResource(..), ImportError(..), ManifestError(..), PackageFailures(..), RemoteResource(..), RequestError(..))
 import Registry.Scripts.LegacyImport.Manifest as Manifest
@@ -46,13 +46,10 @@ main = Aff.launchAff_ do
   API.checkIndexExists
 
   log "Starting import from legacy registries..."
-  registry <- downloadLegacyRegistry
+  { registry, reservedNames } <- downloadLegacyRegistry
 
   log "Temporary: we filter packages to only deal with the ones in core and other orgs we control"
   let
-    emptyPackages :: Array PackageName
-    emptyPackages = Set.toUnfoldable $ Map.keys $ Map.filter Map.isEmpty registry
-
     sortedPackages :: Array Manifest
     sortedPackages = Graph.topologicalSort registry
 
@@ -87,27 +84,35 @@ main = Aff.launchAff_ do
   log "Creating a Metadata Ref"
   packagesMetadataRef <- API.mkMetadataRef
 
-  log "Filtering out packages we already uploaded"
-  packagesMetadata <- liftEffect $ Ref.read packagesMetadataRef
-  let
-    wasPackageUploaded { name, version } = API.isPackageVersionInMetadata name version packagesMetadata
-    packagesToUpload = Array.filter (not wasPackageUploaded) corePackages
-
   log "Starting upload..."
-  void $ for packagesToUpload \manifest -> do
+  runRegistryM (mkEnv packagesMetadataRef) do
+    log "Adding metadata for reserved package names"
+    forWithIndex_ reservedNames \package repo -> do
+      let metadata = { location: repo, releases: Object.empty, unpublished: Object.empty }
+      liftAff $ Json.stringifyJsonFile (metadataFile package) metadata
+      updatePackagesMetadata package metadata
+
+    log "Filtering out packages we already uploaded"
+    packagesMetadata <- readPackagesMetadata
+
     let
-      addition = Addition
-        { addToPackageSet: false -- heh, we don't have package sets until we do this import!
-        , legacy: true
-        , newPackageLocation: manifest.repository
-        , newRef: Version.rawVersion manifest.version
-        , packageName: manifest.name
-        }
-    log "\n\n----------------------------------------------------------------------"
-    log $ "UPLOADING PACKAGE: " <> show manifest.name <> " " <> show manifest.version
-    logShow addition
-    log "----------------------------------------------------------------------"
-    runRegistryM (mkEnv packagesMetadataRef) (API.runOperation addition)
+      wasPackageUploaded { name, version } = API.isPackageVersionInMetadata name version packagesMetadata
+      packagesToUpload = Array.filter (not wasPackageUploaded) corePackages
+
+    for_ packagesToUpload \manifest -> do
+      let
+        addition = Addition
+          { addToPackageSet: false -- heh, we don't have package sets until we do this import!
+          , legacy: true
+          , newPackageLocation: manifest.repository
+          , newRef: Version.rawVersion manifest.version
+          , packageName: manifest.name
+          }
+      log "\n\n----------------------------------------------------------------------"
+      log $ "UPLOADING PACKAGE: " <> show manifest.name <> " " <> show manifest.version
+      logShow addition
+      log "----------------------------------------------------------------------"
+      API.runOperation addition
 
   log "Done!"
 
@@ -122,7 +127,7 @@ mkEnv packagesMetadata =
   , packagesMetadata
   }
 
-downloadLegacyRegistry :: Aff RegistryIndex
+downloadLegacyRegistry :: Aff { registry :: RegistryIndex, reservedNames :: Map PackageName Repo }
 downloadLegacyRegistry = do
   octokit <- liftEffect GitHub.mkOctokit
   bowerPackages <- readRegistryFile "bower-packages.json"
@@ -218,20 +223,21 @@ downloadLegacyRegistry = do
     log (show (Array.length unsatisfied) <> " manifest entries with unsatisfied dependencies")
 
   let
-    -- Many packages are removed altogether during processing. In this step,
-    -- we ensure the registry index has every package with a valid package
-    -- name included. `Map.unionWith const` prefers earlier keys in the case of
-    -- collision, which we can use to overwrite these empty packages.
-    allPackageNames :: Map PackageName (Map Version Manifest)
-    allPackageNames =
+    reservedNames :: Map PackageName Repo
+    reservedNames =
       Map.fromFoldable
-        $ map (\package -> Tuple package Map.empty)
-        $ Array.mapMaybe (hush <<< PackageName.parse)
-        $ (coerce :: Array RawPackageName -> Array String)
-        $ Set.toUnfoldable
-        $ Map.keys allPackages
+        $ Array.mapMaybe
+            ( \(Tuple (RawPackageName name) address) -> do
+                parsedName <- hush $ PackageName.parse name
+                -- We don't need to preserve any packages that made it through
+                -- processing into the resulting registry index.
+                guard $ isNothing $ Map.lookup parsedName registryIndex
+                { owner, repo } <- hush $ GitHub.parseRepo address
+                pure $ Tuple parsedName (GitHub { owner, repo, subdir: Nothing })
+            )
+        $ Map.toUnfoldable allPackages
 
-  pure $ Map.unionWith const checkedIndex allPackageNames
+  pure { registry: checkedIndex, reservedNames }
 
 -- Packages can be specified either in 'package-name' format or
 -- in owner/package-name format. This function ensures we don't pick

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -13,7 +13,6 @@ import Dotenv as Dotenv
 import Effect.Aff as Aff
 import Foreign.GitHub as GitHub
 import Foreign.Object as Object
-import Registry.API (metadataFile)
 import Registry.API as API
 import Registry.Index (RegistryIndex)
 import Registry.Json as Json
@@ -89,7 +88,7 @@ main = Aff.launchAff_ do
     log "Adding metadata for reserved package names"
     forWithIndex_ reservedNames \package repo -> do
       let metadata = { location: repo, releases: Object.empty, unpublished: Object.empty }
-      liftAff $ Json.stringifyJsonFile (metadataFile package) metadata
+      liftAff $ Json.stringifyJsonFile (API.metadataFile package) metadata
       updatePackagesMetadata package metadata
 
     log "Filtering out packages we already uploaded"

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -88,7 +88,7 @@ main = Aff.launchAff_ do
     log "Adding metadata for reserved package names"
     forWithIndex_ reservedNames \package repo -> do
       let metadata = { location: repo, releases: Object.empty, unpublished: Object.empty }
-      liftAff $ Json.stringifyJsonFile (API.metadataFile package) metadata
+      liftAff $ Json.writeJsonFile (API.metadataFile package) metadata
       updatePackagesMetadata package metadata
 
     log "Filtering out packages we already uploaded"

--- a/metadata/ajax.json
+++ b/metadata/ajax.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"joneshf","githubRepo":"purescript-ajax"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "joneshf",
+    "githubRepo": "purescript-ajax"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/ajax.json
+++ b/metadata/ajax.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"joneshf","githubRepo":"purescript-ajax"},"releases":{},"unpublished":{}}

--- a/metadata/algebra.json
+++ b/metadata/algebra.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"joneshf","githubRepo":"purescript-algebra"},"releases":{},"unpublished":{}}

--- a/metadata/algebra.json
+++ b/metadata/algebra.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"joneshf","githubRepo":"purescript-algebra"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "joneshf",
+    "githubRepo": "purescript-algebra"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/angular.json
+++ b/metadata/angular.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"ethul","githubRepo":"purescript-angular"},"releases":{},"unpublished":{}}

--- a/metadata/angular.json
+++ b/metadata/angular.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"ethul","githubRepo":"purescript-angular"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "ethul",
+    "githubRepo": "purescript-angular"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/apparch.json
+++ b/metadata/apparch.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"agrafix","githubRepo":"purescript-apparch"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "agrafix",
+    "githubRepo": "purescript-apparch"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/apparch.json
+++ b/metadata/apparch.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"agrafix","githubRepo":"purescript-apparch"},"releases":{},"unpublished":{}}

--- a/metadata/arb-instances.json
+++ b/metadata/arb-instances.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"purescript","githubRepo":"purescript-arb-instances"},"releases":{},"unpublished":{}}

--- a/metadata/arb-instances.json
+++ b/metadata/arb-instances.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"purescript","githubRepo":"purescript-arb-instances"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "purescript",
+    "githubRepo": "purescript-arb-instances"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/array-shuffle.json
+++ b/metadata/array-shuffle.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"dgendill","githubRepo":"purescript-array-shuffle"},"releases":{},"unpublished":{}}

--- a/metadata/array-shuffle.json
+++ b/metadata/array-shuffle.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"dgendill","githubRepo":"purescript-array-shuffle"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "dgendill",
+    "githubRepo": "purescript-array-shuffle"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/asap.json
+++ b/metadata/asap.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"bodil","githubRepo":"purescript-asap"},"releases":{},"unpublished":{}}

--- a/metadata/asap.json
+++ b/metadata/asap.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"bodil","githubRepo":"purescript-asap"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "bodil",
+    "githubRepo": "purescript-asap"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/aws.json
+++ b/metadata/aws.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"dysinger","githubRepo":"purescript-aws"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "dysinger",
+    "githubRepo": "purescript-aws"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/aws.json
+++ b/metadata/aws.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"dysinger","githubRepo":"purescript-aws"},"releases":{},"unpublished":{}}

--- a/metadata/backtrack.json
+++ b/metadata/backtrack.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"juspay","githubRepo":"purescript-backtrack"},"releases":{},"unpublished":{}}

--- a/metadata/backtrack.json
+++ b/metadata/backtrack.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"juspay","githubRepo":"purescript-backtrack"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "juspay",
+    "githubRepo": "purescript-backtrack"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/base64.json
+++ b/metadata/base64.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"Thimoteus","githubRepo":"purescript-base64"},"releases":{},"unpublished":{}}

--- a/metadata/base64.json
+++ b/metadata/base64.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"Thimoteus","githubRepo":"purescript-base64"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "Thimoteus",
+    "githubRepo": "purescript-base64"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/batteries-env.json
+++ b/metadata/batteries-env.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"purescript-polyform","githubRepo":"batteries-env"},"releases":{},"unpublished":{}}

--- a/metadata/batteries-env.json
+++ b/metadata/batteries-env.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"purescript-polyform","githubRepo":"batteries-env"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "purescript-polyform",
+    "githubRepo": "batteries-env"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/batteries-json.json
+++ b/metadata/batteries-json.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"purescript-polyform","githubRepo":"batteries-json"},"releases":{},"unpublished":{}}

--- a/metadata/batteries-json.json
+++ b/metadata/batteries-json.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"purescript-polyform","githubRepo":"batteries-json"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "purescript-polyform",
+    "githubRepo": "batteries-json"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/batteries-urlencoded.json
+++ b/metadata/batteries-urlencoded.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"purescript-polyform","githubRepo":"batteries-urlencoded"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "purescript-polyform",
+    "githubRepo": "batteries-urlencoded"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/batteries-urlencoded.json
+++ b/metadata/batteries-urlencoded.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"purescript-polyform","githubRepo":"batteries-urlencoded"},"releases":{},"unpublished":{}}

--- a/metadata/bcrypt.json
+++ b/metadata/bcrypt.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"VFabricio","githubRepo":"purescript-bcrypt"},"releases":{},"unpublished":{}}

--- a/metadata/bcrypt.json
+++ b/metadata/bcrypt.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"VFabricio","githubRepo":"purescript-bcrypt"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "VFabricio",
+    "githubRepo": "purescript-bcrypt"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/big-integer.json
+++ b/metadata/big-integer.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"athanclark","githubRepo":"purescript-big-integer"},"releases":{},"unpublished":{}}

--- a/metadata/big-integer.json
+++ b/metadata/big-integer.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"athanclark","githubRepo":"purescript-big-integer"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "athanclark",
+    "githubRepo": "purescript-big-integer"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/blueprint.json
+++ b/metadata/blueprint.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"atomicits","githubRepo":"purescript-blueprint"},"releases":{},"unpublished":{}}

--- a/metadata/blueprint.json
+++ b/metadata/blueprint.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"atomicits","githubRepo":"purescript-blueprint"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "atomicits",
+    "githubRepo": "purescript-blueprint"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/browser-sniffer.json
+++ b/metadata/browser-sniffer.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-browser-sniffer"},"releases":{},"unpublished":{}}

--- a/metadata/browser-sniffer.json
+++ b/metadata/browser-sniffer.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-browser-sniffer"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "CapillarySoftware",
+    "githubRepo": "purescript-browser-sniffer"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/channels.json
+++ b/metadata/channels.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"purescript-deprecated","githubRepo":"purescript-channels"},"releases":{},"unpublished":{}}

--- a/metadata/channels.json
+++ b/metadata/channels.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"purescript-deprecated","githubRepo":"purescript-channels"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "purescript-deprecated",
+    "githubRepo": "purescript-channels"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/chosen-halogen.json
+++ b/metadata/chosen-halogen.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"michael-swan","githubRepo":"purescript-chosen-halogen"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "michael-swan",
+    "githubRepo": "purescript-chosen-halogen"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/chosen-halogen.json
+++ b/metadata/chosen-halogen.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"michael-swan","githubRepo":"purescript-chosen-halogen"},"releases":{},"unpublished":{}}

--- a/metadata/chosen.json
+++ b/metadata/chosen.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"michael-swan","githubRepo":"purescript-chosen"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "michael-swan",
+    "githubRepo": "purescript-chosen"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/chosen.json
+++ b/metadata/chosen.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"michael-swan","githubRepo":"purescript-chosen"},"releases":{},"unpublished":{}}

--- a/metadata/client-ajax.json
+++ b/metadata/client-ajax.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"wfaler","githubRepo":"purescript-jquery-ajax"},"releases":{},"unpublished":{}}

--- a/metadata/client-ajax.json
+++ b/metadata/client-ajax.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"wfaler","githubRepo":"purescript-jquery-ajax"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "wfaler",
+    "githubRepo": "purescript-jquery-ajax"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/client-routing.json
+++ b/metadata/client-routing.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"philopon","githubRepo":"purescript-client-routing"},"releases":{},"unpublished":{}}

--- a/metadata/client-routing.json
+++ b/metadata/client-routing.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"philopon","githubRepo":"purescript-client-routing"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "philopon",
+    "githubRepo": "purescript-client-routing"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/codec-ejson.json
+++ b/metadata/codec-ejson.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"slamdata","githubRepo":"purescript-codec-ejson"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "slamdata",
+    "githubRepo": "purescript-codec-ejson"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/codec-ejson.json
+++ b/metadata/codec-ejson.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"slamdata","githubRepo":"purescript-codec-ejson"},"releases":{},"unpublished":{}}

--- a/metadata/combinators.json
+++ b/metadata/combinators.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"awkure","githubRepo":"purescript-combinators"},"releases":{},"unpublished":{}}

--- a/metadata/combinators.json
+++ b/metadata/combinators.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"awkure","githubRepo":"purescript-combinators"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "awkure",
+    "githubRepo": "purescript-combinators"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/constraint-kanren.json
+++ b/metadata/constraint-kanren.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"raduom","githubRepo":"purescript-constraint-kanren"},"releases":{},"unpublished":{}}

--- a/metadata/constraint-kanren.json
+++ b/metadata/constraint-kanren.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"raduom","githubRepo":"purescript-constraint-kanren"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "raduom",
+    "githubRepo": "purescript-constraint-kanren"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/cookies.json
+++ b/metadata/cookies.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"dbushenko","githubRepo":"purescript-cookies"},"releases":{},"unpublished":{}}

--- a/metadata/cookies.json
+++ b/metadata/cookies.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"dbushenko","githubRepo":"purescript-cookies"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "dbushenko",
+    "githubRepo": "purescript-cookies"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/csv-rk.json
+++ b/metadata/csv-rk.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"robkuz","githubRepo":"purescript-csv"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "robkuz",
+    "githubRepo": "purescript-csv"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/csv-rk.json
+++ b/metadata/csv-rk.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"robkuz","githubRepo":"purescript-csv"},"releases":{},"unpublished":{}}

--- a/metadata/dom-keyboard.json
+++ b/metadata/dom-keyboard.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"slamdata","githubRepo":"purescript-dom-keyboard"},"releases":{},"unpublished":{}}

--- a/metadata/dom-keyboard.json
+++ b/metadata/dom-keyboard.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"slamdata","githubRepo":"purescript-dom-keyboard"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "slamdata",
+    "githubRepo": "purescript-dom-keyboard"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/domparser.json
+++ b/metadata/domparser.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"Fresheyeball","githubRepo":"purescript-DOMParser"},"releases":{},"unpublished":{}}

--- a/metadata/domparser.json
+++ b/metadata/domparser.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"Fresheyeball","githubRepo":"purescript-DOMParser"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "Fresheyeball",
+    "githubRepo": "purescript-DOMParser"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/dynamic.json
+++ b/metadata/dynamic.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"raduom","githubRepo":"purescript-dynamic"},"releases":{},"unpublished":{}}

--- a/metadata/dynamic.json
+++ b/metadata/dynamic.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"raduom","githubRepo":"purescript-dynamic"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "raduom",
+    "githubRepo": "purescript-dynamic"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/elm-basics.json
+++ b/metadata/elm-basics.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"brainrape","githubRepo":"purescript-elm-basics"},"releases":{},"unpublished":{}}

--- a/metadata/elm-basics.json
+++ b/metadata/elm-basics.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"brainrape","githubRepo":"purescript-elm-basics"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "brainrape",
+    "githubRepo": "purescript-elm-basics"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/enchantjs.json
+++ b/metadata/enchantjs.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"algas","githubRepo":"purescript-enchantjs"},"releases":{},"unpublished":{}}

--- a/metadata/enchantjs.json
+++ b/metadata/enchantjs.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"algas","githubRepo":"purescript-enchantjs"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "algas",
+    "githubRepo": "purescript-enchantjs"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/endpoints-express.json
+++ b/metadata/endpoints-express.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"FrigoEU","githubRepo":"purescript-endpoints-express"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "FrigoEU",
+    "githubRepo": "purescript-endpoints-express"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/endpoints-express.json
+++ b/metadata/endpoints-express.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"FrigoEU","githubRepo":"purescript-endpoints-express"},"releases":{},"unpublished":{}}

--- a/metadata/endpoints-websocket.json
+++ b/metadata/endpoints-websocket.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"FrigoEU","githubRepo":"purescript-endpoints-websocket"},"releases":{},"unpublished":{}}

--- a/metadata/endpoints-websocket.json
+++ b/metadata/endpoints-websocket.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"FrigoEU","githubRepo":"purescript-endpoints-websocket"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "FrigoEU",
+    "githubRepo": "purescript-endpoints-websocket"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/envparse.json
+++ b/metadata/envparse.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "srghma",
+    "githubRepo": "purescript-envparse"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/events.json
+++ b/metadata/events.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-events"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "CapillarySoftware",
+    "githubRepo": "purescript-events"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/events.json
+++ b/metadata/events.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-events"},"releases":{},"unpublished":{}}

--- a/metadata/execa.json
+++ b/metadata/execa.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"ethul","githubRepo":"purescript-execa"},"releases":{},"unpublished":{}}

--- a/metadata/execa.json
+++ b/metadata/execa.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"ethul","githubRepo":"purescript-execa"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "ethul",
+    "githubRepo": "purescript-execa"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/ffi-options.json
+++ b/metadata/ffi-options.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"ursi","githubRepo":"purescript-ffi-options"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "ursi",
+    "githubRepo": "purescript-ffi-options"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/ffi-options.json
+++ b/metadata/ffi-options.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"ursi","githubRepo":"purescript-ffi-options"},"releases":{},"unpublished":{}}

--- a/metadata/flow.json
+++ b/metadata/flow.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"juspay","githubRepo":"purescript-flow"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "juspay",
+    "githubRepo": "purescript-flow"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/flow.json
+++ b/metadata/flow.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"juspay","githubRepo":"purescript-flow"},"releases":{},"unpublished":{}}

--- a/metadata/flux-store.json
+++ b/metadata/flux-store.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"KolesnichenkoDS","githubRepo":"purescript-flux-store"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "KolesnichenkoDS",
+    "githubRepo": "purescript-flux-store"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/flux-store.json
+++ b/metadata/flux-store.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"KolesnichenkoDS","githubRepo":"purescript-flux-store"},"releases":{},"unpublished":{}}

--- a/metadata/focus-ui.json
+++ b/metadata/focus-ui.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"mbid","githubRepo":"purescript-focus-ui"},"releases":{},"unpublished":{}}

--- a/metadata/focus-ui.json
+++ b/metadata/focus-ui.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"mbid","githubRepo":"purescript-focus-ui"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "mbid",
+    "githubRepo": "purescript-focus-ui"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/foreign-callbacks.json
+++ b/metadata/foreign-callbacks.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"fluffynukeit","githubRepo":"purescript-foreign-callbacks"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "fluffynukeit",
+    "githubRepo": "purescript-foreign-callbacks"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/foreign-callbacks.json
+++ b/metadata/foreign-callbacks.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"fluffynukeit","githubRepo":"purescript-foreign-callbacks"},"releases":{},"unpublished":{}}

--- a/metadata/foreign-helpers.json
+++ b/metadata/foreign-helpers.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"adarqui","githubRepo":"purescript-foreign-helpers"},"releases":{},"unpublished":{}}

--- a/metadata/foreign-helpers.json
+++ b/metadata/foreign-helpers.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"adarqui","githubRepo":"purescript-foreign-helpers"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "adarqui",
+    "githubRepo": "purescript-foreign-helpers"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/foreign-options.json
+++ b/metadata/foreign-options.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"fluffynukeit","githubRepo":"purescript-foreign-options"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "fluffynukeit",
+    "githubRepo": "purescript-foreign-options"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/foreign-options.json
+++ b/metadata/foreign-options.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"fluffynukeit","githubRepo":"purescript-foreign-options"},"releases":{},"unpublished":{}}

--- a/metadata/formulate.json
+++ b/metadata/formulate.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"garyb","githubRepo":"purescript-formulate"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "garyb",
+    "githubRepo": "purescript-formulate"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/formulate.json
+++ b/metadata/formulate.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"garyb","githubRepo":"purescript-formulate"},"releases":{},"unpublished":{}}

--- a/metadata/function-checked.json
+++ b/metadata/function-checked.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"ddfisher","githubRepo":"purescript-function-checked"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "ddfisher",
+    "githubRepo": "purescript-function-checked"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/function-checked.json
+++ b/metadata/function-checked.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"ddfisher","githubRepo":"purescript-function-checked"},"releases":{},"unpublished":{}}

--- a/metadata/fussy.json
+++ b/metadata/fussy.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"garyb","githubRepo":"purescript-fussy"},"releases":{},"unpublished":{}}

--- a/metadata/fussy.json
+++ b/metadata/fussy.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"garyb","githubRepo":"purescript-fussy"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "garyb",
+    "githubRepo": "purescript-fussy"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/globals-safe.json
+++ b/metadata/globals-safe.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"nsaunders","githubRepo":"purescript-globals-safe"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "nsaunders",
+    "githubRepo": "purescript-globals-safe"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/globals-safe.json
+++ b/metadata/globals-safe.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"nsaunders","githubRepo":"purescript-globals-safe"},"releases":{},"unpublished":{}}

--- a/metadata/google-auth.json
+++ b/metadata/google-auth.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"FrigoEU","githubRepo":"purescript-google-auth"},"releases":{},"unpublished":{}}

--- a/metadata/google-auth.json
+++ b/metadata/google-auth.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"FrigoEU","githubRepo":"purescript-google-auth"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "FrigoEU",
+    "githubRepo": "purescript-google-auth"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/halogen-html-component.json
+++ b/metadata/halogen-html-component.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"garyb","githubRepo":"purescript-halogen-html-component"},"releases":{},"unpublished":{}}

--- a/metadata/halogen-html-component.json
+++ b/metadata/halogen-html-component.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"garyb","githubRepo":"purescript-halogen-html-component"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "garyb",
+    "githubRepo": "purescript-halogen-html-component"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/halogen-monaco.json
+++ b/metadata/halogen-monaco.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"maxhillaert","githubRepo":"purescript-halogen-monaco"},"releases":{},"unpublished":{}}

--- a/metadata/halogen-monaco.json
+++ b/metadata/halogen-monaco.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"maxhillaert","githubRepo":"purescript-halogen-monaco"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "maxhillaert",
+    "githubRepo": "purescript-halogen-monaco"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/halogen-svg.json
+++ b/metadata/halogen-svg.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"AidanDelaney","githubRepo":"purescript-halogen-svg"},"releases":{},"unpublished":{}}

--- a/metadata/halogen-svg.json
+++ b/metadata/halogen-svg.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"AidanDelaney","githubRepo":"purescript-halogen-svg"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "AidanDelaney",
+    "githubRepo": "purescript-halogen-svg"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/hashable.json
+++ b/metadata/hashable.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"paf31","githubRepo":"purescript-hashable"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "paf31",
+    "githubRepo": "purescript-hashable"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/hashable.json
+++ b/metadata/hashable.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"paf31","githubRepo":"purescript-hashable"},"releases":{},"unpublished":{}}

--- a/metadata/hedwig.json
+++ b/metadata/hedwig.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"utkarshkukreti","githubRepo":"purescript-hedwig"},"releases":{},"unpublished":{}}

--- a/metadata/hedwig.json
+++ b/metadata/hedwig.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"utkarshkukreti","githubRepo":"purescript-hedwig"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "utkarshkukreti",
+    "githubRepo": "purescript-hedwig"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/hertz.json
+++ b/metadata/hertz.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"utkarshkukreti","githubRepo":"purescript-hertz"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "utkarshkukreti",
+    "githubRepo": "purescript-hertz"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/hertz.json
+++ b/metadata/hertz.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"utkarshkukreti","githubRepo":"purescript-hertz"},"releases":{},"unpublished":{}}

--- a/metadata/hibachi.json
+++ b/metadata/hibachi.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"justinwoo","githubRepo":"purescript-kushikatsu"},"releases":{},"unpublished":{}}

--- a/metadata/hibachi.json
+++ b/metadata/hibachi.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"justinwoo","githubRepo":"purescript-kushikatsu"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "justinwoo",
+    "githubRepo": "purescript-kushikatsu"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/history.json
+++ b/metadata/history.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-history"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "CapillarySoftware",
+    "githubRepo": "purescript-history"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/history.json
+++ b/metadata/history.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-history"},"releases":{},"unpublished":{}}

--- a/metadata/http-headers.json
+++ b/metadata/http-headers.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"garyb","githubRepo":"purescript-http-headers"},"releases":{},"unpublished":{}}

--- a/metadata/http-headers.json
+++ b/metadata/http-headers.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"garyb","githubRepo":"purescript-http-headers"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "garyb",
+    "githubRepo": "purescript-http-headers"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/hubot.json
+++ b/metadata/hubot.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"mcoffin","githubRepo":"purescript-hubot"},"releases":{},"unpublished":{}}

--- a/metadata/hubot.json
+++ b/metadata/hubot.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"mcoffin","githubRepo":"purescript-hubot"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "mcoffin",
+    "githubRepo": "purescript-hubot"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/in-purescript.json
+++ b/metadata/in-purescript.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"purescript","githubRepo":"purescript-in-purescript"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "purescript",
+    "githubRepo": "purescript-in-purescript"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/in-purescript.json
+++ b/metadata/in-purescript.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"purescript","githubRepo":"purescript-in-purescript"},"releases":{},"unpublished":{}}

--- a/metadata/io.json
+++ b/metadata/io.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"slamdata","githubRepo":"purescript-io"},"releases":{},"unpublished":{}}

--- a/metadata/io.json
+++ b/metadata/io.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"slamdata","githubRepo":"purescript-io"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "slamdata",
+    "githubRepo": "purescript-io"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/ips.json
+++ b/metadata/ips.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"chrisdotcode","githubRepo":"purescript-ips"},"releases":{},"unpublished":{}}

--- a/metadata/ips.json
+++ b/metadata/ips.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"chrisdotcode","githubRepo":"purescript-ips"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "chrisdotcode",
+    "githubRepo": "purescript-ips"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/jquery-ajax.json
+++ b/metadata/jquery-ajax.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"wfaler","githubRepo":"purescript-jquery-ajax"},"releases":{},"unpublished":{}}

--- a/metadata/jquery-ajax.json
+++ b/metadata/jquery-ajax.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"wfaler","githubRepo":"purescript-jquery-ajax"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "wfaler",
+    "githubRepo": "purescript-jquery-ajax"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/json.json
+++ b/metadata/json.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"garyb","githubRepo":"purescript-json"},"releases":{},"unpublished":{}}

--- a/metadata/json.json
+++ b/metadata/json.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"garyb","githubRepo":"purescript-json"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "garyb",
+    "githubRepo": "purescript-json"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/keys.json
+++ b/metadata/keys.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"slamdata","githubRepo":"purescript-keys"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "slamdata",
+    "githubRepo": "purescript-keys"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/keys.json
+++ b/metadata/keys.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"slamdata","githubRepo":"purescript-keys"},"releases":{},"unpublished":{}}

--- a/metadata/language-purescript-parser-lexer.json
+++ b/metadata/language-purescript-parser-lexer.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"cdepillabout","githubRepo":"purescript-language-purescript-parser-lexer"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "cdepillabout",
+    "githubRepo": "purescript-language-purescript-parser-lexer"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/language-purescript-parser-lexer.json
+++ b/metadata/language-purescript-parser-lexer.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"cdepillabout","githubRepo":"purescript-language-purescript-parser-lexer"},"releases":{},"unpublished":{}}

--- a/metadata/leaflet.json
+++ b/metadata/leaflet.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"dysinger","githubRepo":"purescript-leaflet"},"releases":{},"unpublished":{}}

--- a/metadata/leaflet.json
+++ b/metadata/leaflet.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"dysinger","githubRepo":"purescript-leaflet"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "dysinger",
+    "githubRepo": "purescript-leaflet"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/mailgun.json
+++ b/metadata/mailgun.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"piq9117","githubRepo":"purescript-mailgun"},"releases":{},"unpublished":{}}

--- a/metadata/mailgun.json
+++ b/metadata/mailgun.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"piq9117","githubRepo":"purescript-mailgun"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "piq9117",
+    "githubRepo": "purescript-mailgun"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/markup-incdom.json
+++ b/metadata/markup-incdom.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"zrho","githubRepo":"purescript-markup-incdom"},"releases":{},"unpublished":{}}

--- a/metadata/markup-incdom.json
+++ b/metadata/markup-incdom.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"zrho","githubRepo":"purescript-markup-incdom"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "zrho",
+    "githubRepo": "purescript-markup-incdom"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/markup.json
+++ b/metadata/markup.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"zrho","githubRepo":"purescript-markup"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "zrho",
+    "githubRepo": "purescript-markup"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/markup.json
+++ b/metadata/markup.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"zrho","githubRepo":"purescript-markup"},"releases":{},"unpublished":{}}

--- a/metadata/mathjs.json
+++ b/metadata/mathjs.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"robkuz","githubRepo":"purescript-mathjs"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "robkuz",
+    "githubRepo": "purescript-mathjs"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/mathjs.json
+++ b/metadata/mathjs.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"robkuz","githubRepo":"purescript-mathjs"},"releases":{},"unpublished":{}}

--- a/metadata/mdcss.json
+++ b/metadata/mdcss.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"askasp","githubRepo":"purescript-mdcss"},"releases":{},"unpublished":{}}

--- a/metadata/mdcss.json
+++ b/metadata/mdcss.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"askasp","githubRepo":"purescript-mdcss"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "askasp",
+    "githubRepo": "purescript-mdcss"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/moment.json
+++ b/metadata/moment.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-moment"},"releases":{},"unpublished":{}}

--- a/metadata/moment.json
+++ b/metadata/moment.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-moment"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "CapillarySoftware",
+    "githubRepo": "purescript-moment"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/monaco.json
+++ b/metadata/monaco.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"maxhillaert","githubRepo":"purescript-monaco"},"releases":{},"unpublished":{}}

--- a/metadata/monaco.json
+++ b/metadata/monaco.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"maxhillaert","githubRepo":"purescript-monaco"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "maxhillaert",
+    "githubRepo": "purescript-monaco"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/monad-fix.json
+++ b/metadata/monad-fix.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"zrho","githubRepo":"purescript-monad-fix"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "zrho",
+    "githubRepo": "purescript-monad-fix"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/monad-fix.json
+++ b/metadata/monad-fix.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"zrho","githubRepo":"purescript-monad-fix"},"releases":{},"unpublished":{}}

--- a/metadata/neodoc-parsing.json
+++ b/metadata/neodoc-parsing.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"felixSchl","githubRepo":"purescript-neodoc-parsing"},"releases":{},"unpublished":{}}

--- a/metadata/neodoc-parsing.json
+++ b/metadata/neodoc-parsing.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"felixSchl","githubRepo":"purescript-neodoc-parsing"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "felixSchl",
+    "githubRepo": "purescript-neodoc-parsing"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/node-args.json
+++ b/metadata/node-args.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"purescript","githubRepo":"purescript-node-args"},"releases":{},"unpublished":{}}

--- a/metadata/node-args.json
+++ b/metadata/node-args.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"purescript","githubRepo":"purescript-node-args"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "purescript",
+    "githubRepo": "purescript-node-args"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/node-datagrams.json
+++ b/metadata/node-datagrams.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"jliuhtonen","githubRepo":"purescript-node-datagrams"},"releases":{},"unpublished":{}}

--- a/metadata/node-datagrams.json
+++ b/metadata/node-datagrams.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"jliuhtonen","githubRepo":"purescript-node-datagrams"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "jliuhtonen",
+    "githubRepo": "purescript-node-datagrams"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/node-fs-aff-extra.json
+++ b/metadata/node-fs-aff-extra.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"dgendill","githubRepo":"purescript-node-fs-aff-extra"},"releases":{},"unpublished":{}}

--- a/metadata/node-fs-aff-extra.json
+++ b/metadata/node-fs-aff-extra.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"dgendill","githubRepo":"purescript-node-fs-aff-extra"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "dgendill",
+    "githubRepo": "purescript-node-fs-aff-extra"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/node-github.json
+++ b/metadata/node-github.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"obmarg","githubRepo":"purescript-node-github"},"releases":{},"unpublished":{}}

--- a/metadata/node-github.json
+++ b/metadata/node-github.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"obmarg","githubRepo":"purescript-node-github"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "obmarg",
+    "githubRepo": "purescript-node-github"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/node-readline-question.json
+++ b/metadata/node-readline-question.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"i-am-tom","githubRepo":"purescript-node-readline-question"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "i-am-tom",
+    "githubRepo": "purescript-node-readline-question"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/node-readline-question.json
+++ b/metadata/node-readline-question.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"i-am-tom","githubRepo":"purescript-node-readline-question"},"releases":{},"unpublished":{}}

--- a/metadata/noms.json
+++ b/metadata/noms.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"yjpark","githubRepo":"purescript-noms"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "yjpark",
+    "githubRepo": "purescript-noms"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/noms.json
+++ b/metadata/noms.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"yjpark","githubRepo":"purescript-noms"},"releases":{},"unpublished":{}}

--- a/metadata/openwhisk.json
+++ b/metadata/openwhisk.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"yjpark","githubRepo":"purescript-openwhisk"},"releases":{},"unpublished":{}}

--- a/metadata/openwhisk.json
+++ b/metadata/openwhisk.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"yjpark","githubRepo":"purescript-openwhisk"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "yjpark",
+    "githubRepo": "purescript-openwhisk"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/optic-ui.json
+++ b/metadata/optic-ui.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"zrho","githubRepo":"purescript-optic-ui"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "zrho",
+    "githubRepo": "purescript-optic-ui"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/optic-ui.json
+++ b/metadata/optic-ui.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"zrho","githubRepo":"purescript-optic-ui"},"releases":{},"unpublished":{}}

--- a/metadata/org.json
+++ b/metadata/org.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"birdgg","githubRepo":"purescript-org"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "birdgg",
+    "githubRepo": "purescript-org"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/org.json
+++ b/metadata/org.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"birdgg","githubRepo":"purescript-org"},"releases":{},"unpublished":{}}

--- a/metadata/parsing-extras.json
+++ b/metadata/parsing-extras.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"dgendill","githubRepo":"purescript-parsing-extras"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "dgendill",
+    "githubRepo": "purescript-parsing-extras"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/parsing-extras.json
+++ b/metadata/parsing-extras.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"dgendill","githubRepo":"purescript-parsing-extras"},"releases":{},"unpublished":{}}

--- a/metadata/parsing-foreign.json
+++ b/metadata/parsing-foreign.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"markfarrell","githubRepo":"purescript-parsing-foreign"},"releases":{},"unpublished":{}}

--- a/metadata/parsing-foreign.json
+++ b/metadata/parsing-foreign.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"markfarrell","githubRepo":"purescript-parsing-foreign"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "markfarrell",
+    "githubRepo": "purescript-parsing-foreign"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/phantomjs.json
+++ b/metadata/phantomjs.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"cxfreeio","githubRepo":"purescript-phantomjs"},"releases":{},"unpublished":{}}

--- a/metadata/phantomjs.json
+++ b/metadata/phantomjs.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"cxfreeio","githubRepo":"purescript-phantomjs"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "cxfreeio",
+    "githubRepo": "purescript-phantomjs"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/photons.json
+++ b/metadata/photons.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"slamdata","githubRepo":"purescript-photons"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "slamdata",
+    "githubRepo": "purescript-photons"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/photons.json
+++ b/metadata/photons.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"slamdata","githubRepo":"purescript-photons"},"releases":{},"unpublished":{}}

--- a/metadata/plaid-node.json
+++ b/metadata/plaid-node.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"piq9117","githubRepo":"purescript-plaid-node"},"releases":{},"unpublished":{}}

--- a/metadata/plaid-node.json
+++ b/metadata/plaid-node.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"piq9117","githubRepo":"purescript-plaid-node"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "piq9117",
+    "githubRepo": "purescript-plaid-node"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/plottable.json
+++ b/metadata/plottable.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"atomicits","githubRepo":"purescript-plottable"},"releases":{},"unpublished":{}}

--- a/metadata/plottable.json
+++ b/metadata/plottable.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"atomicits","githubRepo":"purescript-plottable"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "atomicits",
+    "githubRepo": "purescript-plottable"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/pouchdb-ffi.json
+++ b/metadata/pouchdb-ffi.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"fehrenbach","githubRepo":"purescript-pouchdb-ffi"},"releases":{},"unpublished":{}}

--- a/metadata/pouchdb-ffi.json
+++ b/metadata/pouchdb-ffi.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"fehrenbach","githubRepo":"purescript-pouchdb-ffi"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "fehrenbach",
+    "githubRepo": "purescript-pouchdb-ffi"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/presto-backend.json
+++ b/metadata/presto-backend.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"juspay","githubRepo":"purescript-presto-backend"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "juspay",
+    "githubRepo": "purescript-presto-backend"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/presto-backend.json
+++ b/metadata/presto-backend.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"juspay","githubRepo":"purescript-presto-backend"},"releases":{},"unpublished":{}}

--- a/metadata/proact.json
+++ b/metadata/proact.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"alvart","githubRepo":"purescript-proact"},"releases":{},"unpublished":{}}

--- a/metadata/proact.json
+++ b/metadata/proact.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"alvart","githubRepo":"purescript-proact"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "alvart",
+    "githubRepo": "purescript-proact"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/pspec.json
+++ b/metadata/pspec.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"philopon","githubRepo":"purescript-pspec"},"releases":{},"unpublished":{}}

--- a/metadata/pspec.json
+++ b/metadata/pspec.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"philopon","githubRepo":"purescript-pspec"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "philopon",
+    "githubRepo": "purescript-pspec"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/pux-router.json
+++ b/metadata/pux-router.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"alvart","githubRepo":"purescript-pux-router"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "alvart",
+    "githubRepo": "purescript-pux-router"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/pux-router.json
+++ b/metadata/pux-router.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"alvart","githubRepo":"purescript-pux-router"},"releases":{},"unpublished":{}}

--- a/metadata/pux-undo.json
+++ b/metadata/pux-undo.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"parsonsmatt","githubRepo":"purescript-pux-undo"},"releases":{},"unpublished":{}}

--- a/metadata/pux-undo.json
+++ b/metadata/pux-undo.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"parsonsmatt","githubRepo":"purescript-pux-undo"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "parsonsmatt",
+    "githubRepo": "purescript-pux-undo"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/ractive.json
+++ b/metadata/ractive.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"brakmic","githubRepo":"purescript-ractive"},"releases":{},"unpublished":{}}

--- a/metadata/ractive.json
+++ b/metadata/ractive.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"brakmic","githubRepo":"purescript-ractive"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "brakmic",
+    "githubRepo": "purescript-ractive"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/radix64.json
+++ b/metadata/radix64.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"PipocaQuemada","githubRepo":"purescript-radix64"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "PipocaQuemada",
+    "githubRepo": "purescript-radix64"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/radix64.json
+++ b/metadata/radix64.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"PipocaQuemada","githubRepo":"purescript-radix64"},"releases":{},"unpublished":{}}

--- a/metadata/react-native.json
+++ b/metadata/react-native.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"hoodunit","githubRepo":"purescript-react-native"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "hoodunit",
+    "githubRepo": "purescript-react-native"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/react-native.json
+++ b/metadata/react-native.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"hoodunit","githubRepo":"purescript-react-native"},"releases":{},"unpublished":{}}

--- a/metadata/react-simpleaction.json
+++ b/metadata/react-simpleaction.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"doolse","githubRepo":"purescript-react-simpleaction"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "doolse",
+    "githubRepo": "purescript-react-simpleaction"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/react-simpleaction.json
+++ b/metadata/react-simpleaction.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"doolse","githubRepo":"purescript-react-simpleaction"},"releases":{},"unpublished":{}}

--- a/metadata/react-toolbox.json
+++ b/metadata/react-toolbox.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"AlexKovalevych","githubRepo":"purescript-react-toolbox"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "AlexKovalevych",
+    "githubRepo": "purescript-react-toolbox"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/react-toolbox.json
+++ b/metadata/react-toolbox.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"AlexKovalevych","githubRepo":"purescript-react-toolbox"},"releases":{},"unpublished":{}}

--- a/metadata/reactive-jquery.json
+++ b/metadata/reactive-jquery.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"purescript","githubRepo":"purescript-reactive-jquery"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "purescript",
+    "githubRepo": "purescript-reactive-jquery"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/reactive-jquery.json
+++ b/metadata/reactive-jquery.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"purescript","githubRepo":"purescript-reactive-jquery"},"releases":{},"unpublished":{}}

--- a/metadata/reactive.json
+++ b/metadata/reactive.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"purescript","githubRepo":"purescript-reactive"},"releases":{},"unpublished":{}}

--- a/metadata/reactive.json
+++ b/metadata/reactive.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"purescript","githubRepo":"purescript-reactive"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "purescript",
+    "githubRepo": "purescript-reactive"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/rnx.json
+++ b/metadata/rnx.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"atomicits","githubRepo":"purescript-rnx"},"releases":{},"unpublished":{}}

--- a/metadata/rnx.json
+++ b/metadata/rnx.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"atomicits","githubRepo":"purescript-rnx"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "atomicits",
+    "githubRepo": "purescript-rnx"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/router.json
+++ b/metadata/router.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"dbushenko","githubRepo":"purescript-router"},"releases":{},"unpublished":{}}

--- a/metadata/router.json
+++ b/metadata/router.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"dbushenko","githubRepo":"purescript-router"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "dbushenko",
+    "githubRepo": "purescript-router"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/screeps.json
+++ b/metadata/screeps.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"hoodunit","githubRepo":"purescript-screeps"},"releases":{},"unpublished":{}}

--- a/metadata/screeps.json
+++ b/metadata/screeps.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"hoodunit","githubRepo":"purescript-screeps"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "hoodunit",
+    "githubRepo": "purescript-screeps"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/sequelize.json
+++ b/metadata/sequelize.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"athanclark","githubRepo":"purescript-sequelize"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "athanclark",
+    "githubRepo": "purescript-sequelize"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/sequelize.json
+++ b/metadata/sequelize.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"athanclark","githubRepo":"purescript-sequelize"},"releases":{},"unpublished":{}}

--- a/metadata/sequential-aff-coroutines.json
+++ b/metadata/sequential-aff-coroutines.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"beckyconning","githubRepo":"purescript-sequential-aff-coroutines"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "beckyconning",
+    "githubRepo": "purescript-sequential-aff-coroutines"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/sequential-aff-coroutines.json
+++ b/metadata/sequential-aff-coroutines.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"beckyconning","githubRepo":"purescript-sequential-aff-coroutines"},"releases":{},"unpublished":{}}

--- a/metadata/sigment.json
+++ b/metadata/sigment.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"ptol","githubRepo":"purescript-sigment"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "ptol",
+    "githubRepo": "purescript-sigment"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/sigment.json
+++ b/metadata/sigment.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"ptol","githubRepo":"purescript-sigment"},"releases":{},"unpublished":{}}

--- a/metadata/simple-dom-generated.json
+++ b/metadata/simple-dom-generated.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"aktowns","githubRepo":"purescript-simple-dom-generated"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "aktowns",
+    "githubRepo": "purescript-simple-dom-generated"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/simple-dom-generated.json
+++ b/metadata/simple-dom-generated.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"aktowns","githubRepo":"purescript-simple-dom-generated"},"releases":{},"unpublished":{}}

--- a/metadata/simple-templates.json
+++ b/metadata/simple-templates.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"jacereda","githubRepo":"purescript-simple-templates"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "jacereda",
+    "githubRepo": "purescript-simple-templates"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/simple-templates.json
+++ b/metadata/simple-templates.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"jacereda","githubRepo":"purescript-simple-templates"},"releases":{},"unpublished":{}}

--- a/metadata/slack.json
+++ b/metadata/slack.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"saksdirect","githubRepo":"purescript-slack"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "saksdirect",
+    "githubRepo": "purescript-slack"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/slack.json
+++ b/metadata/slack.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"saksdirect","githubRepo":"purescript-slack"},"releases":{},"unpublished":{}}

--- a/metadata/slides-remember.json
+++ b/metadata/slides-remember.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"soupi","githubRepo":"purescript-slides-remember"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "soupi",
+    "githubRepo": "purescript-slides-remember"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/slides-remember.json
+++ b/metadata/slides-remember.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"soupi","githubRepo":"purescript-slides-remember"},"releases":{},"unpublished":{}}

--- a/metadata/slides.json
+++ b/metadata/slides.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"soupi","githubRepo":"purescript-slides"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "soupi",
+    "githubRepo": "purescript-slides"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/slides.json
+++ b/metadata/slides.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"soupi","githubRepo":"purescript-slides"},"releases":{},"unpublished":{}}

--- a/metadata/social-icons.json
+++ b/metadata/social-icons.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"athanclark","githubRepo":"purescript-social-icons"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "athanclark",
+    "githubRepo": "purescript-social-icons"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/social-icons.json
+++ b/metadata/social-icons.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"athanclark","githubRepo":"purescript-social-icons"},"releases":{},"unpublished":{}}

--- a/metadata/solc.json
+++ b/metadata/solc.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"f-o-a-m","githubRepo":"purescript-solc"},"releases":{},"unpublished":{}}

--- a/metadata/solc.json
+++ b/metadata/solc.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"f-o-a-m","githubRepo":"purescript-solc"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "f-o-a-m",
+    "githubRepo": "purescript-solc"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/soundcloud.json
+++ b/metadata/soundcloud.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"vyorkin","githubRepo":"purescript-handsontable"},"releases":{},"unpublished":{}}

--- a/metadata/soundcloud.json
+++ b/metadata/soundcloud.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"vyorkin","githubRepo":"purescript-handsontable"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "vyorkin",
+    "githubRepo": "purescript-handsontable"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/spidermonkey-ast.json
+++ b/metadata/spidermonkey-ast.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"michaelficarra","githubRepo":"purescript-spidermonkey-ast"},"releases":{},"unpublished":{}}

--- a/metadata/spidermonkey-ast.json
+++ b/metadata/spidermonkey-ast.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"michaelficarra","githubRepo":"purescript-spidermonkey-ast"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "michaelficarra",
+    "githubRepo": "purescript-spidermonkey-ast"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/ssrs.json
+++ b/metadata/ssrs.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"PureFunctor","githubRepo":"purescript-ssrs"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "PureFunctor",
+    "githubRepo": "purescript-ssrs"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/ssrs.json
+++ b/metadata/ssrs.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"PureFunctor","githubRepo":"purescript-ssrs"},"releases":{},"unpublished":{}}

--- a/metadata/stm.json
+++ b/metadata/stm.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"rightfold","githubRepo":"purescript-stm"},"releases":{},"unpublished":{}}

--- a/metadata/stm.json
+++ b/metadata/stm.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"rightfold","githubRepo":"purescript-stm"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "rightfold",
+    "githubRepo": "purescript-stm"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/streams.json
+++ b/metadata/streams.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"puffnfresh","githubRepo":"purescript-streams"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "puffnfresh",
+    "githubRepo": "purescript-streams"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/streams.json
+++ b/metadata/streams.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"puffnfresh","githubRepo":"purescript-streams"},"releases":{},"unpublished":{}}

--- a/metadata/stsequence.json
+++ b/metadata/stsequence.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"mgmeier","githubRepo":"purescript-stsequence"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "mgmeier",
+    "githubRepo": "purescript-stsequence"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/stsequence.json
+++ b/metadata/stsequence.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"mgmeier","githubRepo":"purescript-stsequence"},"releases":{},"unpublished":{}}

--- a/metadata/subtype.json
+++ b/metadata/subtype.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"rightfold","githubRepo":"purescript-subtype"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "rightfold",
+    "githubRepo": "purescript-subtype"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/subtype.json
+++ b/metadata/subtype.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"rightfold","githubRepo":"purescript-subtype"},"releases":{},"unpublished":{}}

--- a/metadata/sync-websockets.json
+++ b/metadata/sync-websockets.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"pkamenarsky","githubRepo":"purescript-sync-websockets"},"releases":{},"unpublished":{}}

--- a/metadata/sync-websockets.json
+++ b/metadata/sync-websockets.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"pkamenarsky","githubRepo":"purescript-sync-websockets"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "pkamenarsky",
+    "githubRepo": "purescript-sync-websockets"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/sytc.json
+++ b/metadata/sytc.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"mikesol","githubRepo":"purescript-sytc"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "mikesol",
+    "githubRepo": "purescript-sytc"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/sytc.json
+++ b/metadata/sytc.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"mikesol","githubRepo":"purescript-sytc"},"releases":{},"unpublished":{}}

--- a/metadata/task-http.json
+++ b/metadata/task-http.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"ursi","githubRepo":"purescript-task-http"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "ursi",
+    "githubRepo": "purescript-task-http"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/task-http.json
+++ b/metadata/task-http.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"ursi","githubRepo":"purescript-task-http"},"releases":{},"unpublished":{}}

--- a/metadata/test-pontificate.json
+++ b/metadata/test-pontificate.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"Fresheyeball","githubRepo":"purescript-test-pontificate"},"releases":{},"unpublished":{}}

--- a/metadata/test-pontificate.json
+++ b/metadata/test-pontificate.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"Fresheyeball","githubRepo":"purescript-test-pontificate"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "Fresheyeball",
+    "githubRepo": "purescript-test-pontificate"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/toastr.json
+++ b/metadata/toastr.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"dbushenko","githubRepo":"purescript-toastr"},"releases":{},"unpublished":{}}

--- a/metadata/toastr.json
+++ b/metadata/toastr.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"dbushenko","githubRepo":"purescript-toastr"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "dbushenko",
+    "githubRepo": "purescript-toastr"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/trace.json
+++ b/metadata/trace.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"pkamenarsky","githubRepo":"purescript-trace"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "pkamenarsky",
+    "githubRepo": "purescript-trace"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/trace.json
+++ b/metadata/trace.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"pkamenarsky","githubRepo":"purescript-trace"},"releases":{},"unpublished":{}}

--- a/metadata/typeahead.json
+++ b/metadata/typeahead.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"ascjones","githubRepo":"purescript-typeahead"},"releases":{},"unpublished":{}}

--- a/metadata/typeahead.json
+++ b/metadata/typeahead.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"ascjones","githubRepo":"purescript-typeahead"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "ascjones",
+    "githubRepo": "purescript-typeahead"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/typed-wire.json
+++ b/metadata/typed-wire.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"typed-wire","githubRepo":"purescript-typed-wire"},"releases":{},"unpublished":{}}

--- a/metadata/typed-wire.json
+++ b/metadata/typed-wire.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"typed-wire","githubRepo":"purescript-typed-wire"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "typed-wire",
+    "githubRepo": "purescript-typed-wire"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/typelevel-graph.json
+++ b/metadata/typelevel-graph.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"mikesol","githubRepo":"purescript-typelevel-graph"},"releases":{},"unpublished":{}}

--- a/metadata/typelevel-graph.json
+++ b/metadata/typelevel-graph.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"mikesol","githubRepo":"purescript-typelevel-graph"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "mikesol",
+    "githubRepo": "purescript-typelevel-graph"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/typelevel-measures.json
+++ b/metadata/typelevel-measures.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"csicar","githubRepo":"purescript-typelevel-measures"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "csicar",
+    "githubRepo": "purescript-typelevel-measures"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/typelevel-measures.json
+++ b/metadata/typelevel-measures.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"csicar","githubRepo":"purescript-typelevel-measures"},"releases":{},"unpublished":{}}

--- a/metadata/uport.json
+++ b/metadata/uport.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"f-o-a-m","githubRepo":"purescript-uport"},"releases":{},"unpublished":{}}

--- a/metadata/uport.json
+++ b/metadata/uport.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"f-o-a-m","githubRepo":"purescript-uport"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "f-o-a-m",
+    "githubRepo": "purescript-uport"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/vdom-worker.json
+++ b/metadata/vdom-worker.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"FrigoEU","githubRepo":"purescript-vdom-worker"},"releases":{},"unpublished":{}}

--- a/metadata/vdom-worker.json
+++ b/metadata/vdom-worker.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"FrigoEU","githubRepo":"purescript-vdom-worker"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "FrigoEU",
+    "githubRepo": "purescript-vdom-worker"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/webcomponents.json
+++ b/metadata/webcomponents.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"Risto-Stevcev","githubRepo":"purescript-webcomponents"},"releases":{},"unpublished":{}}

--- a/metadata/webcomponents.json
+++ b/metadata/webcomponents.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"Risto-Stevcev","githubRepo":"purescript-webcomponents"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "Risto-Stevcev",
+    "githubRepo": "purescript-webcomponents"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/webrtc.json
+++ b/metadata/webrtc.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"puffnfresh","githubRepo":"purescript-webrtc"},"releases":{},"unpublished":{}}

--- a/metadata/webrtc.json
+++ b/metadata/webrtc.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"puffnfresh","githubRepo":"purescript-webrtc"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "puffnfresh",
+    "githubRepo": "purescript-webrtc"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/whatwg-html.json
+++ b/metadata/whatwg-html.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"ursi","githubRepo":"purescript-whatwg-html"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "ursi",
+    "githubRepo": "purescript-whatwg-html"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/whatwg-html.json
+++ b/metadata/whatwg-html.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"ursi","githubRepo":"purescript-whatwg-html"},"releases":{},"unpublished":{}}

--- a/metadata/winston.json
+++ b/metadata/winston.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"dysinger","githubRepo":"purescript-winston"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "dysinger",
+    "githubRepo": "purescript-winston"
+  },
+  "releases": {},
+  "unpublished": {}
+}

--- a/metadata/winston.json
+++ b/metadata/winston.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"dysinger","githubRepo":"purescript-winston"},"releases":{},"unpublished":{}}

--- a/metadata/yaml.json
+++ b/metadata/yaml.json
@@ -1,0 +1,1 @@
+{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-yaml"},"releases":{},"unpublished":{}}

--- a/metadata/yaml.json
+++ b/metadata/yaml.json
@@ -1,1 +1,8 @@
-{"location":{"githubOwner":"CapillarySoftware","githubRepo":"purescript-yaml"},"releases":{},"unpublished":{}}
+{
+  "location": {
+    "githubOwner": "CapillarySoftware",
+    "githubRepo": "purescript-yaml"
+  },
+  "releases": {},
+  "unpublished": {}
+}


### PR DESCRIPTION
Fixes #302 by ensuring that all packages with a valid package name are included in the registry index during the legacy import process. This does not ensure that these packages are uploaded (we're going to have to decide how we want to do that -- write an empty directory?), and the unused binding will leave a warning active until we have added them to the upload process.