### PR TITLE
Improve use of Octokit to reach the GitHub API

### DIFF
--- a/ci/package-lock.json
+++ b/ci/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@octokit/plugin-retry": "^3.0.9",
+        "@octokit/plugin-throttling": "^3.7.0",
         "@octokit/rest": "^18.12.0",
         "aws-sdk": "^2.1050.0",
         "decimal.js": "^10.3.1",
@@ -125,6 +127,27 @@
         "@octokit/core": ">=3"
       }
     },
+    "node_modules/@octokit/plugin-retry": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz",
+      "integrity": "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "node_modules/@octokit/plugin-throttling": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.7.0.tgz",
+      "integrity": "sha512-qrKT1Yl/KuwGSC6/oHpLBot3ooC9rq0/ryDYBCpkRtoj+R8T47xTMDT6Tk2CxWopFota/8Pi/2SqArqwC0JPow==",
+      "dependencies": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^3.5.0"
+      }
+    },
     "node_modules/@octokit/request": {
       "version": "5.6.2",
       "license": "MIT",
@@ -206,6 +229,11 @@
     "node_modules/before-after-hook": {
       "version": "2.2.2",
       "license": "Apache-2.0"
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -853,6 +881,24 @@
         "deprecation": "^2.3.1"
       }
     },
+    "@octokit/plugin-retry": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-3.0.9.tgz",
+      "integrity": "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "bottleneck": "^2.15.3"
+      }
+    },
+    "@octokit/plugin-throttling": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-3.7.0.tgz",
+      "integrity": "sha512-qrKT1Yl/KuwGSC6/oHpLBot3ooC9rq0/ryDYBCpkRtoj+R8T47xTMDT6Tk2CxWopFota/8Pi/2SqArqwC0JPow==",
+      "requires": {
+        "@octokit/types": "^6.0.1",
+        "bottleneck": "^2.15.3"
+      }
+    },
     "@octokit/request": {
       "version": "5.6.2",
       "requires": {
@@ -909,6 +955,11 @@
     },
     "before-after-hook": {
       "version": "2.2.2"
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/ci/package.json
+++ b/ci/package.json
@@ -12,6 +12,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@octokit/plugin-retry": "^3.0.9",
+    "@octokit/plugin-throttling": "^3.7.0",
     "@octokit/rest": "^18.12.0",
     "aws-sdk": "^2.1050.0",
     "decimal.js": "^10.3.1",

--- a/ci/spago.dhall
+++ b/ci/spago.dhall
@@ -39,6 +39,7 @@
   , "node-process"
   , "now"
   , "nullable"
+  , "numbers"
   , "ordered-collections"
   , "parallel"
   , "partial"

--- a/ci/src/Foreign/GitHub.js
+++ b/ci/src/Foreign/GitHub.js
@@ -1,4 +1,7 @@
-const { Octokit } = require("@octokit/rest");
+const { Octokit: GitHubOctokit } = require("@octokit/rest");
+const { retry } = require("@octokit/plugin-retry");
+const { throttling } = require("@octokit/plugin-throttling");
+const Octokit = GitHubOctokit.plugin(retry, throttling);
 
 exports.mkOctokit = function () {
   if ("GITHUB_TOKEN" in process.env) {
@@ -7,43 +10,125 @@ exports.mkOctokit = function () {
     process.exit(1);
   }
 
-  return new Octokit({ auth: process.env.GITHUB_TOKEN });
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_TOKEN,
+    throttle: {
+      onRateLimit: (retryAfter, options) => {
+        octokit.log.warn(
+          `Request quota exhausted for request ${options.method} ${options.url}`
+        );
+
+        // Retry twice after hitting a rate limit error, then give up
+        if (options.request.retryCount <= 2) {
+          console.log(`Retrying after ${retryAfter} seconds!`);
+          return true;
+        }
+      },
+      onAbuseLimit: (retryAfter, options) => {
+        // does not retry, only logs a warning
+        octokit.log.warn(
+          `Abuse detected for request ${options.method} ${options.url}`
+        );
+      },
+    },
+  });
+
+  return octokit;
 };
 
-exports.getReleasesImpl = function (octokit, { owner, repo }) {
+/* Ideally, we would implement this using conditional requests and read releases
+   from cache if we get a 304 response. This would reduce the number of requests
+   made dramatically. However, octokit doesn't provide a way to access request
+   headers, so this isn't yet implemented.
+*/
+exports.getReleasesImpl = function (octokit, { owner, repo }, left, right) {
   return octokit
     .paginate(octokit.repos.listTags, {
       owner,
       repo,
+      per_page: 100, // maximum is 100, minimizes requests made
     })
-    .then((data) =>
-      data.map((element) => {
+    .then((data) => {
+      const tags = data.map((element) => {
         return { name: element.name, sha: element.commit.sha };
-      })
-    );
+      });
+      return right(tags);
+    })
+    .catch((e) => {
+      return left(e);
+    });
 };
 
-exports.getRefCommitImpl = function (octokit, { owner, repo }, ref) {
+exports.getRefCommitImpl = function (
+  octokit,
+  { owner, repo },
+  ref,
+  left,
+  right
+) {
   return octokit.rest.git
     .getRef({ owner, repo, ref })
-    .then((data) => data.object.sha);
+    .then((data) => {
+      return right(data.object.sha);
+    })
+    .catch((e) => {
+      return left(e);
+    });
 };
 
-exports.getCommitDateImpl = function (octokit, { owner, repo }, sha) {
+exports.getCommitDateImpl = function (
+  octokit,
+  { owner, repo },
+  sha,
+  left,
+  right
+) {
   return octokit.rest.git
     .getCommit({ owner, repo, commit_sha: sha })
-    .then(({ data }) => data.committer.date);
+    .then(({ data }) => {
+      return right(data.committer.date);
+    })
+    .catch((e) => {
+      return left(e);
+    });
 };
 
-exports.closeIssueImpl = function (octokit, { owner, repo }, issue_number) {
-  return octokit.issues.update({
-    owner,
-    repo,
-    issue_number,
-    state: "closed",
-  });
+exports.closeIssueImpl = function (
+  octokit,
+  { owner, repo },
+  issue_number,
+  left,
+  right
+) {
+  return octokit.issues
+    .update({
+      owner,
+      repo,
+      issue_number,
+      state: "closed",
+    })
+    .then(() => {
+      return right(undefined);
+    })
+    .catch((e) => {
+      return left(e);
+    });
 };
 
-exports.createCommentImpl = function (octokit, { owner, repo }, issue_number, body) {
-  return octokit.issues.createComment({ owner, repo, issue_number, body });
+exports.createCommentImpl = function (
+  octokit,
+  { owner, repo },
+  issue_number,
+  body,
+  left,
+  right
+) {
+  return octokit.issues
+    .createComment({ owner, repo, issue_number, body })
+    .then(() => {
+      return right(undefined);
+    })
+    .catch((e) => {
+      return left(e);
+    });
 };

--- a/ci/src/Foreign/GitHub.purs
+++ b/ci/src/Foreign/GitHub.purs
@@ -2,14 +2,21 @@ module Foreign.GitHub where
 
 import Registry.Prelude
 
+import Affjax.StatusCode as Http
 import Control.Promise (Promise)
 import Control.Promise as Promise
+import Data.Bitraversable (ltraverse)
+import Data.DateTime.Instant (Instant)
+import Data.DateTime.Instant as Instant
 import Data.List as List
 import Data.Newtype (unwrap)
+import Data.Number as Number
 import Data.RFC3339String (RFC3339String(..))
 import Data.String as String
 import Data.String.CodeUnits (fromCharArray)
-import Effect.Uncurried (EffectFn2, EffectFn3, EffectFn4, runEffectFn2, runEffectFn3, runEffectFn4)
+import Data.Time.Duration (Milliseconds(..))
+import Effect.Exception as Exception
+import Effect.Uncurried (EffectFn4, EffectFn5, EffectFn6, runEffectFn4, runEffectFn5, runEffectFn6)
 import Registry.Json ((.:))
 import Registry.Json as Json
 import Safe.Coerce (coerce)
@@ -67,24 +74,61 @@ parseRepo = unwrap >>> Parser.runParser do
   let repo = fromMaybe repoWithSuffix $ String.stripSuffix (String.Pattern ".git") repoWithSuffix
   pure { owner, repo }
 
-foreign import getReleasesImpl :: EffectFn2 Octokit Address (Promise (Array Tag))
+type GitHubAPIError =
+  { status :: Http.StatusCode
+  , ratelimitRemaining :: Number
+  , ratelimitReset :: Instant
+  , message :: String
+  }
 
-getReleases :: Octokit -> Address -> Aff (Array Tag)
-getReleases octokit address = Promise.toAffE $ runEffectFn2 getReleasesImpl octokit address
+decodeGitHubAPIError :: Object Json -> Either String GitHubAPIError
+decodeGitHubAPIError obj = do
+  status <- map Http.StatusCode $ obj .: "status"
+  response <- obj .: "response"
+  responseData <- response .: "data"
+  responseHeaders <- response .: "headers"
+  ratelimitResetStr <- responseHeaders .: "x-ratelimit-reset"
+  ratelimitReset <- note "Invalid number received for x-ratelimit-reset" $ Number.fromString ratelimitResetStr
+  ratelimitRemainingStr <- responseHeaders .: "x-ratelimit-remaining"
+  ratelimitRemaining <- note "Invalid number received for x-ratelimit-remaining" $ Number.fromString ratelimitRemainingStr
+  message <- responseData .: "message"
+  pure
+    { status
+    , ratelimitRemaining
+    -- Instants measure milliseconds since epoch time:
+    -- https://github.com/purescript/purescript-datetime/blob/a6a0cf1b0324964ad1854bc3377ed8766ba90e6f/src/Data/DateTime/Instant.purs#L20-L21
+    --
+    -- However, GitHub returns seconds since epoch time, so we need to multiply
+    -- it by 1000 to get a valid reset time.
+    , ratelimitReset: unsafeFromJust $ Instant.instant $ Milliseconds $ ratelimitReset * 1000.0
+    , message
+    }
 
-foreign import getRefCommitImpl :: EffectFn3 Octokit Address String (Promise String)
+convertGitHubAPIError :: forall r. Either (Object Json) r -> Aff (Either GitHubAPIError r)
+convertGitHubAPIError = ltraverse \error -> case decodeGitHubAPIError error of
+  Left err -> throwError $ Exception.error $ "Unexpected error decoding GitHubAPIError: " <> err
+  Right value -> pure value
 
-getRefCommit :: Octokit -> Address -> String -> Aff String
-getRefCommit octokit address ref = do
-  commitSha <- Promise.toAffE $ runEffectFn3 getRefCommitImpl octokit address ref
-  pure commitSha
+foreign import getReleasesImpl :: forall r. EffectFn4 Octokit Address (Object Json -> r) (Array Tag -> r) (Promise r)
 
-foreign import getCommitDateImpl :: EffectFn3 Octokit Address String (Promise String)
+getReleases :: Octokit -> Address -> ExceptT GitHubAPIError Aff (Array Tag)
+getReleases octokit address = ExceptT do
+  result <- Promise.toAffE $ runEffectFn4 getReleasesImpl octokit address Left Right
+  convertGitHubAPIError result
 
-getCommitDate :: Octokit -> Address -> String -> Aff RFC3339String
-getCommitDate octokit address sha = do
-  date <- Promise.toAffE $ runEffectFn3 getCommitDateImpl octokit address sha
-  pure $ RFC3339String date
+foreign import getRefCommitImpl :: forall r. EffectFn5 Octokit Address String (Object Json -> r) (String -> r) (Promise r)
+
+getRefCommit :: Octokit -> Address -> String -> ExceptT GitHubAPIError Aff String
+getRefCommit octokit address ref = ExceptT do
+  commitSha <- Promise.toAffE $ runEffectFn5 getRefCommitImpl octokit address ref Left Right
+  convertGitHubAPIError commitSha
+
+foreign import getCommitDateImpl :: forall r. EffectFn5 Octokit Address String (Object Json -> r) (String -> r) (Promise r)
+
+getCommitDate :: Octokit -> Address -> String -> ExceptT GitHubAPIError Aff RFC3339String
+getCommitDate octokit address sha = ExceptT do
+  date <- Promise.toAffE $ runEffectFn5 getCommitDateImpl octokit address sha Left Right
+  convertGitHubAPIError $ map RFC3339String date
 
 newtype IssueNumber = IssueNumber Int
 
@@ -93,12 +137,16 @@ derive newtype instance Eq IssueNumber
 derive newtype instance Show IssueNumber
 derive newtype instance RegistryJson IssueNumber
 
-foreign import createCommentImpl :: EffectFn4 Octokit Address Int String (Promise Unit)
+foreign import createCommentImpl :: forall r. EffectFn6 Octokit Address Int String (Object Json -> r) (Unit -> r) (Promise r)
 
-createComment :: Octokit -> IssueNumber -> String -> Aff Unit
-createComment octokit issue body = Promise.toAffE $ runEffectFn4 createCommentImpl octokit registryAddress (coerce issue) body
+createComment :: Octokit -> IssueNumber -> String -> ExceptT GitHubAPIError Aff Unit
+createComment octokit issue body = ExceptT do
+  result <- Promise.toAffE $ runEffectFn6 createCommentImpl octokit registryAddress (coerce issue) body Left Right
+  convertGitHubAPIError result
 
-foreign import closeIssueImpl :: EffectFn3 Octokit Address Int (Promise Unit)
+foreign import closeIssueImpl :: forall r. EffectFn5 Octokit Address Int (Object Json -> r) (Unit -> r) (Promise r)
 
-closeIssue :: Octokit -> IssueNumber -> Aff Unit
-closeIssue octokit issue = Promise.toAffE $ runEffectFn3 closeIssueImpl octokit registryAddress (coerce issue)
+closeIssue :: Octokit -> IssueNumber -> ExceptT GitHubAPIError Aff Unit
+closeIssue octokit issue = ExceptT do
+  result <- Promise.toAffE $ runEffectFn5 closeIssueImpl octokit registryAddress (coerce issue) Left Right
+  convertGitHubAPIError result


### PR DESCRIPTION
While working on scheduled registry importing I noticed a few issues with our use of Octokit to hit the GitHub API. The most important issue is that if a request failed we have no information about it — we don't know the status code, the error message returned by GitHub, or anything. This made it difficult to do retries or cache 404 failures permanently.

This PR makes a few updates to our use of Octokit when making requests:

1. It introduces a new error type, `GitHubAPIError`, which captures a few of the relevant fields that GitHub returns when a request fails. Most importantly, we now receive the status code and error message (but also the rate limit information, in case we want to use it).
2. It introduces two GitHub-suggested plugins. The first provides automatic throttling in the case we bump up against our rate limit. The second provides automatic retries up to 3 times in the case a non-permanent failure occurred. This saves us from having to implement this logic ourselves and (as far as I can tell) doesn't use up as much of our request quota.

Accordingly, use of Octokit for requests now returns in `ExceptT GitHubAPIError Aff a` instead of `Aff a`. While it's technically true that any `Aff` function can throw, I feel that the new type signature more accurately reflects the possible failure mode.

### Next steps

**Conditional Requests**
In the future, we really ought to make use of [conditional requests](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests) when fetching requests, which will allow us to skip rate-limiting headaches altogether. Essentially, we make a request to check if there are any _new_ releases since our last check. If there are, we fetch them and burn a request. If there aren't, we read from our own cache and don't use up a request.

I didn't implement that in this PR because Octokit doesn't give any access to request headers (as far as I can tell) so we'd need to drop down to a lower level and coordinate it with our on-disk cache. That's a bit much for one PR, so I've stopped here.

**Rate Limiting in CI**
GitHub reports that actions can make up to 1,000 requests per hour using the GITHUB_TOKEN. This is obviously not going to work for us to do batch imports, because fetching releases alone requires 1,700 requests (one per package). Without using conditional requests we will blow through our limit without completing a single run.

However, we can make up to 5,000 requests per hour using a personal token such as the PACCHETTIBOTTI_TOKEN. This allows us to use the tool as-is without reaching our limit, and so long as pacchettibotti doesn't take another 3,300 actions within the hour we should be safe.

#### Other notes
I ran the registry importer again and saw a few 404 errors come through, but no other failures. I then re-ran the importer with an expired cache and saw no errors at all: the 404s were skipped, and everything else fetched successfully.

