### PR TITLE
Standardize use of Node.Path

### DIFF
--- a/ci/src/Foreign/Licensee.purs
+++ b/ci/src/Foreign/Licensee.purs
@@ -7,6 +7,7 @@ import Data.Array as Array
 import Foreign.Tmp as Tmp
 import Node.ChildProcess as NodeProcess
 import Node.FS.Aff as FS
+import Node.Path as Path
 import Registry.Json ((.:))
 import Registry.Json as Json
 import Sunde as Process
@@ -16,7 +17,7 @@ detectFiles :: Array { name :: FilePath, contents :: String } -> Aff (Either Str
 detectFiles files = do
   tmp <- liftEffect Tmp.mkTmpDir
   files # Parallel.parTraverse_ \{ name, contents } ->
-    FS.writeTextFile UTF8 (tmp <> "/" <> name) contents
+    FS.writeTextFile UTF8 (Path.concat [ tmp, name ]) contents
   detect tmp
 
 -- | Attempt to detect the license for the package in the given directory using

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -128,7 +128,7 @@ metadataDir :: FilePath
 metadataDir = "../metadata"
 
 metadataFile :: PackageName -> FilePath
-metadataFile packageName = metadataDir <> "/" <> PackageName.print packageName <> ".json"
+metadataFile packageName = Path.concat [ metadataDir, PackageName.print packageName <> ".json" ]
 
 indexDir :: FilePath
 indexDir = "../registry-index"
@@ -150,7 +150,7 @@ addOrUpdate { ref, packageName } metadata = do
       commit <- liftAff $ GitHub.getRefCommit octokit { owner, repo } ref
       commitDate <- liftAff $ GitHub.getCommitDate octokit { owner, repo } commit
       let tarballName = ref <> ".tar.gz"
-      let absoluteTarballPath = tmpDir <> "/" <> tarballName
+      let absoluteTarballPath = Path.concat [ tmpDir, tarballName ]
       let archiveUrl = "https://github.com/" <> owner <> "/" <> repo <> "/archive/" <> tarballName
       log $ "Fetching tarball from GitHub: " <> archiveUrl
       wget archiveUrl absoluteTarballPath
@@ -163,8 +163,8 @@ addOrUpdate { ref, packageName } metadata = do
           liftEffect $ Tar.extract { cwd: tmpDir, filename: absoluteTarballPath }
           pure { folderName: dir, published: commitDate }
 
-  let absoluteFolderPath = tmpDir <> "/" <> folderName
-  let manifestPath = absoluteFolderPath <> "/purs.json"
+  let absoluteFolderPath = Path.concat [ tmpDir, folderName ]
+  let manifestPath = Path.concat [ absoluteFolderPath, "purs.json" ]
   log $ "Package extracted in " <> absoluteFolderPath
 
   -- If this is a legacy import, then we need to construct a `Manifest` for it
@@ -212,7 +212,7 @@ addOrUpdate { ref, packageName } metadata = do
   -- We need the version number to upload the package
   let newVersion = manifestRecord.version
   let newDirname = PackageName.print packageName <> "-" <> Version.printVersion newVersion
-  let tarballDirname = tmpDir <> "/" <> newDirname
+  let tarballDirname = Path.concat [ tmpDir, newDirname ]
   liftAff do
     FS.rename absoluteFolderPath tarballDirname
     removeIgnoredTarballFiles tarballDirname

--- a/ci/src/Registry/Index.purs
+++ b/ci/src/Registry/Index.purs
@@ -17,7 +17,7 @@ import Foreign.Node.FS as FS.Extra
 import Node.FS.Aff as FS
 import Node.FS.Stats as Stats
 import Node.Glob.Basic as Glob
-import Node.Path as FilePath
+import Node.Path as Path
 import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
@@ -97,7 +97,7 @@ getIndexPath packageName = getIndexDir packageName <> PackageName.print packageN
 -- |  the file doesn't exist, the file is empty, or if we can't decode the Manifests
 readPackage :: FilePath -> PackageName -> Aff (Maybe (NonEmptyArray Manifest))
 readPackage directory packageName = do
-  let path = FilePath.concat [ directory, getIndexPath packageName ]
+  let path = Path.concat [ directory, getIndexPath packageName ]
 
   contentsResult <- try do
     contents <- FS.readTextFile ASCII path
@@ -111,8 +111,8 @@ readPackage directory packageName = do
 insertManifest :: FilePath -> Manifest -> Aff Unit
 insertManifest directory manifest@(Manifest { name, version }) = do
   let
-    manifestPath = FilePath.concat [ directory, getIndexPath name ]
-    manifestDirectory = FilePath.dirname manifestPath
+    manifestPath = Path.concat [ directory, getIndexPath name ]
+    manifestDirectory = Path.dirname manifestPath
 
   existingManifest <- readPackage directory name
 

--- a/ci/src/Registry/PackageUpload.purs
+++ b/ci/src/Registry/PackageUpload.purs
@@ -6,6 +6,7 @@ import Data.Array as Array
 import Effect.Aff as Aff
 import Foreign.S3 as S3
 import Node.FS.Aff as FS
+import Node.Path as Path
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Version (Version)
@@ -28,12 +29,7 @@ upload { name, version } path = do
   -- check that the file for that version is there
   let
     packageName = PackageName.print name
-    filename = Array.fold
-      [ packageName
-      , "/"
-      , Version.printVersion version
-      , ".tar.gz"
-      ]
+    filename = Path.concat [ packageName, Version.printVersion version <> ".tar.gz" ]
 
   publishedPackages <- map _.key <$> S3.listObjects s3 { prefix: packageName <> "/" }
 

--- a/ci/src/Registry/PackageUpload.purs
+++ b/ci/src/Registry/PackageUpload.purs
@@ -29,7 +29,12 @@ upload { name, version } path = do
   -- check that the file for that version is there
   let
     packageName = PackageName.print name
-    filename = Path.concat [ packageName, Version.printVersion version <> ".tar.gz" ]
+    filename = Array.fold
+      [ packageName
+      , "/"
+      , Version.printVersion version
+      , ".tar.gz"
+      ]
 
   publishedPackages <- map _.key <$> S3.listObjects s3 { prefix: packageName <> "/" }
 

--- a/ci/src/Registry/PackageUpload.purs
+++ b/ci/src/Registry/PackageUpload.purs
@@ -6,7 +6,6 @@ import Data.Array as Array
 import Effect.Aff as Aff
 import Foreign.S3 as S3
 import Node.FS.Aff as FS
-import Node.Path as Path
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Version (Version)

--- a/ci/src/Registry/Scripts/LegacyImport/Process.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Process.purs
@@ -20,6 +20,7 @@ import Foreign.GitHub as GitHub
 import Foreign.Node.FS as FS.Extra
 import Node.FS.Aff as FS
 import Node.FS.Stats (Stats(..))
+import Node.Path as Path
 import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.Scripts.LegacyImport.Error (ImportError(..), ImportErrorKey, PackageFailures(..), RequestError(..))
@@ -172,7 +173,7 @@ withCache
 withCache { encode, decode } path maybeDuration action = do
   let
     cacheFolder = ".cache"
-    objectPath = cacheFolder <> "/" <> path
+    objectPath = Path.concat [ cacheFolder, path ]
 
     -- We also cache some failures if they relate to fetching a resource and
     -- the failure is not temporary (for example, a `404 Not Found` error).

--- a/ci/test/Foreign/Licensee.purs
+++ b/ci/test/Foreign/Licensee.purs
@@ -3,14 +3,14 @@ module Test.Foreign.Licensee where
 import Registry.Prelude
 
 import Foreign.Licensee as Licensee
-import Node.Path as Node.Path
+import Node.Path as Path
 import Test.Spec as Spec
 import Test.Spec.Assertions as Assert
 import Test.Support.ManifestFiles as ManifestFiles
 
 licensee :: Spec.Spec Unit
 licensee = do
-  let fixtures = Node.Path.concat [ "test", "fixtures", "halogen-hooks" ]
+  let fixtures = Path.concat [ "test", "fixtures", "halogen-hooks" ]
   Spec.describe "Licensee runs" do
     Spec.it "Detects from directory" do
       detected <- Licensee.detect fixtures

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -46,7 +46,7 @@ main = launchAff_ do
   manifestExamplePaths <- join <$> for packages \package -> do
     let packageDir = examplesDir <> package
     manifests <- FS.readdir packageDir
-    pure $ map (\manifestFile -> packageDir <> "/" <> manifestFile) manifests
+    pure $ map (\manifestFile -> Path.concat [ packageDir, manifestFile ]) manifests
 
   runSpec' (defaultConfig { timeout = Just $ Milliseconds 10_000.0 }) [ consoleReporter ] do
     Spec.describe "API" do

--- a/ci/test/Registry/Hash.purs
+++ b/ci/test/Registry/Hash.purs
@@ -4,7 +4,7 @@ import Registry.Prelude
 
 import Control.Monad.Except as Except
 import Node.ChildProcess as NodeProcess
-import Node.Path as Node.Path
+import Node.Path as Path
 import Registry.Hash as Hash
 import Registry.Json as Json
 import Sunde as Process
@@ -46,7 +46,7 @@ hooksSpagoHash :: Hash.Sha256
 hooksSpagoHash = Hash.unsafeSha256 "sha256-fN9RUAzN21ZY4Y0UwqUSxwUPVz1g7/pcqoDvbJZoT04="
 
 hooksSpago :: FilePath
-hooksSpago = Node.Path.concat [ "test", "fixtures", "halogen-hooks", "spago.dhall" ]
+hooksSpago = Path.concat [ "test", "fixtures", "halogen-hooks", "spago.dhall" ]
 
 -- Test hash produced by `openssl`:
 -- openssl dgst -sha256 -binary < test/fixtures/LICENSE | openssl base64 -A
@@ -54,7 +54,7 @@ hooksLicenseHash :: Hash.Sha256
 hooksLicenseHash = Hash.unsafeSha256 "sha256-wOzNcCq20TAL/LMT1lYIiaoEIFGDBw+yp14bj7qK9v4="
 
 hooksLicense :: FilePath
-hooksLicense = Node.Path.concat [ "test", "fixtures", "halogen-hooks", "LICENSE" ]
+hooksLicense = Path.concat [ "test", "fixtures", "halogen-hooks", "LICENSE" ]
 
 sha256Nix :: FilePath -> ExceptT String Aff Hash.Sha256
 sha256Nix path = ExceptT do

--- a/ci/test/Registry/Index.purs
+++ b/ci/test/Registry/Index.purs
@@ -12,7 +12,7 @@ import Foreign.Object as Object
 import Foreign.Tmp as Tmp
 import Node.FS.Stats as Stats
 import Node.Glob.Basic as Glob
-import Node.Path as Node.Path
+import Node.Path as Path
 import Registry.Index (RegistryIndex)
 import Registry.Index as Index
 import Registry.PackageGraph as PackageGraph
@@ -60,7 +60,7 @@ testRegistryIndex = Spec.before runBefore do
 
       let
         actualPaths = Map.keys $ Map.filter (not Stats.isDirectory) packagePaths
-        expectedPaths = Set.fromFoldable $ map (Node.Path.concat <<< Array.cons tmp)
+        expectedPaths = Set.fromFoldable $ map (Path.concat <<< Array.cons tmp)
           [ [ "2", "ab" ]
           , [ "3", "a", "abc" ]
           , [ "ab", "cd", "abcd" ]

--- a/ci/test/Support/ManifestFiles.purs
+++ b/ci/test/Support/ManifestFiles.purs
@@ -3,7 +3,7 @@ module Test.Support.ManifestFiles (ManifestFiles, readFiles) where
 import Registry.Prelude
 
 import Node.FS.Aff as FS
-import Node.Path as Node.Path
+import Node.Path as Path
 
 type ManifestFiles =
   { license :: String
@@ -21,7 +21,7 @@ readFiles = do
   pure { license, packageJson, spagoDhall, bowerJson }
 
 fixtureFile :: FilePath -> FilePath
-fixtureFile file = Node.Path.concat [ "test", "fixtures", "halogen-hooks", file ]
+fixtureFile file = Path.concat [ "test", "fixtures", "halogen-hooks", file ]
 
 readLicense :: Aff String
 readLicense = FS.readTextFile UTF8 $ fixtureFile "LICENSE"


### PR DESCRIPTION
While working on a PR recently I noticed that we are a bit inconsistent with how we handle paths. In some places we concatenate paths with `<> "/" <>` and in others we use Node's path concatenation. Sometimes we import `Node.Path` as `Path`, or as `FilePath`, or as `Node.Path`.

This PR standardizes us on using Node path concatenation when working with file paths (to keep compatibility with Windows users) and importing qualified as `Path`.