### PR TITLE
Rename purs.json to .purs.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ will live on various [storage backends](#Storage-Backends).
 A `Manifest` stores all the metadata (e.g. package name, version, dependencies, etc)
 for **a specific  version** of **a specific package**.
 
-Packages are expected to version in their sources a `purs.json` file, that conforms
+Packages are expected to version in their sources a `.purs.json` file, that conforms
 to the [`Manifest` schema](./v1/Manifest.dhall) to ensure __forwards-compatibility__
 with future schemas.
 This means that new clients will be able to read old schemas, but not vice-versa.
@@ -95,7 +95,7 @@ Here we embed a copy of the `Manifest` schema for ease of consultation:
 ```dhall
 {-
 
-The schema for `purs.json` files.
+The schema for `.purs.json` files.
 
 This object holds all the info that the Registry needs to know about it.
 
@@ -399,7 +399,7 @@ I.e. the answer to the question:
 
 > How do I know which dependencies package X at version Y has?
 
-Without an index of all the package manifests you'd have to fetch the right tarball and look at its `purs.json`.
+Without an index of all the package manifests you'd have to fetch the right tarball and look at its `.purs.json`.
 
 That might be a lot of work to do at scale, and there are usecases - e.g. for package-sets - where
 we need to lookup lots of manifests to build the dependency graph.

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -163,8 +163,8 @@ addOrUpdate { ref, packageName } metadata = do
           liftEffect $ Tar.extract { cwd: tmpDir, filename: absoluteTarballPath }
           pure { folderName: dir, published: commitDate }
 
-  let absoluteFolderPath = tmpDir <> "/" <> folderName
-  let manifestPath = absoluteFolderPath <> "/purs.json"
+  let absoluteFolderPath = Path.concat [ tmpDir, folderName ]
+  let manifestPath = Path.concat [ absoluteFolderPath, ".purs.json" ]
   log $ "Package extracted in " <> absoluteFolderPath
 
   -- If this is a legacy import, then we need to construct a `Manifest` for it

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -117,7 +117,7 @@ removeTarballFiles = Spec.it "Removes files not allowed in package tarballs" do
   let
     extraIgnoredFiles = [ "Unsaved.purs.swp", "._unused" ]
     acceptedDirectories = [ "src", "test" ]
-    acceptedFiles = [ "purs.json", "spago.dhall" ]
+    acceptedFiles = [ ".purs.json", "spago.dhall" ]
 
     writeDirectory directory = do
       let path = Path.concat [ tmp, directory ]

--- a/v1/Manifest.dhall
+++ b/v1/Manifest.dhall
@@ -1,6 +1,6 @@
 {-
 
-The schema for `purs.json` files.
+The schema for `.purs.json` files.
 
 This object holds all the info that the Registry needs to know about it.
 


### PR DESCRIPTION
Fixes #325 by adjusting references to `purs.json` to `.purs.json`.