### PR TITLE
Automated Package Sets: Read package set from registry repository

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -126,7 +126,7 @@ Package sets are stored in the `registry` repository under the `package-sets` di
 
 1. `version`, which is a string containing the SemVer package set version for this set.
 2. `compiler`, which is a string containing the SemVer compiler version used to verify the package set.
-3. `date`, which is a date string in YYYY-MM-DD format that describes which day this package set was produced.
+3. `published`, which is a date string in YYYY-MM-DD format that describes which day this package set was produced.
 4. `packages`, which is an object in which keys are package names and values are package versions (a SemVer version).
 
 For example, in JSON:
@@ -134,7 +134,7 @@ For example, in JSON:
 ```json
 {
   "version": "2.3.1",
-  "date": "2022-04-19",
+  "published": "2022-04-19",
   "compiler": "0.14.9",
   "packages": {
     "aff": "5.0.0",
@@ -145,15 +145,7 @@ For example, in JSON:
 
 #### Package Set Naming Conventions
 
-Package sets use the following naming convention:
-
-`MAJOR.MINOR.PATCH+YYYY-MM-DD-purs-MAJOR.MINOR.PATCH`
-
-The first major/minor/patch version refers to the package set version. The date refers to the date the package set was produced. The `purs-` major/minor/patch version refers to the compiler version used to produce the set. Here's an example package set version:
-
-`2.3.1+2022-04-19-purs-0_14_9`
-
-This information is also contained in the package set file itself.
+Package sets use the same versioning scheme as packages in the registry: semantic versions with no build metadata or prerelease identifiers. The package set version can be used to determine if is is safe for your project to update to a new package set. We version according to the following rules:
 
 The package sets version number can be used to determine if it is safe for your project to update to a new package set. We version according to the following rules:
 
@@ -193,7 +185,7 @@ Fourth, we release the new package set (if we could produce one). Automatic pack
 2. If the highest SemVer upgrade in the set was a minor version, or any new packages were added to the package set, then the package set increments a minor version.
 3. If the highest SemVer upgrade in the set was a patch version, then the package set increments a patch version.
 
-For example, if the previous release was `2.1.1+2022-06-01-purs-0_15_2` (`2.1.1` for short), and the next day no packages changed versions but a new package was registered, the new version would be `2.2.0+2022-06-02-purs-0_15_2` (`2.2.0` for short).
+For example, if the previous release was `2.1.1`, and the next day no packages changed versions but a new package was registered, the new version would be `2.2.0`.
 
 #### Manual Intervention in the Package Sets via the Package Sets API
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,7 +147,6 @@ For example, in JSON:
 
 Package sets use the same versioning scheme as packages in the registry: semantic versions with no build metadata or prerelease identifiers. The package set version can be used to determine if is is safe for your project to update to a new package set. We version according to the following rules:
 
-The package sets version number can be used to determine if it is safe for your project to update to a new package set. We version according to the following rules:
 
 1. The major version is incremented when breaking changes occur in the package set: a package is removed, or a major version of a package in the set is incremented.
 2. The minor version is incremented when new packages are added to the package set, or when there was a minor version update in the package set.

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -85,7 +85,7 @@ dateFormatter = List.fromFoldable
 
 newtype PackageSet = PackageSet
   { compiler :: Version
-  , publishedTime :: Date
+  , published :: Date
   , packages :: Map PackageName Version
   , version :: Version
   }

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -2,6 +2,7 @@ module Registry.Scripts.PublishPackageSet where
 
 import Registry.Prelude
 
+import Control.Monad.Reader (asks)
 import Data.Array as Array
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.DateTime as DateTime
@@ -95,7 +96,8 @@ main = Aff.launchAff_ do
 
     liftEffect $ Console.log "Fetching latest package set..."
 
-    packageSets <- liftAff $ FS.Aff.readdir (Path.concat [ "registry", "package-sets" ])
+    registryPath <- asks _.registry
+    packageSets <- liftAff $ FS.Aff.readdir (Path.concat [ registryPath, "package-sets" ])
 
     let
       packageSetVersions :: Array Version

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -53,7 +53,6 @@ main = Aff.launchAff_ do
   let
     env :: Env
     env =
-      -- TODO: Do we need to comment?
       { comment: mempty
       , closeIssue: mempty
       , commitMetadataFile: \_ _ -> pure (Right unit)
@@ -95,13 +94,6 @@ main = Aff.launchAff_ do
         pure (Tuple packageName versions)
 
     liftEffect $ Console.log "Fetching latest package set..."
-
-    -- Read package set directory from "registry" - FS.Aff.readDir
-    -- Trim JSON extension, parse versions, sort, take highest version
-    -- Check purescript-formatters for formatDateTime
-    -- Read that file as `PackageSet` - Date (YYYY-MM-DD, add newtype around DateTime, format as YYYY-MM-DD), not RFC3339String - to compare: date, then version
-    --    encode :: turn string to datetime
-    --    decode :: turn string to datetime, then print
 
     packageSets <- liftAff $ FS.Aff.readdir (Path.concat [ "registry", "package-sets" ])
 
@@ -147,13 +139,5 @@ main = Aff.launchAff_ do
 
     liftEffect $ Console.log "Found the following uploads eligible for inclusion in package set:"
     liftEffect $ Console.log (show uploads)
-
-    -- NOTE:
-    --    - Compute eligible uploads
-    --    - Compute batches via dependencies
-    --    - Make sure dependencies are in the package set unioned with the batch
-
-
-    -- Determine semver 
 
     pure unit

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -101,7 +101,7 @@ main = Aff.launchAff_ do
 
     let
       packageSetVersions :: Array Version
-      packageSetVersions = packageSets # Array.mapMaybe \s -> do 
+      packageSetVersions = packageSets # Array.mapMaybe \s -> do
         let versionString = String.take (String.length s - 5) s
         hush $ Version.parseVersion Version.Lenient versionString
 
@@ -117,7 +117,7 @@ main = Aff.launchAff_ do
     packageSetPath :: FilePath <- case latestPackageSet of
       Nothing -> unsafeCrashWith "ERROR: No existing package set."
       Just packageSetPath -> pure packageSetPath
-    
+
     packageSetResult :: Either String PackageSet <- liftAff $ Json.readJsonFile packageSetPath
 
     PackageSet { packages } :: PackageSet <- case packageSetResult of


### PR DESCRIPTION
Part of https://github.com/purescript/registry/issues/387

Modifies the package set publishing script to read the latest package set from the registry repository instead of from the package-sets repo.

To compute the "latest" package set, we read the directory containing the package sets, parse the versions, and take the latest one.

As part of this I've updated the schema for the `PackageSet` type, bringing it up to date with the spec. In particular, the `publishedTime` field is now called `published`, and it contains a date string in YYYY-MM-DD format.