### PR TITLE
CI: Verify build plan in runChecks

### DIFF
--- a/ci/spago.dhall
+++ b/ci/spago.dhall
@@ -43,7 +43,6 @@
   , "precise-datetime"
   , "prelude"
   , "profunctor-lenses"
-  , "psci-support"
   , "record"
   , "refs"
   , "safe-coerce"

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -240,7 +240,7 @@ indexDir :: FilePath
 indexDir = "../registry-index"
 
 addOrUpdate :: UpdateData -> Metadata -> RegistryM Unit
-addOrUpdate { updateRef, buildPlan: _buildPlan, packageName } inputMetadata = do
+addOrUpdate { updateRef, buildPlan, packageName } inputMetadata = do
   tmpDir <- liftEffect $ Tmp.mkTmpDir
 
   -- fetch the repo and put it in the tempdir, returning the name of its toplevel dir

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -18,6 +18,8 @@ import Data.RFC3339String as RFC3339String
 import Data.Set as Set
 import Data.String as String
 import Data.Time.Duration (Hours(..))
+import Data.Tuple (uncurry)
+import Data.Tuple.Nested (type (/\))
 import Effect.Aff as Aff
 import Effect.Exception (throw)
 import Effect.Now as Now
@@ -42,11 +44,11 @@ import Registry.PackageName as PackageName
 import Registry.PackageUpload as Upload
 import Registry.RegistryM (Env, RegistryM, closeIssue, comment, commitToTrunk, deletePackage, readPackagesMetadata, runRegistryM, throwWithComment, updatePackagesMetadata, uploadPackage)
 import Registry.SSH as SSH
-import Registry.Schema (AuthenticatedData(..), AuthenticatedOperation(..), Location(..), Manifest(..), Metadata, Operation(..), UpdateData, addVersionToMetadata, isVersionInMetadata, mkNewMetadata, unpublishVersionInMetadata)
+import Registry.Schema (AuthenticatedData(..), AuthenticatedOperation(..), BuildPlan(..), Location(..), Manifest(..), Metadata, Operation(..), UpdateData, addVersionToMetadata, isVersionInMetadata, mkNewMetadata, unpublishVersionInMetadata)
 import Registry.Scripts.LegacyImport.Error (ImportError(..))
 import Registry.Scripts.LegacyImport.Manifest as Manifest
 import Registry.Types (RawPackageName(..), RawVersion(..))
-import Registry.Version (ParseMode(..), Version)
+import Registry.Version (ParseMode(..), Range, Version)
 import Registry.Version as Version
 import Sunde as Process
 import Text.Parsing.StringParser as StringParser
@@ -300,7 +302,7 @@ addOrUpdate { updateRef, buildPlan, packageName } inputMetadata = do
     metadata =
       inputMetadata { owners = manifestRecord.owners }
 
-  runChecks metadata manifest
+  runChecks buildPlan metadata manifest
 
   -- After we pass all the checks it's time to do side effects and register the package
   log "Packaging the tarball to upload..."
