### PR TITLE
Remove `legacy` and `addToPackageSet` flags from operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.psc*
 examples
 registry-index

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -105,21 +105,21 @@ readOperation eventPath = do
 runOperation :: Operation -> RegistryM Unit
 runOperation operation = case operation of
   -- TODO handle addToPackageSet
-  Addition { packageName, legacy, newRef, newPackageLocation } -> do
+  Addition { packageName, newRef, newPackageLocation } -> do
     -- check that we don't have a metadata file for that package
     ifM (liftAff $ FS.exists $ metadataFile packageName)
       -- if the metadata file already exists then we steer this to be an Update instead
-      (runOperation $ Update { packageName, legacy, updateRef: newRef })
+      (runOperation $ Update { packageName, updateRef: newRef })
       do
-        addOrUpdate { packageName, legacy, ref: newRef } $ mkNewMetadata newPackageLocation
+        addOrUpdate { packageName, ref: newRef } $ mkNewMetadata newPackageLocation
 
-  Update { packageName, legacy, updateRef } -> do
+  Update { packageName, updateRef } -> do
     ifM (liftAff $ FS.exists $ metadataFile packageName)
       do
         metadata <- readPackagesMetadata >>= \packages -> case Map.lookup packageName packages of
           Nothing -> throwWithComment "Couldn't read metadata file for your package"
           Just m -> pure m
-        addOrUpdate { packageName, legacy, ref: updateRef } metadata
+        addOrUpdate { packageName, ref: updateRef } metadata
       (throwWithComment "Metadata file should exist. Did you mean to create an Addition?")
 
   Unpublish _ -> throwWithComment "Unpublish not implemented! Ask us for help!" -- TODO
@@ -133,8 +133,8 @@ metadataFile packageName = metadataDir <> "/" <> PackageName.print packageName <
 indexDir :: FilePath
 indexDir = "../registry-index"
 
-addOrUpdate :: { legacy :: Boolean, ref :: String, packageName :: PackageName } -> Metadata -> RegistryM Unit
-addOrUpdate { ref, legacy, packageName } metadata = do
+addOrUpdate :: { ref :: String, packageName :: PackageName } -> Metadata -> RegistryM Unit
+addOrUpdate { ref, packageName } metadata = do
   -- let's get a temp folder to do our stuffs
   tmpDir <- liftEffect $ Tmp.mkTmpDir
   -- fetch the repo and put it in the tempdir, returning the name of its toplevel dir
@@ -168,7 +168,7 @@ addOrUpdate { ref, legacy, packageName } metadata = do
   log $ "Package extracted in " <> absoluteFolderPath
 
   -- If this is a legacy import, then we need to construct a `Manifest` for it
-  when legacy do
+  unlessM (liftAff $ FS.exists manifestPath) do
     address <- case metadata.location of
       Git _ -> throwWithComment "Legacy packages can only come from GitHub. Aborting."
       GitHub { owner, repo } -> pure { owner, repo }

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -136,8 +136,7 @@ instance RegistryJson Operation where
     parseAddition <|> parseUpdate <|> parseUnpublish
 
 type AdditionData =
