### PR TITLE
CI: Regenerate the metadata directory

### DIFF
--- a/metadata/accounting.json
+++ b/metadata/accounting.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "ascjones",
+    "githubRepo": "purescript-accounting"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/affjax-node.json
+++ b/metadata/affjax-node.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "purescript-contrib",
+    "githubRepo": "purescript-affjax-node"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/affjax-web.json
+++ b/metadata/affjax-web.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "purescript-contrib",
+    "githubRepo": "purescript-affjax-web"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/ajax.json
+++ b/metadata/ajax.json
@@ -3,6 +3,6 @@
     "githubOwner": "joneshf",
     "githubRepo": "purescript-ajax"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/algebra.json
+++ b/metadata/algebra.json
@@ -3,6 +3,6 @@
     "githubOwner": "joneshf",
     "githubRepo": "purescript-algebra"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/angular.json
+++ b/metadata/angular.json
@@ -3,6 +3,6 @@
     "githubOwner": "ethul",
     "githubRepo": "purescript-angular"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/apparch.json
+++ b/metadata/apparch.json
@@ -3,6 +3,6 @@
     "githubOwner": "agrafix",
     "githubRepo": "purescript-apparch"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/arb-instances.json
+++ b/metadata/arb-instances.json
@@ -3,6 +3,6 @@
     "githubOwner": "purescript",
     "githubRepo": "purescript-arb-instances"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/array-shuffle.json
+++ b/metadata/array-shuffle.json
@@ -3,6 +3,6 @@
     "githubOwner": "dgendill",
     "githubRepo": "purescript-array-shuffle"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/asap.json
+++ b/metadata/asap.json
@@ -3,6 +3,6 @@
     "githubOwner": "bodil",
     "githubRepo": "purescript-asap"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/aws.json
+++ b/metadata/aws.json
@@ -3,6 +3,6 @@
     "githubOwner": "dysinger",
     "githubRepo": "purescript-aws"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/backtrack.json
+++ b/metadata/backtrack.json
@@ -3,6 +3,6 @@
     "githubOwner": "juspay",
     "githubRepo": "purescript-backtrack"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/barbies.json
+++ b/metadata/barbies.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "the-dr-lazy",
+    "githubRepo": "purescript-barbies"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/base64.json
+++ b/metadata/base64.json
@@ -3,6 +3,6 @@
     "githubOwner": "Thimoteus",
     "githubRepo": "purescript-base64"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/batteries-env.json
+++ b/metadata/batteries-env.json
@@ -3,6 +3,6 @@
     "githubOwner": "purescript-polyform",
     "githubRepo": "batteries-env"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/batteries-json.json
+++ b/metadata/batteries-json.json
@@ -3,6 +3,6 @@
     "githubOwner": "purescript-polyform",
     "githubRepo": "batteries-json"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/batteries-urlencoded.json
+++ b/metadata/batteries-urlencoded.json
@@ -3,6 +3,6 @@
     "githubOwner": "purescript-polyform",
     "githubRepo": "batteries-urlencoded"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/bcrypt.json
+++ b/metadata/bcrypt.json
@@ -3,6 +3,6 @@
     "githubOwner": "VFabricio",
     "githubRepo": "purescript-bcrypt"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/big-integer.json
+++ b/metadata/big-integer.json
@@ -3,6 +3,6 @@
     "githubOwner": "athanclark",
     "githubRepo": "purescript-big-integer"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/blueprint.json
+++ b/metadata/blueprint.json
@@ -3,6 +3,6 @@
     "githubOwner": "atomicits",
     "githubRepo": "purescript-blueprint"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/browser-sniffer.json
+++ b/metadata/browser-sniffer.json
@@ -1,8 +1,0 @@
-{
-  "location": {
-    "githubOwner": "CapillarySoftware",
-    "githubRepo": "purescript-browser-sniffer"
-  },
-  "releases": {},
-  "unpublished": {}
-}

--- a/metadata/channels.json
+++ b/metadata/channels.json
@@ -3,6 +3,6 @@
     "githubOwner": "purescript-deprecated",
     "githubRepo": "purescript-channels"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/chosen-halogen.json
+++ b/metadata/chosen-halogen.json
@@ -3,6 +3,6 @@
     "githubOwner": "michael-swan",
     "githubRepo": "purescript-chosen-halogen"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/chosen.json
