### PR TITLE
Minor: remove space

### DIFF
--- a/new-packages.json
+++ b/new-packages.json
@@ -16,7 +16,7 @@
   "purescript-cirru-parser": "https://github.com/Cirru/parser.purs.git",
   "purescript-cirru-edn": "https://github.com/Cirru/cirru-edn.purs.git",
   "purescript-web-url": "https://github.com/mjepronk/purescript-web-url.git",
-  "purescript-bf-gun" : "https://github.com/gorillatron/purescript-bf-gun.git",
+  "purescript-bf-gun": "https://github.com/gorillatron/purescript-bf-gun.git",
   "purescript-grain": "https://github.com/purescript-grain/purescript-grain.git",
   "purescript-grain-portal": "https://github.com/purescript-grain/purescript-grain-portal.git",
   "purescript-grain-router": "https://github.com/purescript-grain/purescript-grain-router.git",


### PR DESCRIPTION
While not a syntax error, there is only one line in the file with `"key" : "value"` instead of `"key": "value"`