### PR TITLE
Implement authenticated operations

### DIFF
--- a/ci/package-lock.json
+++ b/ci/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@octokit/rest": "^18.12.0",
         "aws-sdk": "^2.1050.0",
+        "decimal.js": "^10.3.1",
         "fast-glob": "^3.2.11",
         "fs-extra": "^10.0.0",
         "fuse.js": "^6.5.3",
@@ -244,6 +245,11 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
+    },
+    "node_modules/decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
@@ -932,6 +938,11 @@
     },
     "concat-map": {
       "version": "0.0.1"
+    },
+    "decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "deprecation": {
       "version": "2.3.1"

--- a/ci/package.json
+++ b/ci/package.json
@@ -15,6 +15,7 @@
     "@octokit/rest": "^18.12.0",
     "aws-sdk": "^2.1050.0",
     "fast-glob": "^3.2.11",
+    "decimal.js": "^10.3.1",
     "fs-extra": "^10.0.0",
     "fuse.js": "^6.5.3",
     "jsonrepair": "^2.2.1",

--- a/ci/src/Foreign/S3.js
+++ b/ci/src/Foreign/S3.js
@@ -45,3 +45,17 @@ exports.putObjectImpl = function (s3, params) {
     });
   };
 };
+
+exports.deleteObjectImpl = function (s3, params) {
+  return function () {
+    return new Promise(function (resolve, reject) {
+      s3.deleteObject(params, function (err, data) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+  };
+};

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -427,12 +427,12 @@ mkMetadataRef = do
       Left err -> Aff.throwError $ Aff.error $ "Error while parsing json from " <> metadataPath <> " : " <> err
       Right r -> pure r
     let
-      fixupMetadata = do
+      metadataParsedKeys = do
         let parseKey = lmap StringParser.printParserError <<< Version.parseVersion Version.Strict
         published <- traverseKeys parseKey metadataRaw.published
         unpublished <- traverseKeys parseKey metadataRaw.unpublished
         pure $ metadataRaw { published = published, unpublished = unpublished }
-    metadata <- case fixupMetadata of
+    metadata <- case metadataParsedKeys of
       Left err -> Aff.throwError $ Aff.error $ "Error converting versions from " <> metadataPath <> " : " <> err
       Right val -> pure val
     pure $ packageName /\ metadata

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -117,7 +117,7 @@ runOperation operation = case operation of
     ifM (liftAff $ FS.exists $ metadataFile packageName)
       do
         metadata <- readPackagesMetadata >>= \packages -> case Map.lookup packageName packages of
-          Nothing -> throwWithComment "Couldn't read metadata file for your package"
+          Nothing -> throwWithComment "Couldn't read metadata file for your package.\ncc @purescript/packaging"
           Just m -> pure m
         addOrUpdate { packageName, ref: updateRef } metadata
       (throwWithComment "Metadata file should exist. Did you mean to create an Addition?")
@@ -130,7 +130,7 @@ runOperation operation = case operation of
         _ -> pure unit
 
       metadata <- readPackagesMetadata >>= \packages -> case Map.lookup packageName packages of
-        Nothing -> throwWithComment "Couldn't read metadata file for your package."
+        Nothing -> throwWithComment "Couldn't read metadata file for your package.\ncc @purescript/packaging"
         Just m -> pure m
 
       case metadata.owners of

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -18,7 +18,7 @@ import Foreign.GitHub (IssueNumber)
 import Foreign.GitHub as GitHub
 import Foreign.Node.FS as FS.Extra
 import Foreign.Object as Object
-import Foreign.SSH as SSH
+import Registry.SSH as SSH
 import Foreign.Tar as Tar
 import Foreign.Tmp as Tmp
 import Node.ChildProcess as NodeProcess

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -121,7 +121,7 @@ runOperation operation = case operation of
         addOrUpdate { packageName, ref: updateRef } metadata
       (throwWithComment "Metadata file should exist. Did you mean to create an Addition?")
 
-  Unpublish _ -> throwWithComment "Unpublish not implemented! Ask us for help!" -- TODO
+  Authenticated _ -> throwWithComment "Authenticated operations not implemented! Ask us for help!" -- TODO
 
 metadataDir :: FilePath
 metadataDir = "../metadata"

--- a/ci/src/Registry/PackageUpload.purs
+++ b/ci/src/Registry/PackageUpload.purs
@@ -11,38 +11,64 @@ import Registry.PackageName as PackageName
 import Registry.Version (Version)
 import Registry.Version as Version
 
+connect :: Aff S3.Space
+connect = do
+  let bucket = "purescript-registry"
+  log $ "Connecting to the bucket " <> show bucket
+  S3.connect "ams3.digitaloceanspaces.com" bucket
+
 type PackageInfo =
   { name :: PackageName
   , version :: Version
   }
 
+formatPackagePath :: String -> Version -> String
+formatPackagePath name version = Array.fold
+  [ name
+  , "/"
+  , Version.printVersion version
+  , ".tar.gz"
+  ]
+
 upload :: PackageInfo -> FilePath -> Aff Unit
 upload { name, version } path = do
   fileContent <- FS.readFile path
+  s3 <- connect
 
-  -- connect to the bucket
-  let bucket = "purescript-registry"
-  log $ "Connecting to the bucket " <> show bucket
-  s3 <- S3.connect "ams3.digitaloceanspaces.com" bucket
+  let
+    packageName = PackageName.print name
+    packagePath = formatPackagePath packageName version
+
+  -- check that the file for that version is there
+  publishedPackages <- map _.key <$> S3.listObjects s3 { prefix: packageName <> "/" }
+
+  if Array.elem packagePath publishedPackages then
+    -- if the release is already there we crash
+    Aff.throwError $ Aff.error $ "The package " <> show packagePath <> " already exists"
+  else do
+    -- if it's not, we upload it with public read permission
+    log $ "Uploading release to the bucket: " <> show packagePath
+    let putParams = { key: packagePath, body: fileContent, acl: S3.PublicRead }
+    void $ S3.putObject s3 putParams
+    log "Done."
+
+delete :: PackageInfo -> Aff Unit
+delete { name, version } = do
+  s3 <- connect
 
   -- check that the file for that version is there
   let
     packageName = PackageName.print name
-    filename = Array.fold
-      [ packageName
-      , "/"
-      , Version.printVersion version
-      , ".tar.gz"
-      ]
+    packagePath = formatPackagePath packageName version
 
   publishedPackages <- map _.key <$> S3.listObjects s3 { prefix: packageName <> "/" }
 
-  if Array.elem filename publishedPackages then
-    -- if the release is already there we crash
-    Aff.throwError $ Aff.error $ "The package " <> show filename <> " already exists"
-  else do
-    -- if it's not, we upload it with public read permission
-    log $ "Uploading release to the bucket: " <> show filename
-    let putParams = { key: filename, body: fileContent, acl: S3.PublicRead }
-    void $ S3.putObject s3 putParams
+  if Array.elem packagePath publishedPackages then do
+    -- if the release is already there we delete it
+    log $ "Deleting release from the bucket: " <> show packagePath
+    let deleteParams = { key: packagePath }
+    void $ S3.deleteObject s3 deleteParams
     log "Done."
+  else do
+    -- if it's not, we crash
+    Aff.throwError $ Aff.error $ "The package " <> show packagePath <> " doesn't exist."

--- a/ci/src/Registry/RegistryM.purs
+++ b/ci/src/Registry/RegistryM.purs
@@ -17,6 +17,7 @@ type Env =
   , closeIssue :: Aff Unit
   , commitToTrunk :: PackageName -> FilePath -> Aff (Either String Unit)
   , uploadPackage :: Upload.PackageInfo -> FilePath -> Aff Unit
+  , deletePackage :: Upload.PackageInfo -> Aff Unit
   , packagesMetadata :: Ref (Map PackageName Metadata)
   }
 
@@ -62,6 +63,12 @@ uploadPackage :: Upload.PackageInfo -> FilePath -> RegistryM Unit
 uploadPackage info path = do
   f <- asks _.uploadPackage
   liftAff $ f info path
+
+-- | Delete a package from the backend storage provider
+deletePackage :: Upload.PackageInfo -> RegistryM Unit
+deletePackage info = do
+  f <- asks _.deletePackage
+  liftAff $ f info
 
 -- TODO: right now we write this to file separately, but maybe it'd be better
 -- to do everything here so we don't risk to forget this?

--- a/ci/src/Registry/SSH.purs
+++ b/ci/src/Registry/SSH.purs
@@ -1,4 +1,4 @@
-module Foreign.SSH where
+module Registry.SSH where
 
 import Registry.Prelude
 

--- a/ci/src/Registry/SSH.purs
+++ b/ci/src/Registry/SSH.purs
@@ -36,8 +36,8 @@ verifyPayload owners (AuthenticatedData { email, signature, rawPayload }) = do
   sshKeygenVerify tmp = do
     let cmd = "ssh-keygen"
     let stdin = Just rawPayload
-    let args = [ "-Y", "verify", "-f allowed_signers", "-I", email, "-n", "file", "-s", "payload_signature.sig" ]
+    let args = [ "-Y", "verify", "-f", allowedSigners, "-I", email, "-n", "file", "-s", payloadSignature ]
     result <- Process.spawn { cmd, stdin, args } (NodeProcess.defaultSpawnOptions { cwd = Just tmp })
-    pure $ case result.exit of
+    pure $ bimap String.trim String.trim case result.exit of
       NodeProcess.Normally 0 -> Right result.stdout
       _ -> Left result.stderr

--- a/ci/src/Registry/SSH.purs
+++ b/ci/src/Registry/SSH.purs
@@ -1,0 +1,43 @@
+module Foreign.SSH where
+
+import Registry.Prelude
+
+import Data.Array.NonEmpty as NEA
+import Data.String as String
+import Foreign.Tmp as Tmp
+import Node.ChildProcess as NodeProcess
+import Node.FS.Aff as FS
+import Node.Path as Path
+import Registry.Schema (AuthenticatedData(..), Owner(..))
+import Sunde as Process
+
+allowedSigners :: FilePath
+allowedSigners = "allowed_signers"
+
+payloadSignature :: FilePath
+payloadSignature = "payload_signature.sig"
+
+-- Payload verification is based on this description:
+-- https://www.agwa.name/blog/post/ssh_signatures
+verifyPayload :: NonEmptyArray Owner -> AuthenticatedData -> Aff (Either String String)
+verifyPayload owners (AuthenticatedData { email, signature, rawPayload }) = do
+  tmp <- liftEffect Tmp.mkTmpDir
+  let joinWithNewlines = String.joinWith "\n"
+  let signers = joinWithNewlines $ NEA.toArray $ map formatOwner owners
+  FS.writeTextFile UTF8 (Path.concat [ tmp, allowedSigners ]) signers
+  FS.writeTextFile UTF8 (Path.concat [ tmp, payloadSignature ]) (joinWithNewlines signature)
+  -- The 'ssh-keygen' command will only exit normally if the signature verifies,
+  -- and otherwise will report an error status code.
+  sshKeygenVerify tmp
+  where
+  formatOwner (Owner owner) =
+    String.joinWith " " [ owner.email, owner.keytype, owner.public ]
+
+  sshKeygenVerify tmp = do
+    let cmd = "ssh-keygen"
+    let stdin = Just rawPayload
+    let args = [ "-Y", "verify", "-f allowed_signers", "-I", email, "-n", "file", "-s", "payload_signature.sig" ]
+    result <- Process.spawn { cmd, stdin, args } (NodeProcess.defaultSpawnOptions { cwd = Just tmp })
+    pure $ case result.exit of
+      NodeProcess.Normally 0 -> Right result.stdout
+      _ -> Left result.stderr

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -216,13 +216,14 @@ type PublishedMetadata =
   { ref :: String
   , hash :: Sha256
   , bytes :: Number
-  , timestamp :: RFC3339String
+  , publishedTime :: RFC3339String
   }
 
 type UnpublishedMetadata =
   { ref :: String
   , reason :: String
-  , timestamp :: { published :: RFC3339String, unpublished :: RFC3339String }
+  , publishedTime :: RFC3339String
+  , unpublishedTime :: RFC3339String
   }
 
 mkNewMetadata :: Location -> Metadata

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -12,11 +12,7 @@ import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Version (Range, Version)
-<<<<<<< HEAD
-import Registry.Version as Version
 import Text.Parsing.StringParser as StringParser
-=======
->>>>>>> 51acdef (Address remaining feedback)
 
 -- | PureScript encoding of ../v1/Manifest.dhall
 newtype Manifest = Manifest

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -124,6 +124,7 @@ mkEnv packagesMetadata =
       log "Skipping committing to trunk.."
       pure (Right unit)
   , uploadPackage: Upload.upload
+  , deletePackage: Upload.delete
   , packagesMetadata
   }
 

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -87,7 +87,7 @@ main = Aff.launchAff_ do
   runRegistryM (mkEnv packagesMetadataRef) do
     log "Adding metadata for reserved package names"
     forWithIndex_ reservedNames \package repo -> do
-      let metadata = { location: repo, releases: Object.empty, unpublished: Object.empty }
+      let metadata = { location: repo, owners: Nothing, releases: Object.empty, unpublished: Object.empty }
       liftAff $ Json.writeJsonFile (API.metadataFile package) metadata
       updatePackagesMetadata package metadata
 

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -87,8 +87,11 @@ main = Aff.launchAff_ do
   runRegistryM (mkEnv packagesMetadataRef) do
     log "Adding metadata for reserved package names"
     forWithIndex_ reservedNames \package repo -> do
-      let metadata = { location: repo, owners: Nothing, releases: Object.empty, unpublished: Object.empty }
-      liftAff $ Json.writeJsonFile (API.metadataFile package) metadata
+      let metadata = { location: repo, owners: Nothing, published: Map.empty, unpublished: Map.empty }
+      liftAff $ Json.writeJsonFile (API.metadataFile package) $ metadata
+        { unpublished = mapKeys Version.printVersion metadata.unpublished
+        , published = mapKeys Version.printVersion metadata.published
+        }
       updatePackagesMetadata package metadata
 
     log "Filtering out packages we already uploaded"

--- a/ci/src/Registry/Scripts/LegacyImport/Manifest.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Manifest.purs
@@ -276,7 +276,7 @@ toManifest package location version manifest = do
       -- for errors, but this is just so the types all work out.
       license <- Except.except eitherLicense
       dependencies <- Except.except eitherDependencies
-      pure $ Manifest { name: package, license, location, description, dependencies, version, files: Nothing }
+      pure $ Manifest { name: package, license, location, description, dependencies, version, owners: Nothing, files: Nothing }
 
     Just err ->
       throwError err

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -27,6 +27,7 @@ import Test.Foreign.JsonRepair as Foreign.JsonRepair
 import Test.Foreign.Licensee (licensee)
 import Test.Registry.Hash as Registry.Hash
 import Test.Registry.Index as Registry.Index
+import Test.Registry.SSH as SSH
 import Test.Registry.Scripts.LegacyImport.Stats (errorStats)
 import Test.Registry.Version (testRange, testVersion) as Version
 import Test.Spec as Spec
@@ -56,6 +57,7 @@ main = launchAff_ do
         Spec.describe "Good SPDX licenses" goodSPDXLicense
         Spec.describe "Bad SPDX licenses" badSPDXLicense
         Spec.describe "Decode GitHub event to Operation" decodeEventsToOps
+        Spec.describe "Authenticated operations" SSH.spec
       Spec.describe "Tarball" do
         removeIgnoredTarballFiles
     Spec.describe "Bowerfile" do

--- a/ci/test/Registry/SSH.purs
+++ b/ci/test/Registry/SSH.purs
@@ -5,7 +5,7 @@ import Registry.Prelude
 import Data.Array.NonEmpty as NEA
 import Data.Newtype (over)
 import Data.String as String
-import Foreign.SSH as SSH
+import Registry.SSH as SSH
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Schema (AuthenticatedData(..), AuthenticatedOperation(..), Owner(..))

--- a/ci/test/Registry/SSH.purs
+++ b/ci/test/Registry/SSH.purs
@@ -1,0 +1,134 @@
+module Test.Registry.SSH (spec) where
+
+import Registry.Prelude
+
+import Data.Array.NonEmpty as NEA
+import Data.Newtype (over)
+import Data.String as String
+import Foreign.SSH as SSH
+import Registry.PackageName (PackageName)
+import Registry.PackageName as PackageName
+import Registry.Schema (AuthenticatedData(..), AuthenticatedOperation(..), Owner(..))
+import Registry.Version (Version)
+import Registry.Version as Version
+import Test.Spec as Spec
+import Test.Spec.Assertions as Assert
+
+spec :: Spec.Spec Unit
+spec = do
+  Spec.it "Verifies correct payloads" do
+    SSH.verifyPayload (NEA.singleton validOwner) validPayload >>= case _ of
+      Left err -> Assert.fail err
+      Right _ -> mempty
+
+  Spec.it "Fails to verify when public key is incorrect" do
+    let badPublicKey = over Owner (_ { public = "" }) validOwner
+    SSH.verifyPayload (NEA.singleton badPublicKey) validPayload >>= case _ of
+      Left err -> verifyError err "allowed_signers:1: invalid key"
+      Right _ -> Assert.fail "Verified an invalid public key."
+
+  Spec.it "Fails to verify when signature is incorrect" do
+    let
+      badSignature =
+        [ "-----BEGIN SSH SIGNATURE-----"
+        , "U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgEAD8tAhhDMvn3Ydoy40uk7Ga7s"
+        , "rV9CGhaPk8UG3B5NAAAAAEZmlsZQAAAAAAAAAGc2hhNTEyAAAAUwAAAAtzc2gtZWQyNTUx"
+        , "OQAAAECB+9OSWkoZ5rHVg22oB8Ks56Jg3einV9tRw+6ypes1ZsmwdvJB2XjuvGPZG0iXdb"
+        , "/9KJFfXFSvUgP5PpuaAfkM"
+        , "-----END SSH SIGNATURE-----"
+        ]
+
+      badSignatureData = over AuthenticatedData (_ { signature = badSignature }) validPayload
+
+    SSH.verifyPayload (NEA.singleton validOwner) badSignatureData >>= case _ of
+      Left err -> verifyError err "Signature verification failed: incorrect signature"
+      Right _ -> Assert.fail "Verified an incorrect SSH signature for the payload."
+
+  Spec.it "Fails to verify when email is incorrect in authenticated data" do
+    let badEmailData = over AuthenticatedData (_ { email = "test@bar" }) validPayload
+    SSH.verifyPayload (NEA.singleton validOwner) badEmailData >>= case _ of
+      Left err -> verifyError err ""
+      Right _ -> Assert.fail "Verified with an incorrect email address."
+
+  Spec.it "Fails to verify when email is incorrect in owner field" do
+    let badEmailOwner = over Owner (_ { email = "test@bar" }) validOwner
+    SSH.verifyPayload (NEA.singleton badEmailOwner) validPayload >>= case _ of
+      Left err -> verifyError err ""
+      Right _ -> Assert.fail "Verified with an incorrect email address."
+
+  Spec.it "Fails to verify when payload is incorrect" do
+    let badRawPayload = over AuthenticatedData (_ { rawPayload = "{}" }) validPayload
+    SSH.verifyPayload (NEA.singleton validOwner) badRawPayload >>= case _ of
+      Left err -> verifyError err "Signature verification failed: incorrect signature"
+      Right _ -> Assert.fail "Verified with a modified payload."
+
+  where
+  verifyError err intended =
+    unless (err == intended) do
+      Assert.fail $ String.joinWith "\n"
+        [ "Received error message:"
+        , "  " <> err
+        , "  but expected error message:"
+        , "  " <> intended
+        ]
+
+validOwner :: Owner
+validOwner = Owner
+  { email
+  , keytype
+  , public: publicKey
+  }
+
+validPayload :: AuthenticatedData
+validPayload = AuthenticatedData
+  { email
+  , signature: rawPayloadSignature
+  , payload: Unpublish
+      { packageName
+      , unpublishVersion
+      , unpublishReason: "Committed bad credentials"
+      }
+  , rawPayload
+  }
+
+packageName :: PackageName
+packageName = unsafeFromRight $ PackageName.parse "foo"
+
+unpublishVersion :: Version
+unpublishVersion = unsafeFromRight $ Version.parseVersion Version.Strict "1.2.3"
+
+email :: String
+email = "test@foo"
+
+keytype :: String
+keytype = "ssh-ed25519"
+
+publicKey :: String
+publicKey = "AAAAC3NzaC1lZDI1NTE5AAAAIF6B6R9yp8yFM3wYcOhGO0EyZAefKWkvsTET+KeaegY/"
+
+rawPayload :: String
+rawPayload = """{ "packageName": "foo", "unpublishVersion": "1.2.3", "unpublishReason": "Committed bad credentials" }"""
+
+rawPayloadSignature :: Array String
+rawPayloadSignature =
+  [ "-----BEGIN SSH SIGNATURE-----"
+  , "U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgXoHpH3KnzIUzfBhw6EY7QTJkB5"
+  , "8paS+xMRP4p5p6Bj8AAAAEZmlsZQAAAAAAAAAGc2hhNTEyAAAAUwAAAAtzc2gtZWQyNTUx"
+  , "OQAAAED8x4+yJphe3ELjnrVZLmPct/4w0R1KBryG2NnnRLY9sjQlrjMYGp+Gx6X0PQ7ylq"
+  , "xqhPdvut0pccR4WiMDjeIC"
+  , "-----END SSH SIGNATURE-----"
+  ]
+
+{- This private key can be written to a file if to test commands manually
+
+privateKey :: Array String
+privateKey =
+  [ "-----BEGIN OPENSSH PRIVATE KEY-----"
+  , "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW"
+  , "QyNTUxOQAAACBegekfcqfMhTN8GHDoRjtBMmQHnylpL7ExE/inmnoGPwAAAJBFbMLrRWzC"
+  , "6wAAAAtzc2gtZWQyNTUxOQAAACBegekfcqfMhTN8GHDoRjtBMmQHnylpL7ExE/inmnoGPw"
+  , "AAAEByKyrnWOpHm54P8vEjlePyM+NKnEJGx74p3YTVd1V10l6B6R9yp8yFM3wYcOhGO0Ey"
+  , "ZAefKWkvsTET+KeaegY/AAAACW93bmVyQGZvbwECAwQ="
+  , "-----END OPENSSH PRIVATE KEY-----"
+  ]
+-}

--- a/ci/test/Registry/Scripts/LegacyImport/Stats.purs
+++ b/ci/test/Registry/Scripts/LegacyImport/Stats.purs
@@ -101,6 +101,7 @@ exampleStats = Stats.errorStats mockStats
                   $ set (traversed <<< _2)
                       ( Manifest
                           { license: mockLicense
+                          , owners: Nothing
                           , name: mockPackageName
                           , location: Git { subdir: Nothing, gitUrl: "https://github.com/purescript/foobar.git" }
                           , dependencies: Map.empty

--- a/ci/test/Support/Manifest.purs
+++ b/ci/test/Support/Manifest.purs
@@ -35,9 +35,9 @@ ab = { name, v1a, v1b, v2 }
     , subdir: Nothing
     }
   description = Just "some description"
-  v1a = Manifest { name, version: version1, license, location: locationWrong, dependencies, description, files: Nothing }
-  v1b = Manifest { name, version: version1, license, location, dependencies, description, files: Nothing }
-  v2 = Manifest { name, version: version2, license, location, dependencies, description, files: Nothing }
+  v1a = Manifest { name, owners: Nothing, version: version1, license, location: locationWrong, dependencies, description, files: Nothing }
+  v1b = Manifest { name, owners: Nothing, version: version1, license, location, dependencies, description, files: Nothing }
+  v2 = Manifest { name, owners: Nothing, version: version2, license, location, dependencies, description, files: Nothing }
 
 abc :: { name :: PackageName, v1 :: Manifest, v2 :: Manifest }
 abc = { name, v1, v2 }
@@ -54,8 +54,8 @@ abc = { name, v1, v2 }
     , subdir: Nothing
     }
   description = Just "some description"
-  v1 = Manifest { name, version: version1, license, location, dependencies: dependencies1, description, files: Nothing }
-  v2 = Manifest { name, version: version2, license, location, dependencies: dependencies2, description, files: Nothing }
+  v1 = Manifest { name, owners: Nothing, version: version1, license, location, dependencies: dependencies1, description, files: Nothing }
+  v2 = Manifest { name, owners: Nothing, version: version2, license, location, dependencies: dependencies2, description, files: Nothing }
 
 abcd :: { name :: PackageName, v1 :: Manifest, v2 :: Manifest }
 abcd = { name, v1, v2 }
@@ -72,5 +72,5 @@ abcd = { name, v1, v2 }
     , subdir: Nothing
     }
   description = Just "some description"
