### PR TITLE
CI: Add support for exercising multiple compilers

### DIFF
--- a/ci/spago.dhall
+++ b/ci/spago.dhall
@@ -43,7 +43,6 @@
   , "precise-datetime"
   , "prelude"
   , "profunctor-lenses"
-  , "psci-support"
   , "record"
   , "refs"
   , "safe-coerce"

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -19,7 +19,6 @@ import Data.Set as Set
 import Data.String as String
 import Data.Time.Duration (Hours(..))
 import Effect.Aff as Aff
-import Effect.Aff as Exn
 import Effect.Exception (throw)
 import Effect.Now as Now
 import Effect.Ref as Ref
@@ -610,7 +609,7 @@ callCompiler { version, args, cwd } = do
 
   result <- Aff.try $ Process.spawn { cmd: compiler, stdin: Nothing, args } (NodeProcess.defaultSpawnOptions { cwd = cwd })
   pure $ case result of
-    Left exception -> case Exn.message exception of
+    Left exception -> case Aff.message exception of
       errorMessage
         | errorMessage == String.joinWith " " [ "spawn", compiler, "ENOENT" ] -> Left MissingCompiler
         | otherwise -> Left $ UnknownError errorMessage

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -19,6 +19,7 @@ import Data.Set as Set
 import Data.String as String
 import Data.Time.Duration (Hours(..))
 import Effect.Aff as Aff
+import Effect.Aff as Exn
 import Effect.Exception (throw)
 import Effect.Now as Now
 import Effect.Ref as Ref
@@ -238,7 +239,7 @@ indexDir :: FilePath
 indexDir = "../registry-index"
 
 addOrUpdate :: UpdateData -> Metadata -> RegistryM Unit
-addOrUpdate { updateRef, buildPlan, packageName } inputMetadata = do
+addOrUpdate { updateRef, buildPlan: _buildPlan, packageName } inputMetadata = do
   tmpDir <- liftEffect $ Tmp.mkTmpDir
 
   -- fetch the repo and put it in the tempdir, returning the name of its toplevel dir
@@ -586,3 +587,34 @@ writeMetadata packageName metadata { commitFailed, commitSucceeded } = do
   commitToTrunk packageName metadataFilePath >>= case _ of
     Left err -> comment (commitFailed err)
     Right _ -> comment commitSucceeded
+
+-- | Call a specific version of the PureScript compiler
+callCompiler_ :: { version :: String, args :: Array String, cwd :: Maybe FilePath } -> Aff Unit
+callCompiler_ = void <<< callCompiler
+
+data CompilerFailure = UnknownError String | MissingCompiler
+
+derive instance Eq CompilerFailure
+
+-- | Call a specific version of the PureScript compiler
+callCompiler :: { version :: String, args :: Array String, cwd :: Maybe FilePath } -> Aff (Either CompilerFailure String)
+callCompiler { version, args, cwd } = do
+  let
+    -- Converts a string version 'v0.13.0' or '0.13.0' to the standard format for
+    -- executables 'purs-0_13_0'
+    compiler =
+      append "purs-"
+        $ String.replaceAll (String.Pattern ".") (String.Replacement "_")
+        $ fromMaybe version
+        $ String.stripPrefix (String.Pattern "v") version
+
+  result <- Aff.try $ Process.spawn { cmd: compiler, stdin: Nothing, args } (NodeProcess.defaultSpawnOptions { cwd = cwd })
+  pure $ case result of
+    Left exception -> case Exn.message exception of
+      errorMessage
+        | errorMessage == String.joinWith " " [ "spawn", compiler, "ENOENT" ] -> Left MissingCompiler
+        | otherwise -> Left $ UnknownError errorMessage
+    Right { exit: NodeProcess.Normally 0, stdout } ->
+      Right $ String.trim stdout
+    Right { stderr } ->
+      Left $ UnknownError $ String.trim stderr

--- a/shell.nix
+++ b/shell.nix
@@ -18,14 +18,31 @@ let
   pursPkgs = import (pkgs.fetchFromGitHub {
     owner = "justinwoo";
     repo = "easy-purescript-nix";
-    rev = "678070816270726e2f428da873fe3f2736201f42";
-    sha256 = "13l9c1sgakpmh9f23201s8d1lnv0zz0q1wsr1lc92wdpkxs9nii4";
+    rev = "86f76316f056628b3693df99ffb1120921e84902";
+    sha256 = "0qpy4j8a0782vgck6lflkw6icxfiymlck6yd4mf62ick23pf4swk";
   }) { inherit pkgs; };
 
+  # Convert a PureScript package from easy-purescript-nix (ie. pursPkgs.purs-0_14_0)
+  # into a shell script of the same name that can be executed at the command line,
+  # such as:
+  #
+  #   $ purs-0_14_0 --version
+  #   0.14.0
+  mkPurs = pursPkg:
+    let
+      stringVersion = builtins.replaceStrings ["."] ["_"] (pkgs.lib.removePrefix "v" (pkgs.lib.getVersion pursPkg));
+    in
+      pkgs.writeShellScriptBin "purs-${stringVersion}" ''
+        exec ${pursPkg}/bin/purs "$@"
+      '';
+
+
+# TODO: Upstream 0.14.9 to easy-purescritp-nix
 in pkgs.stdenv.mkDerivation {
   name = "registry";
   buildInputs = [
-    pursPkgs.purs
+    # Development build inputs
+    pursPkgs.purs-0_14_7
     pursPkgs.spago
     pursPkgs.psa
     pursPkgs.purs-tidy
@@ -41,5 +58,26 @@ in pkgs.stdenv.mkDerivation {
 
     pkgs.jq
     pkgs.licensee
+
+    # Multiple compilers available for building packages
+
+    # 0.13.x series
+    (mkPurs pursPkgs.purs-0_13_0)
+    (mkPurs pursPkgs.purs-0_13_2)
+    (mkPurs pursPkgs.purs-0_13_3)
+    (mkPurs pursPkgs.purs-0_13_4)
+    (mkPurs pursPkgs.purs-0_13_5)
+    (mkPurs pursPkgs.purs-0_13_6)
+    (mkPurs pursPkgs.purs-0_13_8)
+
+    # 0.14.x series
+    (mkPurs pursPkgs.purs-0_14_0)
+    (mkPurs pursPkgs.purs-0_14_1)
+    (mkPurs pursPkgs.purs-0_14_2)
+    (mkPurs pursPkgs.purs-0_14_3)
+    (mkPurs pursPkgs.purs-0_14_4)
+    (mkPurs pursPkgs.purs-0_14_5)
+    (mkPurs pursPkgs.purs-0_14_6)
+    (mkPurs pursPkgs.purs-0_14_7)
   ];
 }


### PR DESCRIPTION
This PR adds all the compilers available in `easy-purescript-nix` to the Nix shell so that the registry can easily call out to them. For now this is done manually, but if I were a better Nixer I'm sure we could write a function that iterates through the pursPkgs and pulls out all the available compilers. I'd like to do that in a followup PR unless it's obvious how to do it now.

This unblocks work on compiling packages for upload to Pursuit.

You can use the new `callCompiler` function to execute the compiler with some given arguments at a particular compiler version.