-  { addToPackageSet :: Boolean
-  , newPackageLocation :: Repo
+  { newPackageLocation :: Repo
   , newRef :: String
   , packageName :: PackageName
   }

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -137,7 +137,6 @@ instance RegistryJson Operation where
 
 type AdditionData =
   { addToPackageSet :: Boolean
-  , legacy :: Boolean
   , newPackageLocation :: Repo
   , newRef :: String
   , packageName :: PackageName
@@ -145,7 +144,6 @@ type AdditionData =
 
 type UpdateData =
   { packageName :: PackageName
-  , legacy :: Boolean
   , updateRef :: String
   }
 

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -101,8 +101,7 @@ main = Aff.launchAff_ do
     for_ packagesToUpload \manifest -> do
       let
         addition = Addition
-          { addToPackageSet: false -- heh, we don't have package sets until we do this import!
-          , newPackageLocation: manifest.repository
+          { newPackageLocation: manifest.repository
           , newRef: Version.rawVersion manifest.version
           , packageName: manifest.name
           }

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -102,7 +102,6 @@ main = Aff.launchAff_ do
       let
         addition = Addition
           { addToPackageSet: false -- heh, we don't have package sets until we do this import!
-          , legacy: true
           , newPackageLocation: manifest.repository
           , newRef: Version.rawVersion manifest.version
           , packageName: manifest.name

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -240,7 +240,6 @@ decodeEventsToOps = do
       operation = Addition
         { packageName: unsafeFromRight $ PackageName.parse "prelude"
         , newRef: "v5.0.0"
-        , addToPackageSet: true
         , newPackageLocation: GitHub { subdir: Nothing, owner: "purescript", repo: "purescript-prelude" }
         }
 

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -229,7 +229,6 @@ decodeEventsToOps = do
       operation = Update
         { packageName: unsafeFromRight $ PackageName.parse "something"
         , updateRef: "v1.2.3"
-        , legacy: false
         }
 
     res <- API.readOperation "test/fixtures/issue_comment.json"
@@ -241,7 +240,6 @@ decodeEventsToOps = do
       operation = Addition
         { packageName: unsafeFromRight $ PackageName.parse "prelude"
         , newRef: "v5.0.0"
-        , legacy: true
         , addToPackageSet: true
         , newPackageLocation: GitHub { subdir: Nothing, owner: "purescript", repo: "purescript-prelude" }
         }

--- a/ci/test/fixtures/issue_comment.json
+++ b/ci/test/fixtures/issue_comment.json
@@ -2,7 +2,7 @@
   "action": "created",
   "comment": {
     "author_association": "MEMBER",
-    "body": "{\"legacy\": false,\"packageName\":\"something\",\"updateRef\":\"v1.2.3\"}",
+    "body": "{\"packageName\":\"something\",\"updateRef\":\"v1.2.3\"}",
     "created_at": "2021-03-09T02:03:56Z",
     "html_url": "https://github.com/purescript/registry/issues/43#issuecomment-793265839",
     "id": 793265839,

--- a/ci/test/fixtures/issue_created.json
+++ b/ci/test/fixtures/issue_created.json
@@ -5,7 +5,7 @@
     "assignee": null,
     "assignees": [],
     "author_association": "CONTRIBUTOR",
-    "body": "{\"addToPackageSet\": true,\"newPackageLocation\": {\"githubOwner\": \"purescript\",\"githubRepo\": \"purescript-prelude\"},\"newRef\": \"v5.0.0\",\"packageName\": \"prelude\"}",
+    "body": "{\"newPackageLocation\": {\"githubOwner\": \"purescript\",\"githubRepo\": \"purescript-prelude\"},\"newRef\": \"v5.0.0\",\"packageName\": \"prelude\"}",
     "closed_at": null,
     "comments": 0,
     "comments_url": "https://api.github.com/repos/purescript/registry/issues/149/comments",

--- a/ci/test/fixtures/issue_created.json
+++ b/ci/test/fixtures/issue_created.json
@@ -5,7 +5,7 @@
     "assignee": null,
     "assignees": [],
     "author_association": "CONTRIBUTOR",
-    "body": "{\"addToPackageSet\": true,\"legacy\": true,\"newPackageLocation\": {\"githubOwner\": \"purescript\",\"githubRepo\": \"purescript-prelude\"},\"newRef\": \"v5.0.0\",\"packageName\": \"prelude\"}",
+    "body": "{\"addToPackageSet\": true,\"newPackageLocation\": {\"githubOwner\": \"purescript\",\"githubRepo\": \"purescript-prelude\"},\"newRef\": \"v5.0.0\",\"packageName\": \"prelude\"}",
     "closed_at": null,
     "comments": 0,
     "comments_url": "https://api.github.com/repos/purescript/registry/issues/149/comments",

--- a/v1/Operation.dhall
+++ b/v1/Operation.dhall
@@ -7,7 +7,7 @@ A type describing all the possible operations for the Registry API.
 let Repo = ./Repo.dhall
 
 in
-  < Addition : { packageName : Text, newPackageLocation : Repo, newRef : Text, addToPackageSet: Bool, legacy : Bool }
-  | Update : { packageName : Text, updateRef : Text, legacy : Bool }
+  < Addition : { packageName : Text, newPackageLocation : Repo, newRef : Text, addToPackageSet: Bool }
+  | Update : { packageName : Text, updateRef : Text }
   | Unpublish : { packageName : Text, unpublishVersion : Text, unpublishReason: Text }
   >


### PR DESCRIPTION
As described in #332:

> > An `Addition` takes an `addToPackageSet` flag, and an `Update` does not
> 
> This is a historical accident that came from the fact that we added this flag long before we specced properly how to do package sets here. I think we could just take this flag away and always try to add packages to the set?
> 
> > removing the `legacy` flag. We know a package is a legacy package if it doesn't have a `.purs.json` file
> 
> I think this is a good idea, yeah. Again the `legacy` flag was added when we did not know better - now we know that we can just use the Manifest existence to decide which path to take in the API