+++ b/metadata/chosen.json
@@ -3,6 +3,6 @@
     "githubOwner": "michael-swan",
     "githubRepo": "purescript-chosen"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/clappr-pux.json
+++ b/metadata/clappr-pux.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "paluh",
+    "githubRepo": "purescript-pux-clappr"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/client-ajax.json
+++ b/metadata/client-ajax.json
@@ -3,6 +3,6 @@
     "githubOwner": "wfaler",
     "githubRepo": "purescript-jquery-ajax"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/client-routing.json
+++ b/metadata/client-routing.json
@@ -3,6 +3,6 @@
     "githubOwner": "philopon",
     "githubRepo": "purescript-client-routing"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/codec-ejson.json
+++ b/metadata/codec-ejson.json
@@ -3,6 +3,6 @@
     "githubOwner": "slamdata",
     "githubRepo": "purescript-codec-ejson"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/combinators.json
+++ b/metadata/combinators.json
@@ -3,6 +3,6 @@
     "githubOwner": "awkure",
     "githubRepo": "purescript-combinators"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/constraint-kanren.json
+++ b/metadata/constraint-kanren.json
@@ -3,6 +3,6 @@
     "githubOwner": "raduom",
     "githubRepo": "purescript-constraint-kanren"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/cookies.json
+++ b/metadata/cookies.json
@@ -3,6 +3,6 @@
     "githubOwner": "dbushenko",
     "githubRepo": "purescript-cookies"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/csv-rk.json
+++ b/metadata/csv-rk.json
@@ -3,6 +3,6 @@
     "githubOwner": "robkuz",
     "githubRepo": "purescript-csv"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/datareify.json
+++ b/metadata/datareify.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "alexknvl",
+    "githubRepo": "purescript-datareify"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/dom-keyboard.json
+++ b/metadata/dom-keyboard.json
@@ -3,6 +3,6 @@
     "githubOwner": "slamdata",
     "githubRepo": "purescript-dom-keyboard"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/domparser.json
+++ b/metadata/domparser.json
@@ -1,8 +1,0 @@
-{
-  "location": {
-    "githubOwner": "Fresheyeball",
-    "githubRepo": "purescript-DOMParser"
-  },
-  "releases": {},
-  "unpublished": {}
-}

--- a/metadata/dynamic.json
+++ b/metadata/dynamic.json
@@ -3,6 +3,6 @@
     "githubOwner": "raduom",
     "githubRepo": "purescript-dynamic"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/elm-basics.json
+++ b/metadata/elm-basics.json
@@ -3,6 +3,6 @@
     "githubOwner": "brainrape",
     "githubRepo": "purescript-elm-basics"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/enchantjs.json
+++ b/metadata/enchantjs.json
@@ -3,6 +3,6 @@
     "githubOwner": "algas",
     "githubRepo": "purescript-enchantjs"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/endpoints-express.json
+++ b/metadata/endpoints-express.json
@@ -3,6 +3,6 @@
     "githubOwner": "FrigoEU",
     "githubRepo": "purescript-endpoints-express"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/endpoints-websocket.json
+++ b/metadata/endpoints-websocket.json
@@ -3,6 +3,6 @@
     "githubOwner": "FrigoEU",
     "githubRepo": "purescript-endpoints-websocket"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/envparse.json
+++ b/metadata/envparse.json
@@ -3,6 +3,6 @@
     "githubOwner": "srghma",
     "githubRepo": "purescript-envparse"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/events.json
+++ b/metadata/events.json
@@ -3,6 +3,6 @@
     "githubOwner": "CapillarySoftware",
     "githubRepo": "purescript-events"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/execa.json
+++ b/metadata/execa.json
@@ -3,6 +3,6 @@
     "githubOwner": "ethul",
     "githubRepo": "purescript-execa"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/ffi-options.json
+++ b/metadata/ffi-options.json
@@ -3,6 +3,6 @@
     "githubOwner": "ursi",
     "githubRepo": "purescript-ffi-options"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/flow.json
+++ b/metadata/flow.json
@@ -3,6 +3,6 @@
     "githubOwner": "juspay",
     "githubRepo": "purescript-flow"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/flux-store.json
+++ b/metadata/flux-store.json
@@ -3,6 +3,6 @@
     "githubOwner": "KolesnichenkoDS",
     "githubRepo": "purescript-flux-store"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/focus-ui.json
