### PR TITLE
Add generate-values pkg

### DIFF
--- a/new-packages.json
+++ b/new-packages.json
@@ -188,5 +188,6 @@
   "purescript-argparse-basic": "https://github.com/natefaubion/purescript-argparse-basic.git",
   "purescript-web-page-visibility": "https://git.sr.ht/~toastal/purescript-web-page-visibility",
   "purescript-web-pointerevents": "https://github.com/gbagan/purescript-web-pointerevents.git",
-  "purescript-qualified-do": "https://github.com/artemisSystem/purescript-qualified-do.git"
+  "purescript-qualified-do": "https://github.com/artemisSystem/purescript-qualified-do.git",
+  "purescript-generate-values": "https://github.com/jordanmartinez/purescript-generate-values.git"
 }


### PR DESCRIPTION
`purescript-generate-values` extracts the `Gen` type out of the `quickcheck` library and re-exposes it as a proper monad transformer, `GenT`.