### PR TITLE
CI: Standardize on no use of instance names

### DIFF
--- a/ci/src/Foreign/SPDX.purs
+++ b/ci/src/Foreign/SPDX.purs
@@ -16,7 +16,7 @@ import Safe.Coerce (coerce)
 -- | An SPDX license identifier such as 'MIT' or 'Apache-2.0'.
 newtype License = License String
 
-derive newtype instance eqLicense :: Eq License
+derive newtype instance Eq License
 
 instance RegistryJson License where
   encode = Json.encode <<< print

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -84,10 +84,10 @@ data OperationDecoding
   | MalformedJson IssueNumber String
   | DecodedOperation IssueNumber Operation
 
-derive instance eqOperationDecoding :: Eq OperationDecoding
-derive instance genericOperationDecoding :: Generic.Generic OperationDecoding _
+derive instance Eq OperationDecoding
+derive instance Generic.Generic OperationDecoding _
 
-instance showOperationDecoding :: Show OperationDecoding where
+instance Show OperationDecoding where
   show = genericShow
 
 readOperation :: FilePath -> Aff OperationDecoding

--- a/ci/src/Registry/Json.purs
+++ b/ci/src/Registry/Json.purs
@@ -141,7 +141,7 @@ class RegistryJson a where
   encode :: a -> Core.Json
   decode :: Core.Json -> Either String a
 
-instance decodeJsonJson :: RegistryJson Core.Json where
+instance RegistryJson Core.Json where
   encode = identity
   decode = Right
 

--- a/ci/src/Registry/RegistryM.purs
+++ b/ci/src/Registry/RegistryM.purs
@@ -23,17 +23,17 @@ type Env =
 
 newtype RegistryM a = RegistryM (ReaderT Env Aff a)
 
-derive instance newtypeRegistryM :: Newtype (RegistryM a) _
+derive instance Newtype (RegistryM a) _
 
-derive newtype instance functorRegistryM :: Functor RegistryM
-derive newtype instance applyRegistryM :: Apply RegistryM
-derive newtype instance applicativeRegistryM :: Applicative RegistryM
-derive newtype instance bindRegistryM :: Bind RegistryM
-derive newtype instance monadRegistryM :: Monad RegistryM
-derive newtype instance monadEffectRegistryM :: MonadEffect RegistryM
-derive newtype instance monadAffRegistryM :: MonadAff RegistryM
-derive newtype instance monadErrorRegistryM :: MonadThrow Error RegistryM
-derive newtype instance monadAskRegistryM :: MonadAsk Env RegistryM
+derive newtype instance Functor RegistryM
+derive newtype instance Apply RegistryM
+derive newtype instance Applicative RegistryM
+derive newtype instance Bind RegistryM
+derive newtype instance Monad RegistryM
+derive newtype instance MonadEffect RegistryM
+derive newtype instance MonadAff RegistryM
+derive newtype instance MonadThrow Error RegistryM
+derive newtype instance MonadAsk Env RegistryM
 
 runRegistryM :: forall a. Env -> RegistryM a -> Aff a
 runRegistryM env (RegistryM m) = runReaderT m env

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -130,11 +130,11 @@ data Operation
   | Update UpdateData
   | Authenticated AuthenticatedData
 
-derive instance eqOperation :: Eq Operation
+derive instance Eq Operation
 
-derive instance genericOperation :: Generic.Generic Operation _
+derive instance Generic.Generic Operation _
 
-instance showOperation :: Show Operation where
+instance Show Operation where
   show = case _ of
     Addition inner -> "Addition (" <> show (showWithPackage inner) <> ")"
     Update inner -> "Update (" <> show (showWithPackage inner) <> ")"


### PR DESCRIPTION
While working on something unrelated, I noticed that we're inconsistent about using explicit instance names vs. generated instance names in the codebase. Since most of the time we use generated names, I've standardized on that.