### PR TITLE
Make published field optional

### DIFF
--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -231,7 +231,7 @@ addOrUpdate { ref, packageName } metadata = do
   uploadPackage uploadPackageInfo tarballPath
   log $ "Adding the new version " <> Version.printVersion newVersion <> " to the package metadata file (hashes, etc)"
   log $ "Hash for ref " <> show ref <> " was " <> show hash
-  let newMetadata = addVersionToMetadata newVersion { hash, ref, published, bytes } metadata
+  let newMetadata = addVersionToMetadata newVersion { hash, ref, published: Just published, bytes } metadata
   let metadataFilePath = metadataFile packageName
   liftAff $ Json.writeJsonFile metadataFilePath newMetadata
   updatePackagesMetadata manifestRecord.name newMetadata

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -161,7 +161,7 @@ type Metadata =
 type VersionMetadata =
   { ref :: String
   , hash :: Sha256
-  , published :: RFC3339String
+  , published :: Maybe RFC3339String
   , bytes :: Number
   }
 

--- a/v1/Metadata.dhall
+++ b/v1/Metadata.dhall
@@ -13,13 +13,14 @@ let SemVer = Text
 
 -- Information about a single published version
 let VersionMetadata =
-  {
   -- The git ref this version points to
-  , ref : Text
+  { ref : Text
   -- The hash of the source tarball fetched from the repo
   , hash : Text
   -- The size in bytes of the tarball
   , bytes : Natural
+  -- The publish date of the version, as an RFC3339 string
+  , published : Optional Text
   }
 
 in


### PR DESCRIPTION
Fixes #342 by making the `published` field optional in package metadata.