### PR TITLE
Implement authenticated transfer operation

### DIFF
--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -141,21 +141,26 @@ instance RegistryJson Operation where
     let parseAuthenticated = Authenticated <$> Json.decode json
     parseAddition <|> parseUpdate <|> parseAuthenticated
 
-data AuthenticatedOperation = Unpublish UnpublishData
+data AuthenticatedOperation
+  = Unpublish UnpublishData
+  | Transfer TransferData
 
 derive instance Eq AuthenticatedOperation
 
 instance RegistryJson AuthenticatedOperation where
   encode = case _ of
     Unpublish fields -> Json.encode fields
+    Transfer fields -> Json.encode fields
 
   decode json = do
     let parseUnpublish = Unpublish <$> Json.decode json
-    parseUnpublish
+    let parseTransfer = Transfer <$> Json.decode json
+    parseUnpublish <|> parseTransfer
 
 instance Show AuthenticatedOperation where
   show = case _ of
     Unpublish inner -> "Unpublish (" <> show (showWithPackage inner) <> ")"
+    Transfer inner -> "Transfer (" <> show (showWithPackage inner) <> ")"
     where
     showWithPackage :: forall r. { packageName :: PackageName | r } -> { packageName :: String | r }
     showWithPackage inner =
@@ -199,6 +204,11 @@ type UnpublishData =
   { packageName :: PackageName
   , unpublishVersion :: Version
   , unpublishReason :: String
+  }
+
+type TransferData =
+  { packageName :: PackageName
+  , newPackageLocation :: Location
   }
 
 type Metadata =

--- a/v1/Operation.dhall
+++ b/v1/Operation.dhall
@@ -9,7 +9,9 @@ let Location = ./Location.dhall
 -- An operation that must be signed with the key listed in the owners field of
 -- the manifest.
 let AuthenticatedOperation =
-  < Unpublish : { packageName : Text, unpublishVersion : Text, unpublishReason : Text } >
+  < Unpublish : { packageName : Text, unpublishVersion : Text, unpublishReason : Text }
+  | Transfer : { packageName : Text, newPackageLocation : Location }
+  >
 
 in
   < Addition : { packageName : Text, newPackageLocation : Location, newRef : Text }


### PR DESCRIPTION
As per the discussion in https://github.com/purescript/registry/issues/331#issuecomment-1040992522, this implements a `Transfer` operation that allows users to transfer their package from one location to another.