@@ -351,8 +353,8 @@ addOrUpdate { updateRef, buildPlan, packageName } inputMetadata = do
 -- TODO: handle addToPackageSet: we'll try to add it to the latest set and build (see #156)
 -- TODO: upload docs to pursuit (see #154)
 
-runChecks :: Metadata -> Manifest -> RegistryM Unit
-runChecks metadata (Manifest manifest) = do
+runChecks :: BuildPlan -> Metadata -> Manifest -> RegistryM Unit
+runChecks (BuildPlan buildPlan) metadata (Manifest manifest) = do
   -- TODO: collect all errors and return them at once. Note: some of the checks
   -- are going to fail while parsing from JSON, so we should move them here if we
   -- want to handle everything together
@@ -373,6 +375,65 @@ runChecks metadata (Manifest manifest) = do
   let pkgsNotInRegistry = Array.mapMaybe pkgNotInRegistry $ Set.toUnfoldable $ Map.keys manifest.dependencies
   unless (Array.null pkgsNotInRegistry) do
     throwWithComment $ "Some dependencies of your package were not found in the Registry: " <> show pkgsNotInRegistry
+
+  log "Check the submitted build plan matches the manifest"
+  let
+    dependencyUnresolved :: PackageName -> Range -> Maybe (Either (PackageName /\ Range) (PackageName /\ Range /\ Version))
+    dependencyUnresolved dependencyName dependencyRange =
+      case Map.lookup dependencyName buildPlan.resolutions of
+        -- If the package is missing from the build plan then the plan is incorrect.
+        Nothing -> Just $ Left $ dependencyName /\ dependencyRange
+        -- If the package exists, but the version is not in the manifest range
+        -- then the build plan is incorrect. Otherwise, this part of the build
+        -- plan is correct.
+        Just version
+          | not (Version.rangeIncludes dependencyRange version) -> Just $ Right $ dependencyName /\ dependencyRange /\ version
+          | otherwise -> Nothing
+
+    unresolvedDependencies =
+      Array.mapMaybe (uncurry dependencyUnresolved) (Map.toUnfoldable manifest.dependencies)
+
+  unless (Array.null unresolvedDependencies) do
+    let
+      { fail: missingPackages, success: incorrectVersions } = partitionEithers unresolvedDependencies
+
+      printPackageRange (name /\ range) = Array.fold
+        [ "`"
+        , PackageName.print name
+        , "` in range `"
+        , Version.printRange range
+        , "`"
+        ]
+
+      missingPackagesError = do
+        guardA (not Array.null missingPackages)
+        pure
+          $ String.joinWith "\n  - "
+          $ Array.cons "The build plan is missing dependencies that are listed in the manifest:"
+          $ map printPackageRange missingPackages
+
+      printPackageVersion (name /\ range /\ version) = Array.fold
+        [ "`"
+        , PackageName.print name
+        , "@"
+        , Version.printVersion version
+        , "` does not satisfy range `"
+        , Version.printRange range
+        , "`"
+        ]
+
+      incorrectVersionsError = do
+        guardA (not Array.null incorrectVersions)
+        pure
+          $ String.joinWith "\n  - "
+          $ Array.cons "The build plan provides dependencies at versions outside the range listed in the manifest:"
+          $ map printPackageVersion incorrectVersions
+
+    throwWithComment $ String.joinWith "\n\n" $ Array.catMaybes
+      [ Just "All dependencies from the manifest must be in the build plan at valid versions."
+      , missingPackagesError
+      , incorrectVersionsError
+      ]
 
 wget :: String -> String -> RegistryM Unit
 wget url path = do

--- a/ci/src/Registry/Prelude.purs
+++ b/ci/src/Registry/Prelude.purs
@@ -13,11 +13,13 @@ module Registry.Prelude
   , unsafeFromRight
   , mapKeys
   , traverseKeys
+  , guardA
   ) where
 
 import Prelude
 
 import Control.Alt ((<|>)) as Extra
+import Control.Alternative (class Alternative, empty)
 import Control.Monad.Error.Class (throwError) as Extra
 import Control.Monad.Except (ExceptT(..)) as Extra
 import Control.Monad.Trans.Class (lift) as Extra
@@ -99,3 +101,6 @@ mapKeys k = Map.fromFoldable <<< map (Extra.lmap k) <<< (Map.toUnfoldable :: _ -
 
 traverseKeys :: forall a b v. Ord a => Ord b => (a -> Either.Either String b) -> Extra.Map a v -> Either.Either String (Extra.Map b v)
 traverseKeys k = map Map.fromFoldable <<< Extra.traverse (ltraverse k) <<< (Map.toUnfoldable :: _ -> Array _)
+
+guardA :: forall f. Alternative f => Boolean -> f Unit
+guardA = if _ then pure unit else empty


### PR DESCRIPTION
This PR adds a verification check to ensure that a user's submitted build plan corresponds with their submitted manifest. If all dependencies present in the manifest are not also present in the build plan and at a version within the supplied range, then we'll reject the package. This ensures that the build plan and manifest are not out of sync, and that when we build the package we're using dependencies that are actually listed in the manifest.

This is part of the work towards building packages in CI.