### PR TITLE
Automated Package Sets: Find package set inclusion candidates from recently uploaded packages

### DIFF
--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -57,6 +57,7 @@ import Registry.Schema (AuthenticatedData(..), AuthenticatedOperation(..), Build
 import Registry.Scripts.LegacyImport.Error (ImportError(..))
 import Registry.Scripts.LegacyImport.Manifest as Manifest
 import Registry.Types (RawPackageName(..), RawVersion(..))
+import Registry.Utils (wget)
 import Registry.Version (ParseMode(..), Range, Version)
 import Registry.Version as Version
 import Sunde as Process
@@ -588,16 +589,6 @@ buildPlanToResolutions { buildPlan: BuildPlan { resolutions }, dependenciesDir }
       bowerPackageName = RawPackageName ("purescript-" <> PackageName.print name)
       packagePath = Path.concat [ dependenciesDir, PackageName.print name <> "-" <> Version.printVersion version ]
     pure $ Tuple bowerPackageName { path: packagePath, version }
-
-wget :: String -> FilePath -> RegistryM Unit
-wget url path = do
-  let cmd = "wget"
-  let stdin = Nothing
-  let args = [ "-O", path, url ]
-  result <- liftAff $ Process.spawn { cmd, stdin, args } NodeProcess.defaultSpawnOptions
-  case result.exit of
-    NodeProcess.Normally 0 -> pure unit
-    _ -> throwWithComment $ "Error while fetching tarball: " <> result.stderr
 
 mkEnv :: GitHub.Octokit -> MetadataRef -> IssueNumber -> Env
 mkEnv octokit packagesMetadata issue =

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -70,7 +70,7 @@ main = launchAff_ $ do
       >>= maybe (throw "GITHUB_EVENT_PATH not defined in the environment") pure
   octokit <- liftEffect GitHub.mkOctokit
   packagesMetadata <- mkMetadataRef
-  checkIndexExists
+  checkIndexExists indexDir
 
   readOperation eventPath >>= case _ of
     -- If the issue body is not just a JSON string, then we don't consider it
@@ -634,12 +634,12 @@ isPackageVersionInMetadata packageName version metadataMap =
     Nothing -> false
     Just metadata -> isVersionInMetadata version metadata
 
-checkIndexExists :: Aff Unit
-checkIndexExists = do
+checkIndexExists :: FilePath -> Aff Unit
+checkIndexExists dir = do
   log "Checking if the registry-index is present..."
-  whenM (not <$> FS.exists indexDir) do
+  whenM (not <$> FS.exists dir) do
     error "Didn't find the 'registry-index' repo, cloning..."
-    Except.runExceptT (runGit [ "clone", "https://github.com/purescript/registry-index.git", indexDir ] Nothing) >>= case _ of
+    Except.runExceptT (runGit [ "clone", "https://github.com/purescript/registry-index.git", dir ] Nothing) >>= case _ of
       Left err -> Aff.throwError $ Aff.error err
       Right _ -> log "Successfully cloned the 'registry-index' repo"
 

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -59,6 +59,43 @@ derive newtype instance Eq Owner
 derive newtype instance Show Owner
 derive newtype instance RegistryJson Owner
 
+newtype PackageSet = PackageSet
+  { compiler :: Version
+  , packages :: Map PackageName Version
+  }
+
+derive instance Newtype PackageSet _
+derive newtype instance Eq PackageSet
+derive newtype instance Show PackageSet
+
+instance RegistryJson PackageSet where
+  encode (PackageSet plan) = Json.encode plan
+  decode = map PackageSet <<< Json.decode
+
+newtype LegacyPackageSet = LegacyPackageSet (Map PackageName LegacyPackageSetEntry)
+
+derive instance Newtype LegacyPackageSet _
+derive newtype instance Eq LegacyPackageSet
+derive newtype instance Show LegacyPackageSet
+
+instance RegistryJson LegacyPackageSet where
+  encode (LegacyPackageSet plan) = Json.encode plan
+  decode = map LegacyPackageSet <<< Json.decode
+
+newtype LegacyPackageSetEntry = LegacyPackageSetEntry 
+  { dependencies :: Array PackageName
+  , repo :: String
+  , version :: RawVersion
+  }
+
+derive instance Newtype LegacyPackageSetEntry _
+derive newtype instance Eq LegacyPackageSetEntry
+derive newtype instance Show LegacyPackageSetEntry
+
+instance RegistryJson LegacyPackageSetEntry where
+  encode (LegacyPackageSetEntry plan) = Json.encode plan
+  decode = map LegacyPackageSetEntry <<< Json.decode
+
 -- | A compiler version and exact dependency versions that should be used to
 -- | compile a newly-uploaded package as an API verification check.
 -- |

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -62,7 +62,7 @@ derive newtype instance RegistryJson Owner
 
 newtype PackageSet = PackageSet
   { compiler :: Version
-  , date :: RFC3339String
+  , publishedTime :: RFC3339String
   , packages :: Map PackageName Version
   , version :: Version
   }

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -82,7 +82,7 @@ instance RegistryJson LegacyPackageSet where
   encode (LegacyPackageSet plan) = Json.encode plan
   decode = map LegacyPackageSet <<< Json.decode
 
-newtype LegacyPackageSetEntry = LegacyPackageSetEntry 
+newtype LegacyPackageSetEntry = LegacyPackageSetEntry
   { dependencies :: Array PackageName
   , repo :: String
   , version :: RawVersion

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -2,6 +2,7 @@ module Registry.Schema where
 
 import Registry.Prelude
 
+import Data.Date (Date)
 import Data.Generic.Rep as Generic
 import Data.Map as Map
 import Data.RFC3339String (RFC3339String)
@@ -61,7 +62,9 @@ derive newtype instance RegistryJson Owner
 
 newtype PackageSet = PackageSet
   { compiler :: Version
+  , date :: RFC3339String
   , packages :: Map PackageName Version
+  , version :: Version
   }
 
 derive instance Newtype PackageSet _

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -45,7 +45,7 @@ main :: Effect Unit
 main = Aff.launchAff_ do
   _ <- Dotenv.loadFile
 
-  API.checkIndexExists
+  API.checkIndexExists API.indexDir
 
   log "Starting import from legacy registries..."
   { registry, reservedNames } <- downloadLegacyRegistry

--- a/ci/src/Registry/Scripts/LegacyImport.purs
+++ b/ci/src/Registry/Scripts/LegacyImport.purs
@@ -21,9 +21,8 @@ import Registry.Json as Json
 import Registry.PackageGraph as Graph
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
-import Registry.PackageUpload as Upload
-import Registry.RegistryM (Env, readPackagesMetadata, runRegistryM, updatePackagesMetadata)
-import Registry.Schema (BuildPlan(..), Location(..), Manifest(..), Metadata, Operation(..))
+import Registry.RegistryM (readPackagesMetadata, runRegistryM, updatePackagesMetadata)
+import Registry.Schema (BuildPlan(..), Location(..), Manifest(..), Operation(..))
 import Registry.Scripts.LegacyImport.Error (APIResource(..), ImportError(..), ManifestError(..), PackageFailures(..), RemoteResource(..), RequestError(..))
 import Registry.Scripts.LegacyImport.Manifest as Manifest
 import Registry.Scripts.LegacyImport.Process as Process

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -1,0 +1,82 @@
+module Registry.Scripts.PublishPackageSet where
+
+import Registry.Prelude
+
+import Data.Array as Array
+import Data.DateTime as DateTime
+import Data.Int as Int
+import Data.Map as Map
+import Data.PreciseDateTime as PDT
+import Data.Time.Duration (Hours(..))
+import Effect.Aff as Aff
+import Effect.Console as Console
+import Effect.Now (nowDateTime)
+import Effect.Now as Now
+import Effect.Ref as Ref
+import Foreign.Tmp as Tmp
+import Node.Process as Node.Process
+import Registry.API as API
+import Registry.Json as Json
+import Registry.PackageName (PackageName)
+import Registry.RegistryM (runRegistryM)
+import Registry.Schema (LegacyPackageSet(..))
+import Registry.Utils (mkLocalEnv, wget)
+import Registry.Version (Version)
+
+{-
+First, we read the contents of the latest package set release and gather all package versions that have been uploaded to the registry since that release. These package versions are the "batch" of packages that we are considering for automatic inclusion to the next package set.
+
+Second, we filter out any packages where, based on their metadata and manifest files alone, we know they can't be added to the package set. This happens for one of three reasons: they have a dependency that isn't in the package sets, or they had multiple releases since the last package set, in which case we only take the highest version, or c) they already have a higher version number released  in the previous package set. In any of these cases, we remove the package from consideration.
+-}
+
+-- 
+
+main :: Effect Unit
+main = Aff.launchAff_ do
+  liftEffect $ Console.log "Starting package set publishing..."
+
+  packagesMetadataRef <- API.mkMetadataRef
+
+  tmpDir <- liftEffect $ Tmp.mkTmpDir
+  liftEffect $ Node.Process.chdir tmpDir
+
+  API.checkIndexExists
+
+  metadata <- liftEffect $ Ref.read packagesMetadataRef
+  liftEffect $ Console.log (show metadata)
+
+  now <- liftEffect $ Now.nowDateTime
+
+  let
+    newUploads :: Array (Tuple PackageName (Array Version))
+    newUploads = do
+      Tuple packageName packageMetadata <- Map.toUnfoldable metadata
+      let
+        versions :: Array Version
+        versions = do
+          Tuple version { publishedTime } <- Map.toUnfoldable packageMetadata.published
+          published <- maybe [] (pure <<< PDT.toDateTimeLossy) (PDT.fromRFC3339String publishedTime)
+          let diff = DateTime.diff now published
+          guardA (diff <= Hours (Int.toNumber 100)) -- TODO - 24 or 25 hours lookback
+          pure version
+
+      guardA (not (Array.null versions))
+      pure $ Tuple packageName versions
+
+  liftEffect $ Console.log (show newUploads)
+
+  liftEffect $ Console.log "Fetching latest package set..."
+
+  runRegistryM (mkLocalEnv packagesMetadataRef) do
+    wget "https://raw.githubusercontent.com/purescript/package-sets/master/packages.json" "packages.json"
+
+  (packageSetResult :: Either String LegacyPackageSet) <- Json.readJsonFile "packages.json"
+
+  packageSet :: LegacyPackageSet <- case packageSetResult of
+    Left err -> unsafeCrashWith err
+    Right packageSet -> pure packageSet
+
+  liftEffect $ Console.log (show packageSet)
+
+
+  pure unit

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -20,7 +20,7 @@ import Registry.Index as Index
 import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.RegistryM (runRegistryM)
-import Registry.Schema (LegacyPackageSet(..), LegacyPackageSetEntry(..), Manifest(..))
+import Registry.Schema (LegacyPackageSet(..), LegacyPackageSetEntry(..))
 import Registry.Utils (mkLocalEnv, wget)
 import Registry.Version (Version)
 import Registry.Version as Version
@@ -35,7 +35,7 @@ main = Aff.launchAff_ do
   liftEffect $ Node.Process.chdir tmpDir
 
   API.checkIndexExists "registry-index"
-  registryIndex <- Index.readRegistryIndex "registry-index"
+  _ <- Index.readRegistryIndex "registry-index"
 
   metadata <- liftEffect $ Ref.read packagesMetadataRef
 
@@ -84,11 +84,6 @@ main = Aff.launchAff_ do
           | Right v <- Version.parseVersion Version.Lenient v'
           , v < version -> pure version
         _ -> []
-      manifests <- Array.fromFoldable (Map.lookup packageName registryIndex)
-      Manifest manifest <- Array.fromFoldable (Map.lookup checkedVersion manifests)
-      let dependencies = Array.fromFoldable (Map.keys manifest.dependencies)
-      -- Reject any package@version with dependencies not in the package set
-      guardA (Array.all (\dependency -> isJust (Map.lookup dependency packageSet)) dependencies)
       pure (Tuple packageName checkedVersion)
 
   liftEffect $ Console.log "Found the following uploads eligible for inclusion in package set:"

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -3,6 +3,7 @@ module Registry.Scripts.PublishPackageSet where
 import Registry.Prelude
 
 import Data.Array as Array
+import Data.Array.NonEmpty as NonEmptyArray
 import Data.DateTime as DateTime
 import Data.Int as Int
 import Data.Map as Map
@@ -10,7 +11,6 @@ import Data.PreciseDateTime as PDT
 import Data.Time.Duration (Hours(..))
 import Effect.Aff as Aff
 import Effect.Console as Console
-import Effect.Now (nowDateTime)
 import Effect.Now as Now
 import Effect.Ref as Ref
 import Foreign.Tmp as Tmp
@@ -19,17 +19,10 @@ import Registry.API as API
 import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.RegistryM (runRegistryM)
-import Registry.Schema (LegacyPackageSet(..))
+import Registry.Schema (LegacyPackageSet(..), LegacyPackageSetEntry(..))
 import Registry.Utils (mkLocalEnv, wget)
 import Registry.Version (Version)
-
-{-
-First, we read the contents of the latest package set release and gather all package versions that have been uploaded to the registry since that release. These package versions are the "batch" of packages that we are considering for automatic inclusion to the next package set.
-
-Second, we filter out any packages where, based on their metadata and manifest files alone, we know they can't be added to the package set. This happens for one of three reasons: they have a dependency that isn't in the package sets, or they had multiple releases since the last package set, in which case we only take the highest version, or c) they already have a higher version number released  in the previous package set. In any of these cases, we remove the package from consideration.
--}
-
--- 
+import Registry.Version as Version
 
 main :: Effect Unit
 main = Aff.launchAff_ do