+++ b/metadata/focus-ui.json
@@ -3,6 +3,6 @@
     "githubOwner": "mbid",
     "githubRepo": "purescript-focus-ui"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/foreign-callbacks.json
+++ b/metadata/foreign-callbacks.json
@@ -3,6 +3,6 @@
     "githubOwner": "fluffynukeit",
     "githubRepo": "purescript-foreign-callbacks"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/foreign-helpers.json
+++ b/metadata/foreign-helpers.json
@@ -3,6 +3,6 @@
     "githubOwner": "adarqui",
     "githubRepo": "purescript-foreign-helpers"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/foreign-options.json
+++ b/metadata/foreign-options.json
@@ -3,6 +3,6 @@
     "githubOwner": "fluffynukeit",
     "githubRepo": "purescript-foreign-options"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/formulate.json
+++ b/metadata/formulate.json
@@ -3,6 +3,6 @@
     "githubOwner": "garyb",
     "githubRepo": "purescript-formulate"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/function-checked.json
+++ b/metadata/function-checked.json
@@ -3,6 +3,6 @@
     "githubOwner": "ddfisher",
     "githubRepo": "purescript-function-checked"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/fussy.json
+++ b/metadata/fussy.json
@@ -3,6 +3,6 @@
     "githubOwner": "garyb",
     "githubRepo": "purescript-fussy"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/generic-graphviz.json
+++ b/metadata/generic-graphviz.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "csicar",
+    "githubRepo": "purescript-generic-graphviz"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/globals-safe.json
+++ b/metadata/globals-safe.json
@@ -3,6 +3,6 @@
     "githubOwner": "nsaunders",
     "githubRepo": "purescript-globals-safe"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/google-auth.json
+++ b/metadata/google-auth.json
@@ -3,6 +3,6 @@
     "githubOwner": "FrigoEU",
     "githubRepo": "purescript-google-auth"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/graphviz.json
+++ b/metadata/graphviz.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "csicar",
+    "githubRepo": "purescript-graphviz"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/halogen-html-component.json
+++ b/metadata/halogen-html-component.json
@@ -3,6 +3,6 @@
     "githubOwner": "garyb",
     "githubRepo": "purescript-halogen-html-component"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/halogen-monaco.json
+++ b/metadata/halogen-monaco.json
@@ -3,6 +3,6 @@
     "githubOwner": "maxhillaert",
     "githubRepo": "purescript-halogen-monaco"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/halogen-svg.json
+++ b/metadata/halogen-svg.json
@@ -3,6 +3,6 @@
     "githubOwner": "AidanDelaney",
     "githubRepo": "purescript-halogen-svg"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/hashable.json
+++ b/metadata/hashable.json
@@ -3,6 +3,6 @@
     "githubOwner": "paf31",
     "githubRepo": "purescript-hashable"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/hedwig.json
+++ b/metadata/hedwig.json
@@ -3,6 +3,6 @@
     "githubOwner": "utkarshkukreti",
     "githubRepo": "purescript-hedwig"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/hertz.json
+++ b/metadata/hertz.json
@@ -3,6 +3,6 @@
     "githubOwner": "utkarshkukreti",
     "githubRepo": "purescript-hertz"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/hibachi.json
+++ b/metadata/hibachi.json
@@ -3,6 +3,6 @@
     "githubOwner": "justinwoo",
     "githubRepo": "purescript-kushikatsu"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/history.json
+++ b/metadata/history.json
@@ -3,6 +3,6 @@
     "githubOwner": "CapillarySoftware",
     "githubRepo": "purescript-history"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/http-headers.json
+++ b/metadata/http-headers.json
@@ -3,6 +3,6 @@
     "githubOwner": "garyb",
     "githubRepo": "purescript-http-headers"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/hubot.json
+++ b/metadata/hubot.json
@@ -3,6 +3,6 @@
     "githubOwner": "mcoffin",
     "githubRepo": "purescript-hubot"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/in-purescript.json
+++ b/metadata/in-purescript.json
@@ -3,6 +3,6 @@
     "githubOwner": "purescript",
     "githubRepo": "purescript-in-purescript"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/io.json
+++ b/metadata/io.json
@@ -3,6 +3,6 @@
     "githubOwner": "slamdata",
     "githubRepo": "purescript-io"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/ips.json
