### PR TITLE
Update Map JSON instance so it is usable with non-coercible keys

### DIFF
--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -535,10 +535,7 @@ readMetadata packageName { noMetadata } = do
 writeMetadata :: PackageName -> Metadata -> { commitFailed :: String -> String, commitSucceeded :: String } -> RegistryM Unit
 writeMetadata packageName metadata { commitFailed, commitSucceeded } = do
   let metadataFilePath = metadataFile packageName
-  liftAff $ Json.writeJsonFile metadataFilePath $ metadata
-    { unpublished = mapKeys Version.printVersion metadata.unpublished
-    , published = mapKeys Version.printVersion metadata.published
-    }
+  liftAff $ Json.writeJsonFile metadataFilePath metadata
   updatePackagesMetadata packageName metadata
   commitToTrunk packageName metadataFilePath >>= case _ of
     Left err -> comment (commitFailed err)

--- a/ci/src/Registry/PackageName.purs
+++ b/ci/src/Registry/PackageName.purs
@@ -10,6 +10,7 @@ import Data.List as List
 import Data.List.NonEmpty as NEL
 import Data.String as String
 import Data.String.CodeUnits (fromCharArray)
+import Registry.Json (class StringEncodable)
 import Registry.Json as Json
 import Text.Parsing.StringParser as Parser
 import Text.Parsing.StringParser.CodePoints as Parse
@@ -21,14 +22,16 @@ newtype PackageName = PackageName String
 derive newtype instance Eq PackageName
 derive newtype instance Ord PackageName
 
-instance RegistryJson PackageName where
-  encode = Json.encode <<< print
-  decode json = do
-    package <- Json.decode json
-    parse package # lmap (append "Expected PackageName: " <<< Parser.printParserError)
-
 instance Show PackageName where
   show = print
+
+instance StringEncodable PackageName where
+  toEncodableString = print
+  fromEncodableString = lmap (append "Expected PackageName: " <<< Parser.printParserError) <<< parse
+
+instance RegistryJson PackageName where
+  encode = Json.encode <<< Json.toEncodableString
+  decode = Json.fromEncodableString <=< Json.decode
 
 print :: PackageName -> String
 print (PackageName package) = package

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -12,7 +12,6 @@ import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Version (Range, Version)
-import Text.Parsing.StringParser as StringParser
 
 -- | PureScript encoding of ../v1/Manifest.dhall
 newtype Manifest = Manifest
@@ -37,13 +36,11 @@ instance RegistryJson Manifest where
     "location" := fields.location
     "owners" := fields.owners
     "description" := fields.description
-    "dependencies" := mapKeys PackageName.print fields.dependencies
+    "dependencies" := fields.dependencies
 
   decode json = do
     manifestFields <- Json.decode json
-    let parse = lmap StringParser.printParserError <<< PackageName.parse
-    parsed <- traverseKeys parse manifestFields.dependencies
-    pure $ Manifest $ manifestFields { dependencies = parsed }
+    pure $ Manifest manifestFields
 
 -- | A package owner, described using their SSH key and associated email address. It
 -- | is not necessary to provide a valid email address, but the email address

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -88,10 +88,7 @@ main = Aff.launchAff_ do
     log "Adding metadata for reserved package names"
     forWithIndex_ reservedNames \package repo -> do
       let metadata = { location: repo, owners: Nothing, published: Map.empty, unpublished: Map.empty }
-      liftAff $ Json.writeJsonFile (API.metadataFile package) $ metadata
-        { unpublished = mapKeys Version.printVersion metadata.unpublished
-        , published = mapKeys Version.printVersion metadata.published
-        }
+      liftAff $ Json.writeJsonFile (API.metadataFile package) metadata
       updatePackagesMetadata package metadata
 
     log "Filtering out packages we already uploaded"

--- a/ci/src/Registry/Scripts/LegacyImport/Error.purs
+++ b/ci/src/Registry/Scripts/LegacyImport/Error.purs
@@ -3,7 +3,7 @@ module Registry.Scripts.LegacyImport.Error where
 import Registry.Prelude
 
 import Data.Interpolate (i)
