### PR TITLE
Ban purescript- prefixes by default

### DIFF
--- a/ci/src/Registry/PackageName.purs
+++ b/ci/src/Registry/PackageName.purs
@@ -51,7 +51,9 @@ parse inputStr = flip Parser.runParser inputStr do
   -- represents the legacy naming scheme and is almost certainly an error.
   -- However, packages can be explicitly blessed so they can use the prefix.
   let
-    allowedPrefixNames = []
+    allowedPrefixNames =
+      [ "purescript-compiler-backend-utilities"
+      ]
     isBlessedPackage = inputStr `Array.elem` allowedPrefixNames
     hasPureScriptPrefix = isJust $ String.stripPrefix (String.Pattern "purescript-") inputStr
 

--- a/ci/src/Registry/PackageName.purs
+++ b/ci/src/Registry/PackageName.purs
@@ -82,7 +82,6 @@ parse inputStr = flip Parser.runParser inputStr do
   -- Make sure that we consume all the string in input
   Parse.eof <?> charErr
 
-  -- Put together the string, stripping the "purescript-" prefix if there
   let
     chars = List.concat $ map NEL.toList $ List.Cons firstChunk nextChunks
     name = fromCharArray $ List.toUnfoldable $ chars

--- a/ci/src/Registry/PackageName.purs
+++ b/ci/src/Registry/PackageName.purs
@@ -6,6 +6,7 @@ module Registry.PackageName
 
 import Registry.Prelude
 
+import Data.Array as Array
 import Data.List as List
 import Data.List.NonEmpty as NEL
 import Data.String as String
@@ -37,13 +38,25 @@ print :: PackageName -> String
 print (PackageName package) = package
 
 parse :: String -> Either Parser.ParseError PackageName
-parse = Parser.runParser do
+parse inputStr = flip Parser.runParser inputStr do
   let
     -- Error messages which also define our rules for package names
     endErr = "Package name should end with a lower case char or digit"
     charErr = "Package name can contain lower case chars, digits and non-consecutive dashes"
     startErr = "Package name should start with a lower case char or a digit"
+    prefixErr = "Package names should not begin with 'purescript-'"
     manyDashesErr = "Package names cannot contain consecutive dashes"
+
+  -- Packages are not allowed to begin with purescript- in general, as that
+  -- represents the legacy naming scheme and is almost certainly an error.
+  -- However, packages can be explicitly blessed so they can use the prefix.
+  let
+    allowedPrefixNames = []
+    isBlessedPackage = inputStr `Array.elem` allowedPrefixNames
+    hasPureScriptPrefix = isJust $ String.stripPrefix (String.Pattern "purescript-") inputStr
+
+  when (hasPureScriptPrefix && not isBlessedPackage) do
+    Parser.fail prefixErr
 
   let
     char = ParseC.choice [ Parse.lowerCaseChar, Parse.anyDigit ] <?> charErr
@@ -52,6 +65,7 @@ parse = Parser.runParser do
 
   -- A "chunk" is an alphanumeric word between dashes
   firstChunk <- chunk <?> startErr
+
   nextChunks <- do
     chunks <- ParseC.many do
       void dash
@@ -69,7 +83,7 @@ parse = Parser.runParser do
   -- Put together the string, stripping the "purescript-" prefix if there
   let
     chars = List.concat $ map NEL.toList $ List.Cons firstChunk nextChunks
-    name = stripPureScriptPrefix $ fromCharArray $ List.toUnfoldable $ chars
+    name = fromCharArray $ List.toUnfoldable $ chars
 
   -- and check that it's not longer than 50 chars
   if String.length name > 50 then

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -160,6 +160,8 @@ goodPackageName = do
 
   parseName "a" "a"
   parseName "some-dash" "some-dash"
+  -- A blessed prefixed package
+  parseName "purescript-compiler-backend-utilities" "purescript-compiler-backend-utilities"
 
 badPackageName :: Spec.Spec Unit
 badPackageName = do

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -168,8 +168,10 @@ badPackageName = do
       (PackageName.print <$> PackageName.parse str) `Assert.shouldSatisfy` case _ of
         Right _ -> false
         Left { error } -> error == err
+
   let startErr = "Package name should start with a lower case char or a digit"
   let midErr = "Package name can contain lower case chars, digits and non-consecutive dashes"
+  let prefixErr = "Package names should not begin with 'purescript-'"
   let endErr = "Package name should end with a lower case char or digit"
   let manyDashes = "Package names cannot contain consecutive dashes"
 
@@ -180,6 +182,7 @@ badPackageName = do
   failParse "a-" endErr
   failParse "" startErr
   failParse "🍝" startErr
+  failParse "purescript-aff" prefixErr
 
 goodSPDXLicense :: Spec.Spec Unit
 goodSPDXLicense = do


### PR DESCRIPTION
This PR adds the `purescript-` prefix as a disallowed package name, though individual packages (such as https://github.com/rightfold/purescript-purescript-compiler-backend-utilities) can be added to an allowlist.