### PR TITLE
Remove NOASSERTION license

### DIFF
--- a/ci/src/Registry/Scripts/LegacyImport/Manifest.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Manifest.purs
@@ -108,7 +108,7 @@ constructManifestFields package version address = do
     let
       spagoLicenses = maybe [] NEA.toArray $ _.license =<< hush spagoManifest
       bowerLicenses = maybe [] NEA.toArray $ _.license =<< hush bowerManifest
-      licenseeLicenses = Array.catMaybes $ map NES.fromString licenseeOutput
+      licenseeLicenses = Array.mapMaybe NES.fromString licenseeOutput
       license = NEA.fromArray $ Array.nub $ Array.concat [ licenseeLicenses, spagoLicenses, bowerLicenses ]
       description = join (_.description <$> hush bowerManifest)
 


### PR DESCRIPTION
This PR removes the `NOASSERTION` license type from Licensee output. We take license types from various manifest files as well as trying to auto-detect from a LICENSE file (if present); the `NOASSERTION` license type represents a failed parse of a LICENSE file.

After discussion with our legal counsel we determined that we can include packages so long as we can prove we made a 'best effort' to represent the author's intent in licensing. Since we take the license from their other assertions in package manifests, and since Licensee is an automated tool that can fail to parse license files that humans would recognize as conveying meaning, we can drop these parsing failures -- we have an alternate way to determine the license (the manifest files' `license` fields).

Filtering this license type from the Licensee output prevents a NOASSERTION from failing the SPDX license check, so a good number of packages that were previously failing are now passing. Note: this does _not_ allow packages that only specify a license via a LICENSE file through if the parse fails; that results in a package being listed as having no valid license at all. So we're still only accepting licensed packages.

Helps fix #250, and closes #266, because now only packages with invalid dependencies are being dropped -- and that means only `purescript-prettier` is going to be dropped, which is pretty good!