### PR TITLE
Fix Eq instances for Version and Range

### DIFF
--- a/ci/src/Registry/Version.purs
+++ b/ci/src/Registry/Version.purs
@@ -128,7 +128,7 @@ newtype Range = Range
   }
 
 instance Eq Range where
-  eq (Range a) (Range b) = a.lhs == b.lhs && a.rhs == b.rhs
+  eq = eq `on` (\(Range { lhs, rhs }) -> [ lhs, rhs ])
 
 instance RegistryJson Range where
   encode = Json.encode <<< printRange

--- a/ci/src/Registry/Version.purs
+++ b/ci/src/Registry/Version.purs
@@ -44,7 +44,8 @@ newtype Version = Version
   , raw :: String
   }
 
-derive instance Eq Version
+instance Eq Version where
+  eq = eq `on` (\(Version v) -> [ v.major, v.minor, v.patch ])
 
 instance Ord Version where
   compare = compare `on` (\(Version v) -> [ v.major, v.minor, v.patch ])
@@ -126,7 +127,8 @@ newtype Range = Range
   , raw :: String
   }
 
-derive instance Eq Range
+instance Eq Range where
+  eq (Range a) (Range b) = a.lhs == b.lhs && a.rhs == b.rhs
 
 instance RegistryJson Range where
   encode = Json.encode <<< printRange


### PR DESCRIPTION
The `Version` and `Range` types use derived `Eq` instances, which will compare on all fields of the record. For example, this means that two versions `1.0.0` will not be considered equal if their parse modes were different, or their raw input strings were different. 

This PR fixes these instances to only consider the parsed versions in the equality checks.