### PR TITLE
Add range inclusion helper function

### DIFF
--- a/ci/src/Registry/Version.purs
+++ b/ci/src/Registry/Version.purs
@@ -7,6 +7,7 @@ module Registry.Version
   , printVersion
   , parseVersion
   , Range
+  , rangeIncludes
   , greaterThanOrEq
   , lessThan
   , printRange
@@ -142,6 +143,10 @@ greaterThanOrEq (Range range) = range.lhs
 
 lessThan :: Range -> Version
 lessThan (Range range) = range.rhs
+
+-- | Check whether a range includes the provided version
+rangeIncludes :: Range -> Version -> Boolean
+rangeIncludes (Range { lhs, rhs }) version = version >= lhs && version < rhs
 
 rawRange :: Range -> String
 rawRange (Range range) = range.raw

--- a/ci/test/Registry/Version.purs
+++ b/ci/test/Registry/Version.purs
@@ -38,6 +38,20 @@ testVersion = do
         let parsedVersion = Version.parseVersion Lenient raw
         map Version.printVersion parsedVersion `Assert.shouldContain` parsed
 
+  Spec.describe "Range inclusion works" do
+    let unsafeVersion = unsafeFromRight <<< Version.parseVersion Version.Strict
+    let unsafeRange = unsafeFromRight <<< Version.parseRange Version.Strict
+
+    Spec.it "Lower bound satisifies" do
+      (unsafeRange ">=1.0.1 <2.0.1") `Assert.shouldSatisfy` Version.includes (unsafeVersion "1.0.1")
+
+    Spec.it "Upper bound satisifies" do
+      (unsafeRange ">=1.0.1 <2.0.1") `Assert.shouldSatisfy` Version.includes (unsafeVersion "2.0.0")
+
+    Spec.it "Out of bounds fails" do
+      (unsafeRange ">=1.0.1 <2.0.1") `Assert.shouldNotSatisfy` Version.includes (unsafeVersion "0.1.1")
+      (unsafeRange ">=1.0.1 <2.0.1") `Assert.shouldNotSatisfy` Version.includes (unsafeVersion "3.0.0")
+
 validStrictVersions :: Array String
 validStrictVersions =
   [ "0.0.0"

--- a/ci/test/Registry/Version.purs
+++ b/ci/test/Registry/Version.purs
@@ -43,14 +43,14 @@ testVersion = do
     let unsafeRange = unsafeFromRight <<< Version.parseRange Version.Strict
 
     Spec.it "Lower bound satisifies" do
-      (unsafeRange ">=1.0.1 <2.0.1") `Assert.shouldSatisfy` Version.includes (unsafeVersion "1.0.1")
+      unsafeVersion "1.0.1" `Assert.shouldSatisfy` Version.rangeIncludes (unsafeRange ">=1.0.1 <2.0.1")
 
     Spec.it "Upper bound satisifies" do
-      (unsafeRange ">=1.0.1 <2.0.1") `Assert.shouldSatisfy` Version.includes (unsafeVersion "2.0.0")
+      unsafeVersion "2.0.0" `Assert.shouldSatisfy` Version.rangeIncludes (unsafeRange ">=1.0.1 <2.0.1")
 
     Spec.it "Out of bounds fails" do
-      (unsafeRange ">=1.0.1 <2.0.1") `Assert.shouldNotSatisfy` Version.includes (unsafeVersion "0.1.1")
-      (unsafeRange ">=1.0.1 <2.0.1") `Assert.shouldNotSatisfy` Version.includes (unsafeVersion "3.0.0")
+      unsafeVersion "0.1.1" `Assert.shouldNotSatisfy` Version.rangeIncludes (unsafeRange ">=1.0.1 <2.0.1")
+      unsafeVersion "3.0.0" `Assert.shouldNotSatisfy` Version.rangeIncludes (unsafeRange ">=1.0.1 <2.0.1")
 
 validStrictVersions :: Array String
 validStrictVersions =


### PR DESCRIPTION
As part of #360, we would like to perform a verification check that the provided build plan matches with the declared dependencies in the manifest file for the package being published. For instance:

* All declared dependencies in the manifest file should be present in the build plan
* All dependency versions in the build plan should match the dependency ranges provided in the manifest

We only perform these quick checks for declared dependencies; the build plan will also include transitive dependencies. Since we don't have the user's declared dependency ranges for transitive dependencies we'll skip checking them for now.

This PR simply adds a helper function for verifying that a version is within a provided range.