### PR TITLE
Update packages.purescript.org link in backends

### DIFF
--- a/v1/backends.dhall
+++ b/v1/backends.dhall
@@ -20,7 +20,7 @@ let Package = { name : Text, version : Text }
 let Backend = Package -> Text
 
 let backends = toMap
-  { main = \(package : Package) -> "https://packages.purescript.org/${package.name}/${package.version}.tar.gz"
+  { main = \(package : Package) -> "https://packages.registry.purescript.org/${package.name}/${package.version}.tar.gz"
   }
 
 in backends : Map Text Backend


### PR DESCRIPTION
The backends.dhall file is currently pointing to an old reference to the packages location.