### PR TITLE
Add Spec helper for running RegistryM

### DIFF
--- a/ci/test/RegistrySpec.purs
+++ b/ci/test/RegistrySpec.purs
@@ -1,0 +1,33 @@
+module Test.RegistrySpec where
+
+import Registry.Prelude
+
+import Data.Map as Map
+import Data.Newtype (unwrap)
+import Effect.Ref as Ref
+import Effect.Unsafe (unsafePerformEffect)
+import Registry.RegistryM (Env, RegistryM)
+import Registry.RegistryM as RegistryM
+import Test.Spec as Spec
+import Test.Spec.Reporter as Reporter
+import Test.Spec.Runner as Runner
+
+newtype RegistrySpec = RegistrySpec (Spec.SpecT RegistryM Unit Identity Unit)
+
+derive instance Newtype RegistrySpec _
+
+defaultTestEnv :: Env
+defaultTestEnv =
+  { closeIssue: mempty
+  , comment: mempty
+  , commitToTrunk: \_ _ -> pure (Right unit)
+  , deletePackage: mempty
+  , uploadPackage: mempty
+  , packagesMetadata: unsafePerformEffect (Ref.new Map.empty)
+  }
+
+toSpec :: RegistrySpec -> Spec.Spec Unit
+toSpec = Spec.hoistSpec identity (\_ -> RegistryM.runRegistryM defaultTestEnv) <<< unwrap
+
+runRegistrySpec :: RegistrySpec -> Aff Unit
+runRegistrySpec = Runner.runSpec [ Reporter.consoleReporter ] <<< toSpec


### PR DESCRIPTION
@colinwahl and I have encountered a few cases in which it would be helpful to test a function that runs in `RegistryM`. However, test specs by default run in `Aff`. This helper allows us to write specs for functions in `RegistryM` by providing a dummy environment.

Ideally we continue to limit how many functions _must_ be run in `RegistryM`, but some functions rely on things like logging and are tedious to pull apart.