### PR TITLE
Rename .purs.json to purs.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ will live on various [storage backends](#Storage-Backends).
 A `Manifest` stores all the metadata (e.g. package name, version, dependencies, etc)
 for **a specific  version** of **a specific package**.
 
-Packages are expected to version in their sources a `.purs.json` file, that conforms
+Packages are expected to version in their sources a `purs.json` file, that conforms
 to the [`Manifest` schema](./v1/Manifest.dhall) to ensure __forwards-compatibility__
 with future schemas.
 This means that new clients will be able to read old schemas, but not vice-versa.
@@ -95,7 +95,7 @@ Here we embed a copy of the `Manifest` schema for ease of consultation:
 ```dhall
 {-
 
-The schema for `.purs.json` files.
+The schema for `purs.json` files.
 
 This object holds all the info that the Registry needs to know about it.
 
@@ -369,7 +369,7 @@ I.e. the answer to the question:
 
 > How do I know which dependencies package X at version Y has?
 
-Without an index of all the package manifests you'd have to fetch the right tarball and look at its `.purs.json`.
+Without an index of all the package manifests you'd have to fetch the right tarball and look at its `purs.json`.
 
 That might be a lot of work to do at scale, and there are usecases - e.g. for package-sets - where
 we need to lookup lots of manifests to build the dependency graph.

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -163,7 +163,7 @@ addOrUpdate { ref, packageName } metadata = do
           pure { folderName: dir, published: commitDate }
 
   let absoluteFolderPath = Path.concat [ tmpDir, folderName ]
-  let manifestPath = Path.concat [ absoluteFolderPath, ".purs.json" ]
+  let manifestPath = Path.concat [ absoluteFolderPath, "purs.json" ]
 
   log $ "Package extracted in " <> absoluteFolderPath
 

--- a/v1/Manifest.dhall
+++ b/v1/Manifest.dhall
@@ -1,6 +1,6 @@
 {-
 
-The schema for `.purs.json` files.
+The schema for `purs.json` files.
 
 This object holds all the info that the Registry needs to know about it.
 


### PR DESCRIPTION
We've had the manifest format renamed to a dotfile for some time now, and it's become clear that this is going to be a hassle for many people going forward:

- The Spago [default gitignore](https://github.com/purescript/spago/blob/master/templates/gitignore) ignores `.purs*` files
- Globbing libraries often ignore dotfiles by default, so you have to explicitly include them

With this in mind, this PR renames this file back to `purs.json`.