-import Registry.Json ((.:))
+import Registry.Json (class StringEncodable, (.:))
 import Registry.Json as Json
 import Registry.PackageName (PackageName)
 
@@ -20,6 +20,7 @@ newtype ImportErrorKey = ImportErrorKey String
 derive instance Newtype ImportErrorKey _
 derive newtype instance Eq ImportErrorKey
 derive newtype instance Ord ImportErrorKey
+derive newtype instance StringEncodable ImportErrorKey
 
 instance Show ImportErrorKey where
   show (ImportErrorKey key) = i "(ImportErrorKey " key ")"

--- a/ci/src/Registry/Types.purs
+++ b/ci/src/Registry/Types.purs
@@ -3,7 +3,7 @@ module Registry.Types where
 import Prelude
 
 import Data.Newtype (class Newtype)
-import Registry.Json (class RegistryJson)
+import Registry.Json (class RegistryJson, class StringEncodable)
 
 -- | An unprocessed package name, which may possibly be malformed.
 newtype RawPackageName = RawPackageName String
@@ -12,6 +12,7 @@ derive instance Newtype RawPackageName _
 derive newtype instance Eq RawPackageName
 derive newtype instance Ord RawPackageName
 derive newtype instance Show RawPackageName
+derive newtype instance StringEncodable RawPackageName
 derive newtype instance RegistryJson RawPackageName
 
 -- | An unprocessed version, taken from a GitHub tag
@@ -21,4 +22,5 @@ derive instance Newtype RawVersion _
 derive newtype instance Eq RawVersion
 derive newtype instance Ord RawVersion
 derive newtype instance Show RawVersion
+derive newtype instance StringEncodable RawVersion
 derive newtype instance RegistryJson RawVersion

--- a/ci/src/Registry/Version.purs
+++ b/ci/src/Registry/Version.purs
@@ -27,6 +27,7 @@ import Data.List.NonEmpty as NEL
 import Data.String as String
 import Data.String.CodeUnits as CodeUnits
 import Foreign.SemVer as SemVer
+import Registry.Json (class StringEncodable)
 import Registry.Json as Json
 import Text.Parsing.StringParser (ParseError, Parser)
 import Text.Parsing.StringParser as StringParser
@@ -48,14 +49,16 @@ derive instance Eq Version
 instance Ord Version where
   compare = compare `on` (\(Version v) -> [ v.major, v.minor, v.patch ])
 
-instance RegistryJson Version where
-  encode = Json.encode <<< printVersion
-  decode json = do
-    string <- Json.decode json
-    lmap StringParser.printParserError $ parseVersion Strict string
-
 instance Show Version where
   show = printVersion
+
+instance StringEncodable Version where
+  toEncodableString = printVersion
+  fromEncodableString = lmap StringParser.printParserError <<< parseVersion Strict
+
+instance RegistryJson Version where
+  encode = Json.encode <<< Json.toEncodableString
+  decode = Json.fromEncodableString <=< Json.decode
 
 major :: Version -> Int
 major (Version version) = version.major

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -101,9 +101,8 @@ manifestEncoding :: Spec.Spec Unit
 manifestEncoding = do
   let
     roundTrip (Manifest manifest) = do
-      let fields = manifest { dependencies = mapKeys PackageName.print manifest.dependencies }
       Spec.it (PackageName.print manifest.name <> " " <> Version.rawVersion manifest.version) do
-        Json.roundtrip fields `Assert.shouldContain` fields
+        Json.roundtrip manifest `Assert.shouldContain` manifest
 
   roundTrip Fixtures.ab.v1a
   roundTrip Fixtures.ab.v1b


### PR DESCRIPTION
The current `Map` instance requires that keys can be coerced to strings, because it encodes to JSON as an object (which requires string keys). However, this is a problem for frequently-used smart constructors in the codebase like `PackageName` and `Version`.

This PR replaces the `Coercible` constraint in the class with a new `StringEncodable` constraint, which is a class specifically for values that can be encoded as JSON strings (ie. which can be used as map keys when written to JSON). This removes the need to constantly call `mapKeys` and `traverseKeys` when encoding and decoding maps using smart constructors as their keys.