@@ -43,40 +36,53 @@ main = Aff.launchAff_ do
   API.checkIndexExists
 
   metadata <- liftEffect $ Ref.read packagesMetadataRef
-  liftEffect $ Console.log (show metadata)
 
   now <- liftEffect $ Now.nowDateTime
 
   let
-    newUploads :: Array (Tuple PackageName (Array Version))
+    newUploads :: Array (Tuple PackageName (NonEmptyArray Version))
     newUploads = do
       Tuple packageName packageMetadata <- Map.toUnfoldable metadata
       let
-        versions :: Array Version
-        versions = do
+        versions' :: Array Version
+        versions' = do
           Tuple version { publishedTime } <- Map.toUnfoldable packageMetadata.published
           published <- maybe [] (pure <<< PDT.toDateTimeLossy) (PDT.fromRFC3339String publishedTime)
           let diff = DateTime.diff now published
-          guardA (diff <= Hours (Int.toNumber 100)) -- TODO - 24 or 25 hours lookback
+          guardA (diff <= Hours (Int.toNumber 1000)) -- TODO - 24 or 25 hours lookback
           pure version
 
-      guardA (not (Array.null versions))
-      pure $ Tuple packageName versions
-
-  liftEffect $ Console.log (show newUploads)
+      versions <- Array.fromFoldable (NonEmptyArray.fromArray versions')
+      pure (Tuple packageName versions)
 
   liftEffect $ Console.log "Fetching latest package set..."
 
   runRegistryM (mkLocalEnv packagesMetadataRef) do
     wget "https://raw.githubusercontent.com/purescript/package-sets/master/packages.json" "packages.json"
 
-  (packageSetResult :: Either String LegacyPackageSet) <- Json.readJsonFile "packages.json"
+  packageSetResult :: Either String LegacyPackageSet <- Json.readJsonFile "packages.json"
 
-  packageSet :: LegacyPackageSet <- case packageSetResult of
+  LegacyPackageSet packageSet :: LegacyPackageSet <- case packageSetResult of
     Left err -> unsafeCrashWith err
     Right packageSet -> pure packageSet
 
-  liftEffect $ Console.log (show packageSet)
+  liftEffect $ Console.log "Computing candidates for inclusion in package set..."
 
+  let 
+    uploads :: Array (Tuple PackageName Version)
+    uploads = do
+      Tuple packageName versions' <- newUploads
+      -- We only care about the latest version
+      let versions = NonEmptyArray.reverse (NonEmptyArray.sort versions')
+      let version = NonEmptyArray.head versions
+      case Map.lookup packageName packageSet of
+        Nothing -> pure (Tuple packageName version)
+        Just (LegacyPackageSetEntry { version: RawVersion v' })
+          | Right v <- Version.parseVersion Version.Lenient v'
+          , v < version -> pure (Tuple packageName version)
+        _ -> []
+
+  liftEffect $ Console.log "Found the following uploads eligible for inclusion in package set:"
+  liftEffect $ Console.log (show uploads)
 
   pure unit

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -70,7 +70,7 @@ main = Aff.launchAff_ do
 
   liftEffect $ Console.log "Computing candidates for inclusion in package set..."
 
-  let 
+  let
     uploads :: Array (Tuple PackageName Version)
     uploads = do
       Tuple packageName versions' <- newUploads

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -19,7 +19,7 @@ import Registry.API as API
 import Registry.Index as Index
 import Registry.Json as Json
 import Registry.PackageName (PackageName)
-import Registry.RegistryM (runRegistryM)
+import Registry.RegistryM (runRegistryM, throwWithComment)
 import Registry.Schema (LegacyPackageSet(..), LegacyPackageSetEntry(..))
 import Registry.Utils (mkLocalEnv, wget)
 import Registry.Version (Version)
@@ -42,6 +42,7 @@ main = Aff.launchAff_ do
   now <- liftEffect $ Now.nowDateTime
 
   let
+    -- TODO: Use latest package's `publishedTime` to find new uploads.
     newUploads :: Array (Tuple PackageName (NonEmptyArray Version))
     newUploads = do
       Tuple packageName packageMetadata <- Map.toUnfoldable metadata

--- a/ci/src/Registry/Utils.purs
+++ b/ci/src/Registry/Utils.purs
@@ -3,7 +3,10 @@ module Registry.Utils where
 import Registry.Prelude
 
 import Node.ChildProcess as NodeProcess
-import Registry.RegistryM (RegistryM, throwWithComment)
+import Registry.PackageName (PackageName)
+import Registry.PackageUpload as Upload
+import Registry.RegistryM (RegistryM, Env, throwWithComment)
+import Registry.Schema (Metadata)
 import Sunde as Process
 
 wget :: String -> FilePath -> RegistryM Unit
@@ -15,3 +18,15 @@ wget url path = do
   case result.exit of
     NodeProcess.Normally 0 -> pure unit
     _ -> throwWithComment $ "Error while fetching tarball: " <> result.stderr
+
+mkLocalEnv :: Ref (Map PackageName Metadata) -> Env
+mkLocalEnv packagesMetadata =
+  { comment: \err -> error err
+  , closeIssue: log "Skipping GitHub issue closing, we're running locally.."
+  , commitToTrunk: \_ _ -> do
+      log "Skipping committing to trunk.."
+      pure (Right unit)
+  , uploadPackage: Upload.upload
+  , deletePackage: Upload.delete
+  , packagesMetadata
+  }

--- a/ci/src/Registry/Utils.purs
+++ b/ci/src/Registry/Utils.purs
@@ -1,0 +1,17 @@
+module Registry.Utils where
+
+import Registry.Prelude
+
+import Node.ChildProcess as NodeProcess
+import Registry.RegistryM (RegistryM, throwWithComment)
+import Sunde as Process
+
+wget :: String -> FilePath -> RegistryM Unit
+wget url path = do
+  let cmd = "wget"
+  let stdin = Nothing
+  let args = [ "-O", path, url ]
+  result <- liftAff $ Process.spawn { cmd, stdin, args } NodeProcess.defaultSpawnOptions
+  case result.exit of
+    NodeProcess.Normally 0 -> pure unit
+    _ -> throwWithComment $ "Error while fetching tarball: " <> result.stderr


### PR DESCRIPTION
First steps towards #387

This PR introduces a script that will be used to implement automatic package sets. Right now, it does the following:

1. Fetch the registry index (used to get at manifests)
2. Fetch the registry metadata
3. Find all package uploads within the last 24 hours (via referencing the `publishedTime` field in metadata)
4. Fetch the latest package set
5. Preprocess the package uploads found in step (3), via:
  * Checking that the package isn't in the package set
  * If the package is in the package set, making sure that the uploaded version is later than the version found in the package set
  * Checking that each dependency for the upload is in the package set (See note)
6. Reports the preprocessed package upload candidates.

After this PR, we can find mutually dependent package uploads, and then continue with validation as laid out in #380.
 
Note: I added the check that each dependency for an upload is in the package set after some brief conversations with @thomashoneyman. However, as I thought more about it, I think the check is too aggressive. It is possible for a user to upload a package whose dependencies are not in the latest package set, but also to upload those dependencies all in the same day. I think the ideal workflow in that case is to group those uploads together as a batch and attempt to add them all to the package set at once - if it works, then they are all included in the package set, and if it doesn't, the smallest viable subset of them is included. The existing dependencies check doesn't allow us to gracefully handle this situation.

If people agree that the dependencies check is premature at this point, I'll remove it and we can handle it in the later stages.