### PR TITLE
Rename eviefp packages

### DIFF
--- a/bower-packages.json
+++ b/bower-packages.json
@@ -1191,7 +1191,7 @@
   "purescript-sodium": "https://github.com/SodiumFRP/purescript-sodium.git",
   "purescript-solc": "https://github.com/f-o-a-m/purescript-solc.git",
   "purescript-son-of-a-j": "https://github.com/paluh/purescript-son-of-a-j.git",
-  "purescript-sorted-arrays": "https://github.com/vladciobanu/purescript-sorted-arrays.git",
+  "purescript-sorted-arrays": "https://github.com/eviefp/purescript-sorted-arrays.git",
   "purescript-soundcloud": "https://github.com/vyorkin/purescript-handsontable.git",
   "purescript-soundfonts": "https://github.com/newlandsvalley/purescript-soundfonts.git",
   "purescript-sparkle": "https://github.com/sharkdp/purescript-sparkle.git",

--- a/new-packages.json
+++ b/new-packages.json
@@ -63,7 +63,7 @@
   "purescript-parsing-foreign": "https://github.com/markfarrell/purescript-parsing-foreign.git",
   "purescript-nested-functor": "https://github.com/acple/purescript-nested-functor.git",
   "purescript-pwned-passwords": "https://github.com/maxdeviant/purescript-pwned-passwords.git",
-  "purescript-pointed": "https://github.com/vladciobanu/purescript-pointed.git",
+  "purescript-pointed": "https://github.com/eviefp/purescript-pointed.git",
   "purescript-debugged": "https://github.com/hdgarrood/purescript-debugged.git",
   "purescript-task": "https://github.com/ursi/purescript-task.git",
   "purescript-downloadjs": "https://github.com/chekoopa/purescript-downloadjs.git",


### PR DESCRIPTION
The proper upstream account for these packages is `@eviefp`.