-  v1 = Manifest { name, version: version1, license, location, dependencies: dependencies1, description, files: Nothing }
-  v2 = Manifest { name, version: version2, license, location, dependencies: dependencies2, description, files: Nothing }
+  v1 = Manifest { name, owners: Nothing, version: version1, license, location, dependencies: dependencies1, description, files: Nothing }
+  v2 = Manifest { name, owners: Nothing, version: version2, license, location, dependencies: dependencies2, description, files: Nothing }

--- a/v1/Manifest.dhall
+++ b/v1/Manifest.dhall
@@ -8,9 +8,13 @@ This object holds all the info that the Registry needs to know about it.
 
 let Map = (./Prelude.dhall).Map.Type
 
+let Owner = ./Owner.dhall
+
 let Manifest =
       -- The name of the package
       { name : Text
+      -- Owners authorized to perform authenticated operations for this package
+      , owners : Optional (List Owner)
       -- A short description of the package
       , description : Optional Text
       -- The SPDX code for the license under which the code is released

--- a/v1/Metadata.dhall
+++ b/v1/Metadata.dhall
@@ -9,25 +9,31 @@ let Map = (./Prelude.dhall).Map.Type
 
 let Location = ./Location.dhall
 
+let Owner = ./Owner.dhall
+
 let SemVer = Text
+
+let RFC3339String = Text
 
 -- Information about a single published version
 let VersionMetadata =
-  {
   -- The ref this version points to (for example, a git commit)
-  , ref : Text
+  { ref : Text
   -- The hash of the source tarball fetched from the repo
   , hash : Text
   -- The size in bytes of the tarball
   , bytes : Natural
+  -- The published date of the version as an RFC3339String
+  , published : RFC3339String
   }
 
 in
-  {
   -- The pointer to where the code lives
-  , location : Location
+  { location : Location
+  -- Owners authorized to perform authenticated operations for this package
+  , owners : Optional (List Owner)
   -- A mapping between versions and info about a release
   , releases : Map SemVer VersionMetadata
   -- A mapping between a version number and the reason for unpublishing
-  , unpublished : Map Text Text
+  , unpublished : Map SemVer Text
   }

--- a/v1/Metadata.dhall
+++ b/v1/Metadata.dhall
@@ -16,15 +16,27 @@ let SemVer = Text
 let RFC3339String = Text
 
 -- Information about a single published version
-let VersionMetadata =
+let PublishedMetadata =
   -- The ref this version points to (for example, a git commit)
   { ref : Text
   -- The hash of the source tarball fetched from the repo
   , hash : Text
   -- The size in bytes of the tarball
   , bytes : Natural
-  -- The published date of the version as an RFC3339String
-  , published : RFC3339String
+  -- The published time of the version as an RFC 3339 string
+  , publishedTime : RFC3339String
+  }
+
+-- Information about a single unpublished version
+let UnpublishedMetadata =
+  -- The ref this version points to (for example, a git commit)
+  { ref : Text
+  -- The hash of the source tarball fetched from the repo
+  , reason : Text
+  -- The published date of the version as an RFC 3339 string
+  , publishedTime : RFC3339String
+  -- The published date of the version as an RFC 3339 string
+  , unpublishedTime : RFC3339String
   }
 
 in
@@ -33,7 +45,7 @@ in
   -- Owners authorized to perform authenticated operations for this package
   , owners : Optional (List Owner)
   -- A mapping between versions and info about a release
-  , releases : Map SemVer VersionMetadata
+  , published : Map SemVer PublishedMetadata
   -- A mapping between a version number and the reason for unpublishing
-  , unpublished : Map SemVer Text
+  , unpublished : Map SemVer UnpublishedMetadata
   }

--- a/v1/Operation.dhall
+++ b/v1/Operation.dhall
@@ -6,8 +6,13 @@ A type describing all the possible operations for the Registry API.
 
 let Location = ./Location.dhall
 
+-- An operation that must be signed with the key listed in the owners field of
+-- the manifest.
+let AuthenticatedOperation =
+  < Unpublish : { packageName : Text, unpublishVersion : Text, unpublishReason : Text } >
+
 in
   < Addition : { packageName : Text, newPackageLocation : Location, newRef : Text, addToPackageSet: Bool }
   | Update : { packageName : Text, updateRef : Text }
-  | Unpublish : { packageName : Text, unpublishVersion : Text, unpublishReason: Text }
+  | Authenticated : { payload : AuthenticatedOperation, signature : List Text, email : Text }
   >

--- a/v1/Operation.dhall
+++ b/v1/Operation.dhall
@@ -12,7 +12,7 @@ let AuthenticatedOperation =
   < Unpublish : { packageName : Text, unpublishVersion : Text, unpublishReason : Text } >
 
 in
-  < Addition : { packageName : Text, newPackageLocation : Location, newRef : Text, addToPackageSet: Bool }
+  < Addition : { packageName : Text, newPackageLocation : Location, newRef : Text }
   | Update : { packageName : Text, updateRef : Text }
   | Authenticated : { payload : AuthenticatedOperation, signature : List Text, email : Text }
   >

--- a/v1/Owner.dhall
+++ b/v1/Owner.dhall
@@ -1,0 +1,20 @@
+{-
+
+A package owner, described using their SSH key and associated email address. It
+is not necessary to provide a valid email address, but the email address
+provided must match the one used to sign payloads.
+
+https://man.openbsd.org/ssh-keygen#ALLOWED_SIGNERS
+
+-}
+
+let Owner =
+      -- An email address associated with a public SSH key
+      { email : Text
+      -- The type of the SSH key, e.g. ssh-rsa or ssh-ed25519
+      , keytype : Text
+      -- The public key
+      , public : Text
+      }
+
+in  Owner


### PR DESCRIPTION
I don't think this technically fixes any issues, but it relates to the conversation in #155 and implements an authorized unpublish operation as per https://github.com/purescript/registry/issues/155#issuecomment-1034142912.