+++ b/metadata/ips.json
@@ -3,6 +3,6 @@
     "githubOwner": "chrisdotcode",
     "githubRepo": "purescript-ips"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/jquery-ajax.json
+++ b/metadata/jquery-ajax.json
@@ -3,6 +3,6 @@
     "githubOwner": "wfaler",
     "githubRepo": "purescript-jquery-ajax"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/json.json
+++ b/metadata/json.json
@@ -3,6 +3,6 @@
     "githubOwner": "garyb",
     "githubRepo": "purescript-json"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/keys.json
+++ b/metadata/keys.json
@@ -3,6 +3,6 @@
     "githubOwner": "slamdata",
     "githubRepo": "purescript-keys"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/language-purescript-parser-lexer.json
+++ b/metadata/language-purescript-parser-lexer.json
@@ -3,6 +3,6 @@
     "githubOwner": "cdepillabout",
     "githubRepo": "purescript-language-purescript-parser-lexer"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/leaflet.json
+++ b/metadata/leaflet.json
@@ -3,6 +3,6 @@
     "githubOwner": "dysinger",
     "githubRepo": "purescript-leaflet"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/mailgun.json
+++ b/metadata/mailgun.json
@@ -3,6 +3,6 @@
     "githubOwner": "piq9117",
     "githubRepo": "purescript-mailgun"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/markup-incdom.json
+++ b/metadata/markup-incdom.json
@@ -3,6 +3,6 @@
     "githubOwner": "zrho",
     "githubRepo": "purescript-markup-incdom"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/markup.json
+++ b/metadata/markup.json
@@ -3,6 +3,6 @@
     "githubOwner": "zrho",
     "githubRepo": "purescript-markup"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/mathjs.json
+++ b/metadata/mathjs.json
@@ -3,6 +3,6 @@
     "githubOwner": "robkuz",
     "githubRepo": "purescript-mathjs"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/mdcss.json
+++ b/metadata/mdcss.json
@@ -3,6 +3,6 @@
     "githubOwner": "askasp",
     "githubRepo": "purescript-mdcss"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/moment.json
+++ b/metadata/moment.json
@@ -1,8 +1,0 @@
-{
-  "location": {
-    "githubOwner": "CapillarySoftware",
-    "githubRepo": "purescript-moment"
-  },
-  "releases": {},
-  "unpublished": {}
-}

--- a/metadata/monaco.json
+++ b/metadata/monaco.json
@@ -3,6 +3,6 @@
     "githubOwner": "maxhillaert",
     "githubRepo": "purescript-monaco"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/monad-fix.json
+++ b/metadata/monad-fix.json
@@ -3,6 +3,6 @@
     "githubOwner": "zrho",
     "githubRepo": "purescript-monad-fix"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/neodoc-parsing.json
+++ b/metadata/neodoc-parsing.json
@@ -3,6 +3,6 @@
     "githubOwner": "felixSchl",
     "githubRepo": "purescript-neodoc-parsing"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/node-args.json
+++ b/metadata/node-args.json
@@ -3,6 +3,6 @@
     "githubOwner": "purescript",
     "githubRepo": "purescript-node-args"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/node-datagrams.json
+++ b/metadata/node-datagrams.json
@@ -3,6 +3,6 @@
     "githubOwner": "jliuhtonen",
     "githubRepo": "purescript-node-datagrams"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/node-fs-aff-extra.json
+++ b/metadata/node-fs-aff-extra.json
@@ -3,6 +3,6 @@
     "githubOwner": "dgendill",
     "githubRepo": "purescript-node-fs-aff-extra"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/node-github.json
+++ b/metadata/node-github.json
@@ -3,6 +3,6 @@
     "githubOwner": "obmarg",
     "githubRepo": "purescript-node-github"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/node-readline-question.json
+++ b/metadata/node-readline-question.json
@@ -3,6 +3,6 @@
     "githubOwner": "i-am-tom",
     "githubRepo": "purescript-node-readline-question"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/noms.json
+++ b/metadata/noms.json
@@ -3,6 +3,6 @@
     "githubOwner": "yjpark",
     "githubRepo": "purescript-noms"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/nunjucks.json
+++ b/metadata/nunjucks.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "plippe",
+    "githubRepo": "purescript-nunjucks"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/openwhisk.json
+++ b/metadata/openwhisk.json
@@ -3,6 +3,6 @@
     "githubOwner": "yjpark",
     "githubRepo": "purescript-openwhisk"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/optic-ui.json
