### PR TITLE
Fix tarball nondeterminism due to timestamps

### DIFF
--- a/ci/src/Foreign/Tar.js
+++ b/ci/src/Foreign/Tar.js
@@ -1,42 +1,54 @@
-const tar = require("tar")
+const tar = require("tar");
 
 // get toplevel directory in tar
-exports.getToplevelDirImpl = function(filename){
-  return function(){
+exports.getToplevelDirImpl = function (filename) {
+  return function () {
     var entries = [];
     tar.list({
       file: filename,
       sync: true,
       filter: (path, entry) => {
-          var topLevel = /^[^\/]+\/$/
-          return topLevel.exec(path);
-       },
-      onentry: entry => { entries.push(entry.path); }
+        var topLevel = /^[^\/]+\/$/;
+        return topLevel.exec(path);
+      },
+      onentry: (entry) => {
+        entries.push(entry.path);
+      },
     });
-    return entries
+    return entries;
   };
 };
 
 // extract tar
-exports.extractImpl = function(cwd, filename){
-  return function(){
+exports.extractImpl = function (cwd, filename) {
+  return function () {
     tar.extract({
       sync: true,
       cwd: cwd,
-      file: filename
+      file: filename,
     });
   };
 };
 
 // create .tar.gz from a folder
-exports.createImpl = function(cwd, foldername, archivename){
-  return function(){
-    tar.create({
-      sync: true,
-      gzip: true,
-      portable: true,
-      cwd: cwd,
-      file: archivename
-    }, [foldername]);
+exports.createImpl = function (cwd, foldername, archivename) {
+  return function () {
+    tar.create(
+      {
+        sync: true,
+        gzip: true,
+        portable: true,
+        noMtime: true,
+        cwd: cwd,
+        filter: (path, stat) => {
+          // 'no mtime' and 'portable' aren't enough on their own:
+          // https://github.com/npm/node-tar/issues/176#issuecomment-391904257
+          stat.mtime = null;
+          stat.birthtime = null;
+        },
+        file: archivename,
+      },
+      [foldername]
+    );
   };
 };

--- a/ci/test/Foreign/Tar.purs
+++ b/ci/test/Foreign/Tar.purs
@@ -23,7 +23,7 @@ tar = do
 
     Spec.it "Tarballs are identical if contents are identical" do
       tarball1 <- createTarball
-      Aff.delay (Aff.Milliseconds 3000.0)
+      Aff.delay (Aff.Milliseconds 100.0)
       tarball2 <- createTarball
       tarball1 `Assert.shouldEqual` tarball2
   where

--- a/ci/test/Foreign/Tar.purs
+++ b/ci/test/Foreign/Tar.purs
@@ -23,7 +23,7 @@ tar = do
 
     Spec.it "Tarballs are identical if contents are identical" do
       tarball1 <- createTarball
-      Aff.delay (Aff.Milliseconds 10.0)
+      Aff.delay (Aff.Milliseconds 1000.0)
       tarball2 <- createTarball
       tarball1 `Assert.shouldEqual` tarball2
   where

--- a/ci/test/Foreign/Tar.purs
+++ b/ci/test/Foreign/Tar.purs
@@ -23,7 +23,7 @@ tar = do
 
     Spec.it "Tarballs are identical if contents are identical" do
       tarball1 <- createTarball
-      Aff.delay (Aff.Milliseconds 1000.0)
+      Aff.delay (Aff.Milliseconds 3000.0)
       tarball2 <- createTarball
       tarball1 `Assert.shouldEqual` tarball2
   where

--- a/ci/test/Foreign/Tar.purs
+++ b/ci/test/Foreign/Tar.purs
@@ -1,0 +1,46 @@
+module Test.Foreign.Tar where
+
+import Registry.Prelude
+
+import Effect.Aff as Aff
+import Foreign.Node.FS as FSE
+import Foreign.Tar as Tar
+import Foreign.Tmp as Tmp
+import Node.FS.Aff as FS
+import Node.FS.Aff as FSA
+import Node.FS.Stats as FS.Stats
+import Node.Path as Path
+import Registry.Hash as Hash
+import Test.Spec as Spec
+import Test.Spec.Assertions as Assert
+
+tar :: Spec.Spec Unit
+tar = do
+  Spec.describe "Tar" do
+    Spec.it "Successfully produces tarball from directory" do
+      { bytes } <- createTarball
+      bytes `Assert.shouldSatisfy` (_ > 0.0)
+
+    Spec.it "Tarballs are identical if contents are identical" do
+      tarball1 <- createTarball
+      Aff.delay (Aff.Milliseconds 10.0)
+      tarball2 <- createTarball
+      tarball1 `Assert.shouldEqual` tarball2
+  where
+  createTarball = do
+    packageTmp <- liftEffect Tmp.mkTmpDir
+    let packagePath = Path.concat [ packageTmp, "package" ]
+    FSE.ensureDirectory packagePath
+    writeTmp packagePath "README.md" "# README\nThis is my package."
+    writeTmp packagePath "purs.json" "{ \"name\": \"project\" }"
+    let archiveName = packagePath <> ".tar.gz"
+    liftEffect $ Tar.create { cwd: packageTmp, folderName: packagePath, archiveName }
+    hashAndBytes archiveName
+
+  writeTmp tmp name contents =
+    FSA.writeTextFile ASCII (Path.concat [ tmp, name ]) contents
+
+  hashAndBytes path = do
+    FS.Stats.Stats { size: bytes } <- FS.stat path
+    hash <- Hash.sha256File path
+    pure { hash, bytes }

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -32,6 +32,7 @@ import Safe.Coerce (coerce)
 import Test.Fixture.Manifest as Fixture
 import Test.Foreign.JsonRepair as Foreign.JsonRepair
 import Test.Foreign.Licensee (licensee)
+import Test.Foreign.Tar as Foreign.Tar
 import Test.Registry.Hash as Registry.Hash
 import Test.Registry.Index as Registry.Index
 import Test.Registry.SSH as SSH
@@ -90,6 +91,8 @@ main = launchAff_ do
       Registry.Hash.testHash
     Spec.describe "Json" do
       Foreign.JsonRepair.testJsonRepair
+    Spec.describe "Tar" do
+      Foreign.Tar.tar
     Spec.describe "Version" do
       TestVersion.testVersion
     Spec.describe "Range" do


### PR DESCRIPTION
Fixes #439 by making tarball creation depend only on the bits in the package itself, not metadata like timestamps. This ensures that if we have ever regenerate packages in the registry (which we currently do often) the hashes won't change, because the file contents haven't changed either. This is also why Nix sets timestamps on everything to the epoch, for example.