### PR TITLE
Trim input strings when reading registry index files

### DIFF
--- a/ci/src/Registry/Index.purs
+++ b/ci/src/Registry/Index.purs
@@ -88,7 +88,7 @@ readPackage directory packageName = do
 
   contentsResult <- try do
     contents <- FS.readTextFile ASCII path
-    pure $ hush $ traverse Json.parseJson $ String.split (Pattern "\n") $ String.trim contents
+    pure $ hush $ traverse Json.parseJson $ String.split (Pattern "\n") $ contents
 
   pure case contentsResult of
     Left _ -> Nothing

--- a/ci/src/Registry/Index.purs
+++ b/ci/src/Registry/Index.purs
@@ -88,7 +88,7 @@ readPackage directory packageName = do
 
   contentsResult <- try do
     contents <- FS.readTextFile ASCII path
-    pure $ hush $ traverse Json.parseJson $ String.split (Pattern "\n") $ contents
+    pure $ hush $ traverse Json.parseJson $ String.split (Pattern "\n") $ String.trim contents
 
   pure case contentsResult of
     Left _ -> Nothing

--- a/ci/src/Registry/Index.purs
+++ b/ci/src/Registry/Index.purs
@@ -112,8 +112,9 @@ insertManifest directory manifest@(Manifest { name, version }) = do
 
     contents :: String
     contents =
-      String.joinWith "\n"
-        $ map (Json.encode >>> Json.stringify)
+      (_ <> "\n")
+        $ String.joinWith "\n"
+        $ map Json.stringifyJson
         $ Array.sortBy (comparing (un Manifest >>> _.version))
         $ Array.fromFoldable modifiedManifests
 


### PR DESCRIPTION
I noticed when working on daily runs of the registry importer that appending a new manifest to the end of an existing registry index entry can cause the whole file to be lost, and only the latest manifest be written. As an example, see:
https://github.com/purescript/registry-index/commit/3c1ae75b329dfb8962ab45ec162f614dbf3d573a

This happens if a file happens to have been written with a trailing newline character. This will cause the JSON parsing of the file to fail on the empty string after it is split by newlines. Technically speaking, if everything is auto-generated then there shouldn't be a trailing newline. In practice, though, we sometimes have to edit these files and normal file conventions on Linux dictate a trailing newline.

This PR fixes the issue by trimming the input string before attempting to parse it as JSON. In addition, I've changed the registry index implementation to always emit a trailing newline, for consistency's sake.