+++ b/metadata/optic-ui.json
@@ -3,6 +3,6 @@
     "githubOwner": "zrho",
     "githubRepo": "purescript-optic-ui"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/org.json
+++ b/metadata/org.json
@@ -3,6 +3,6 @@
     "githubOwner": "birdgg",
     "githubRepo": "purescript-org"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/parsing-extras.json
+++ b/metadata/parsing-extras.json
@@ -3,6 +3,6 @@
     "githubOwner": "dgendill",
     "githubRepo": "purescript-parsing-extras"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/parsing-foreign.json
+++ b/metadata/parsing-foreign.json
@@ -3,6 +3,6 @@
     "githubOwner": "markfarrell",
     "githubRepo": "purescript-parsing-foreign"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/phantomjs.json
+++ b/metadata/phantomjs.json
@@ -3,6 +3,6 @@
     "githubOwner": "cxfreeio",
     "githubRepo": "purescript-phantomjs"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/photons.json
+++ b/metadata/photons.json
@@ -3,6 +3,6 @@
     "githubOwner": "slamdata",
     "githubRepo": "purescript-photons"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/plaid-node.json
+++ b/metadata/plaid-node.json
@@ -3,6 +3,6 @@
     "githubOwner": "piq9117",
     "githubRepo": "purescript-plaid-node"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/plottable.json
+++ b/metadata/plottable.json
@@ -3,6 +3,6 @@
     "githubOwner": "atomicits",
     "githubRepo": "purescript-plottable"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/pouchdb-ffi.json
+++ b/metadata/pouchdb-ffi.json
@@ -3,6 +3,6 @@
     "githubOwner": "fehrenbach",
     "githubRepo": "purescript-pouchdb-ffi"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/presto-backend.json
+++ b/metadata/presto-backend.json
@@ -3,6 +3,6 @@
     "githubOwner": "juspay",
     "githubRepo": "purescript-presto-backend"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/proact.json
+++ b/metadata/proact.json
@@ -3,6 +3,6 @@
     "githubOwner": "alvart",
     "githubRepo": "purescript-proact"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/pspec.json
+++ b/metadata/pspec.json
@@ -3,6 +3,6 @@
     "githubOwner": "philopon",
     "githubRepo": "purescript-pspec"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/pux-clappr.json
+++ b/metadata/pux-clappr.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "paluh",
+    "githubRepo": "purescript-pux-clappr"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/pux-router.json
+++ b/metadata/pux-router.json
@@ -3,6 +3,6 @@
     "githubOwner": "alvart",
     "githubRepo": "purescript-pux-router"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/pux-undo.json
+++ b/metadata/pux-undo.json
@@ -3,6 +3,6 @@
     "githubOwner": "parsonsmatt",
     "githubRepo": "purescript-pux-undo"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/qrcode-js.json
+++ b/metadata/qrcode-js.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "narinari",
+    "githubRepo": "purescript-qrcode-js"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/ractive.json
+++ b/metadata/ractive.json
@@ -1,8 +1,0 @@
-{
-  "location": {
-    "githubOwner": "brakmic",
-    "githubRepo": "purescript-ractive"
-  },
-  "releases": {},
-  "unpublished": {}
-}

--- a/metadata/radix64.json
+++ b/metadata/radix64.json
@@ -3,6 +3,6 @@
     "githubOwner": "PipocaQuemada",
     "githubRepo": "purescript-radix64"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/react-native.json
+++ b/metadata/react-native.json
@@ -3,6 +3,6 @@
     "githubOwner": "hoodunit",
     "githubRepo": "purescript-react-native"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/react-simpleaction.json
+++ b/metadata/react-simpleaction.json
@@ -3,6 +3,6 @@
     "githubOwner": "doolse",
     "githubRepo": "purescript-react-simpleaction"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/react-toolbox.json
+++ b/metadata/react-toolbox.json
@@ -3,6 +3,6 @@
     "githubOwner": "AlexKovalevych",
     "githubRepo": "purescript-react-toolbox"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/reactive-jquery.json
+++ b/metadata/reactive-jquery.json
@@ -3,6 +3,6 @@
     "githubOwner": "purescript",
     "githubRepo": "purescript-reactive-jquery"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/reactive.json
