### PR TITLE
Add build plan to Addition and Update operations

### DIFF
--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -59,8 +59,6 @@ derive newtype instance Eq Owner
 derive newtype instance Show Owner
 derive newtype instance RegistryJson Owner
 
--- TODO: ToEncodable class
-
 -- | A compiler version and exact dependency versions that should be used to
 -- | compile a newly-uploaded package as an API verification check.
 -- |

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -12,7 +12,6 @@ import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Version (Range, Version)
-import Text.Parsing.StringParser as Parser
 
 -- | PureScript encoding of ../v1/Manifest.dhall
 newtype Manifest = Manifest
@@ -73,15 +72,8 @@ derive newtype instance Eq BuildPlan
 derive newtype instance Show BuildPlan
 
 instance RegistryJson BuildPlan where
-  encode (BuildPlan plan) =
-    Json.encode
-      { compiler: plan.compiler
-      , resolutions: mapKeys PackageName.print plan.resolutions
-      }
-  decode json = do
-    plan <- Json.decode json
-    resolutions <- traverseKeys (lmap Parser.printParserError <<< PackageName.parse) plan.resolutions
-    pure $ BuildPlan $ plan { resolutions = resolutions }
+  encode (BuildPlan plan) = Json.encode plan
+  decode = map BuildPlan <<< Json.decode
 
 type LocationData d =
   { subdir :: Maybe String

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -21,7 +21,7 @@ import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.PackageUpload as Upload
 import Registry.RegistryM (Env, readPackagesMetadata, runRegistryM, updatePackagesMetadata)
-import Registry.Schema (Manifest(..), Metadata, Operation(..), Location(..))
+import Registry.Schema (BuildPlan(..), Location(..), Manifest(..), Metadata, Operation(..))
 import Registry.Scripts.LegacyImport.Error (APIResource(..), ImportError(..), ManifestError(..), PackageFailures(..), RemoteResource(..), RequestError(..))
 import Registry.Scripts.LegacyImport.Manifest as Manifest
 import Registry.Scripts.LegacyImport.Process as Process
@@ -103,6 +103,12 @@ main = Aff.launchAff_ do
         addition = Addition
           { newPackageLocation: manifest.location
           , newRef: Version.rawVersion manifest.version
+          -- The build plan check is not used for legacy packages, so we provide
+          -- a dummy value.
+          , buildPlan: BuildPlan
+              { compiler: unsafeFromRight $ Version.parseVersion Version.Strict "0.15.0"
+              , resolutions: Map.empty
+              }
           , packageName: manifest.name
           }
       log "\n\n----------------------------------------------------------------------"

--- a/ci/test/fixtures/issue_comment.json
+++ b/ci/test/fixtures/issue_comment.json
@@ -2,7 +2,7 @@
   "action": "created",
   "comment": {
     "author_association": "MEMBER",
-    "body": "{\"packageName\":\"something\",\"updateRef\":\"v1.2.3\"}",
+    "body": "{\"packageName\":\"something\",\"updateRef\":\"v1.2.3\", \"buildPlan\": { \"compiler\": \"0.15.0\", \"resolutions\": { \"prelude\": \"1.0.0\" } } }",
     "created_at": "2021-03-09T02:03:56Z",
     "html_url": "https://github.com/purescript/registry/issues/43#issuecomment-793265839",
     "id": 793265839,

--- a/ci/test/fixtures/issue_created.json
+++ b/ci/test/fixtures/issue_created.json
@@ -5,7 +5,7 @@
     "assignee": null,
     "assignees": [],
     "author_association": "CONTRIBUTOR",
-    "body": "{\"newPackageLocation\": {\"githubOwner\": \"purescript\",\"githubRepo\": \"purescript-prelude\"},\"newRef\": \"v5.0.0\",\"packageName\": \"prelude\"}",
+    "body": "{\"newPackageLocation\": {\"githubOwner\": \"purescript\",\"githubRepo\": \"purescript-prelude\"},\"newRef\": \"v5.0.0\",\"packageName\": \"prelude\", \"buildPlan\": { \"compiler\": \"0.15.0\", \"resolutions\": { \"prelude\": \"1.0.0\" } } }",
     "closed_at": null,
     "comments": 0,
     "comments_url": "https://api.github.com/repos/purescript/registry/issues/149/comments",

--- a/v1/Operation.dhall
+++ b/v1/Operation.dhall
@@ -6,6 +6,14 @@ A type describing all the possible operations for the Registry API.
 
 let Location = ./Location.dhall
 
+-- A map of package names to package versions describing the dependencies
+-- necessary to compile this package, along with the compiler version to use.
+--
+-- The compiler version must be a non-pre-release version with no build
+-- metadata, such as '0.14.0'. Compiler versions are accepted from 0.13.0
+-- onward; earlier compilers are not supported.
+let BuildPlan = { compiler : SemVer, resolutions : Map Text SemVer }
+
 -- An operation that must be signed with the key listed in the owners field of
 -- the manifest.
 let AuthenticatedOperation =
@@ -14,7 +22,7 @@ let AuthenticatedOperation =
   >
 
 in
-  < Addition : { packageName : Text, newPackageLocation : Location, newRef : Text }
-  | Update : { packageName : Text, updateRef : Text }
+  < Addition : { packageName : Text, newPackageLocation : Location, newRef : Text, buildPlan : BuildPlan }
+  | Update : { packageName : Text, updateRef : Text, buildPlan : BuildPlan }
   | Authenticated : { payload : AuthenticatedOperation, signature : List Text, email : Text }
   >

--- a/v1/Operation.dhall
+++ b/v1/Operation.dhall
@@ -12,7 +12,7 @@ let Location = ./Location.dhall
 -- The compiler version must be a non-pre-release version with no build
 -- metadata, such as '0.14.0'. Compiler versions are accepted from 0.13.0
 -- onward; earlier compilers are not supported.
-let BuildPlan = { compiler : SemVer, resolutions : Map Text SemVer }
+let BuildPlan = { compiler : Text, resolutions : Map Text Text }
 
 -- An operation that must be signed with the key listed in the owners field of
 -- the manifest.

--- a/v1/Operation.dhall
+++ b/v1/Operation.dhall
@@ -4,6 +4,8 @@ A type describing all the possible operations for the Registry API.
 
 -}
 
+let Map = (./Prelude.dhall).Map.Type
+
 let Location = ./Location.dhall
 
 -- A map of package names to package versions describing the dependencies


### PR DESCRIPTION
As part of #360, this adds support for a `buildPlan` argument to the addition and update operations. This allows us to compile package documentation in the API and push the result to Pursuit. Without the build plan we don't have a way to produce the resolutions format the compiler requires for package publishing, other than calling out to Spago or Bower in CI (which I'd prefer not to do).