+++ b/metadata/reactive.json
@@ -3,6 +3,6 @@
     "githubOwner": "purescript",
     "githubRepo": "purescript-reactive"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/rnx.json
+++ b/metadata/rnx.json
@@ -3,6 +3,6 @@
     "githubOwner": "atomicits",
     "githubRepo": "purescript-rnx"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/rotjs.json
+++ b/metadata/rotjs.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "fros1y",
+    "githubRepo": "purescript-rotjs"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/router.json
+++ b/metadata/router.json
@@ -3,6 +3,6 @@
     "githubOwner": "dbushenko",
     "githubRepo": "purescript-router"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/screeps.json
+++ b/metadata/screeps.json
@@ -3,6 +3,6 @@
     "githubOwner": "hoodunit",
     "githubRepo": "purescript-screeps"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/sequelize.json
+++ b/metadata/sequelize.json
@@ -3,6 +3,6 @@
     "githubOwner": "athanclark",
     "githubRepo": "purescript-sequelize"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/sequential-aff-coroutines.json
+++ b/metadata/sequential-aff-coroutines.json
@@ -3,6 +3,6 @@
     "githubOwner": "beckyconning",
     "githubRepo": "purescript-sequential-aff-coroutines"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/sigment.json
+++ b/metadata/sigment.json
@@ -3,6 +3,6 @@
     "githubOwner": "ptol",
     "githubRepo": "purescript-sigment"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/signature-pad.json
+++ b/metadata/signature-pad.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "narinari",
+    "githubRepo": "purescript-signature-pad"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/simple-dom-generated.json
+++ b/metadata/simple-dom-generated.json
@@ -3,6 +3,6 @@
     "githubOwner": "aktowns",
     "githubRepo": "purescript-simple-dom-generated"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/simple-templates.json
+++ b/metadata/simple-templates.json
@@ -3,6 +3,6 @@
     "githubOwner": "jacereda",
     "githubRepo": "purescript-simple-templates"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/slack.json
+++ b/metadata/slack.json
@@ -3,6 +3,6 @@
     "githubOwner": "saksdirect",
     "githubRepo": "purescript-slack"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/slides-remember.json
+++ b/metadata/slides-remember.json
@@ -3,6 +3,6 @@
     "githubOwner": "soupi",
     "githubRepo": "purescript-slides-remember"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/slides.json
+++ b/metadata/slides.json
@@ -3,6 +3,6 @@
     "githubOwner": "soupi",
     "githubRepo": "purescript-slides"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/social-icons.json
+++ b/metadata/social-icons.json
@@ -3,6 +3,6 @@
     "githubOwner": "athanclark",
     "githubRepo": "purescript-social-icons"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/socketio-2.json
+++ b/metadata/socketio-2.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "athanclark",
+    "githubRepo": "purescript-socketio"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/socketio.json
+++ b/metadata/socketio.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "commandodev",
+    "githubRepo": "purescript-socketio"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/solc.json
+++ b/metadata/solc.json
@@ -1,8 +1,0 @@
-{
-  "location": {
-    "githubOwner": "f-o-a-m",
-    "githubRepo": "purescript-solc"
-  },
-  "releases": {},
-  "unpublished": {}
-}

--- a/metadata/soundcloud.json
+++ b/metadata/soundcloud.json
@@ -3,6 +3,6 @@
     "githubOwner": "vyorkin",
     "githubRepo": "purescript-handsontable"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/spidermonkey-ast.json
+++ b/metadata/spidermonkey-ast.json
@@ -3,6 +3,6 @@
     "githubOwner": "michaelficarra",
     "githubRepo": "purescript-spidermonkey-ast"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/ssrs.json
+++ b/metadata/ssrs.json
@@ -3,6 +3,6 @@
     "githubOwner": "PureFunctor",
     "githubRepo": "purescript-ssrs"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/stablename.json
+++ b/metadata/stablename.json
@@ -1,0 +1,8 @@
+{
+  "location": {
+    "githubOwner": "alexknvl",
+    "githubRepo": "purescript-stablename"
+  },
+  "published": {},
+  "unpublished": {}
+}

--- a/metadata/stm.json
+++ b/metadata/stm.json
@@ -3,6 +3,6 @@
     "githubOwner": "rightfold",
     "githubRepo": "purescript-stm"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/streams.json
+++ b/metadata/streams.json
@@ -3,6 +3,6 @@
     "githubOwner": "puffnfresh",
     "githubRepo": "purescript-streams"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/stsequence.json
+++ b/metadata/stsequence.json
@@ -3,6 +3,6 @@
     "githubOwner": "mgmeier",
     "githubRepo": "purescript-stsequence"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/subtype.json
+++ b/metadata/subtype.json
@@ -3,6 +3,6 @@
     "githubOwner": "rightfold",
     "githubRepo": "purescript-subtype"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/sync-websockets.json
+++ b/metadata/sync-websockets.json
@@ -3,6 +3,6 @@
     "githubOwner": "pkamenarsky",
     "githubRepo": "purescript-sync-websockets"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/sytc.json
+++ b/metadata/sytc.json
@@ -3,6 +3,6 @@
     "githubOwner": "mikesol",
     "githubRepo": "purescript-sytc"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/task-http.json
+++ b/metadata/task-http.json
@@ -3,6 +3,6 @@
     "githubOwner": "ursi",
     "githubRepo": "purescript-task-http"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/test-pontificate.json
+++ b/metadata/test-pontificate.json
@@ -3,6 +3,6 @@
     "githubOwner": "Fresheyeball",
     "githubRepo": "purescript-test-pontificate"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/toastr.json
+++ b/metadata/toastr.json
@@ -3,6 +3,6 @@
     "githubOwner": "dbushenko",
     "githubRepo": "purescript-toastr"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/trace.json
+++ b/metadata/trace.json
@@ -3,6 +3,6 @@
     "githubOwner": "pkamenarsky",
     "githubRepo": "purescript-trace"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/typeahead.json
+++ b/metadata/typeahead.json
@@ -3,6 +3,6 @@
     "githubOwner": "ascjones",
     "githubRepo": "purescript-typeahead"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/typed-wire.json
+++ b/metadata/typed-wire.json
@@ -3,6 +3,6 @@
     "githubOwner": "typed-wire",
     "githubRepo": "purescript-typed-wire"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/typelevel-graph.json
+++ b/metadata/typelevel-graph.json
@@ -3,6 +3,6 @@
     "githubOwner": "mikesol",
     "githubRepo": "purescript-typelevel-graph"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/typelevel-measures.json
+++ b/metadata/typelevel-measures.json
@@ -3,6 +3,6 @@
     "githubOwner": "csicar",
     "githubRepo": "purescript-typelevel-measures"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/uport.json
+++ b/metadata/uport.json
@@ -3,6 +3,6 @@
     "githubOwner": "f-o-a-m",
     "githubRepo": "purescript-uport"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/vdom-worker.json
+++ b/metadata/vdom-worker.json
@@ -3,6 +3,6 @@
     "githubOwner": "FrigoEU",
     "githubRepo": "purescript-vdom-worker"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/webcomponents.json
+++ b/metadata/webcomponents.json
@@ -1,8 +1,0 @@
-{
-  "location": {
-    "githubOwner": "Risto-Stevcev",
-    "githubRepo": "purescript-webcomponents"
-  },
-  "releases": {},
-  "unpublished": {}
-}

--- a/metadata/webrtc.json
+++ b/metadata/webrtc.json
@@ -3,6 +3,6 @@
     "githubOwner": "puffnfresh",
     "githubRepo": "purescript-webrtc"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/whatwg-html.json
+++ b/metadata/whatwg-html.json
@@ -3,6 +3,6 @@
     "githubOwner": "ursi",
     "githubRepo": "purescript-whatwg-html"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }

--- a/metadata/winston.json
+++ b/metadata/winston.json
@@ -1,8 +1,0 @@
-{
-  "location": {
-    "githubOwner": "dysinger",
-    "githubRepo": "purescript-winston"
-  },
-  "releases": {},
-  "unpublished": {}
-}

--- a/metadata/yaml.json
+++ b/metadata/yaml.json
@@ -3,6 +3,6 @@
     "githubOwner": "CapillarySoftware",
     "githubRepo": "purescript-yaml"
   },
-  "releases": {},
+  "published": {},
   "unpublished": {}
 }


### PR DESCRIPTION
The format of our metadata file has changed, but the metadata directory was never regenerated. This commit is the result of running the legacy importer and regenerating all the metadata files. It's not intended as the final state of this directory (that will wait for the last run of the legacy importer), but it at least ensures that the artifacts in the repo accurately reflect the spec.