### PR TITLE
Implement automatic batch processing for package sets

### DIFF
--- a/ci/src/Foreign/Node/FS.js
+++ b/ci/src/Foreign/Node/FS.js
@@ -4,5 +4,5 @@ exports.ensureDirectoryImpl = (path) => () => fs.ensureDir(path);
 
 exports.removeImpl = (path) => () => fs.remove(path);
 
-exports.copyImpl = (source) => (destination) => () =>
-  fs.copy(source, destination);
+exports.copyImpl = (source) => (destination) => (options) => () =>
+  fs.copy(source, destination, options);

--- a/ci/src/Foreign/Node/FS.purs
+++ b/ci/src/Foreign/Node/FS.purs
@@ -26,7 +26,17 @@ foreign import removeImpl :: String -> Effect (Promise Unit)
 remove :: FilePath -> Aff Unit
 remove = removeImpl >>> Promise.toAffE
 
-foreign import copyImpl :: String -> String -> Effect (Promise Unit)
+type JSCopyOptions =
+  { preserveTimestamps :: Boolean
+  }
+
+foreign import copyImpl :: String -> String -> JSCopyOptions -> Effect (Promise Unit)
+
+type CopyArgs =
+  { from :: FilePath
+  , to :: FilePath
+  , preserveTimestamps :: Boolean
+  }
 
 -- | Copies a file or directory. If a file or directory already exists at the
 -- | destination, that file or directory will be overwritten.
@@ -35,5 +45,5 @@ foreign import copyImpl :: String -> String -> Effect (Promise Unit)
 -- |
 -- | When `from` is a directory then `to` must be a directory; only directory
 -- | contents are copied, not the directory itself.
-copy :: { from :: FilePath, to :: FilePath } -> Aff Unit
-copy { from, to } = Promise.toAffE $ copyImpl from to
+copy :: CopyArgs -> Aff Unit
+copy { from, to, preserveTimestamps } = Promise.toAffE $ copyImpl from to { preserveTimestamps }

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -951,7 +951,7 @@ copyPackageSourceFiles files { source, destination } = do
 
   let
     copyFiles = userFiles <> includedFiles.succeeded <> includedInsensitiveFiles.succeeded
-    makePaths path = { from: Path.concat [ source, path ], to: Path.concat [ destination, path ] }
+    makePaths path = { from: Path.concat [ source, path ], to: Path.concat [ destination, path ], preserveTimestamps: false }
 
   liftAff $ traverse_ (makePaths >>> FS.Extra.copy) copyFiles
 

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -235,12 +235,12 @@ tryBatch :: PackageSet -> Map PackageName Version -> Aff (Either CompilerFailure
 tryBatch (PackageSet set) packages = do
   let backupDir = "output-backup"
   let outputDir = "output"
-  FSE.copy { from: outputDir, to: backupDir }
+  FSE.copy { from: outputDir, to: backupDir, preserveTimestamps: true }
   installPackages packages
   compileInstalledPackages set.compiler >>= case _ of
     Left err -> do
       FSE.remove outputDir
-      FSE.copy { from: backupDir, to: outputDir }
+      FSE.copy { from: backupDir, to: outputDir, preserveTimestamps: true }
       removePackages (Map.keys packages)
       pure $ Left err
     Right _ -> do
@@ -256,12 +256,12 @@ tryPackage :: PackageSet -> PackageName -> Version -> Aff (Either CompilerFailur
 tryPackage (PackageSet set) package version = do
   let backupDir = "output-backup"
   let outputDir = "output"
-  FSE.copy { from: outputDir, to: backupDir }
+  FSE.copy { from: outputDir, to: backupDir, preserveTimestamps: true }
   installPackage package version
   compileInstalledPackages set.compiler >>= case _ of
     Left err -> do
       FSE.remove outputDir
-      FSE.copy { from: backupDir, to: outputDir }
+      FSE.copy { from: backupDir, to: outputDir, preserveTimestamps: true }
       removePackage package
       pure $ Left err
     Right _ -> do

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -148,10 +148,11 @@ main = Aff.launchAff_ do
     liftEffect $ Console.log "Found the following uploads eligible for inclusion in package set:"
     liftEffect $ Console.log (show uploads)
 
-    buildPackageSet (unsafeFromRight packageSetResult) >>= case _ of
+    buildPackageSet tmpDir (unsafeFromRight packageSetResult) >>= case _ of
       Left MissingCompiler -> logShow "Missing compiler"
-      Left (UnknownError err) -> log err
-      Right str -> log str
+      Left (CompilationError err) -> log $ "Failed compilation: " <> err
+      Left (UnknownError err) -> log $ "Unknown error: " <> err
+      Right _ -> log "All good!"
 
     pure unit
 

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -153,7 +153,7 @@ main = Aff.launchAff_ do
     liftEffect $ Console.log "Found the following uploads eligible for inclusion in package set:"
     liftEffect $ Console.log (show uploads)
 
-    result <- processBatch tmpDir packageSet (Map.fromFoldable uploads)
+    result <- processBatch packageSet (Map.fromFoldable uploads)
     logShow result
 
 type BatchResult =
@@ -164,8 +164,10 @@ type BatchResult =
 
 -- | Attempt to produce a new package set from the given package set by adding
 -- | the provided packages.
-processBatch :: FilePath -> PackageSet -> Map PackageName Version -> RegistryM BatchResult
-processBatch tmp prevSet@(PackageSet { compiler }) batch = do
+processBatch :: PackageSet -> Map PackageName Version -> RegistryM BatchResult
+processBatch prevSet@(PackageSet { compiler }) batch = do
+  tmp <- liftEffect Process.cwd
+
   let
     handleCompilerError = case _ of
       MissingCompiler -> throwError $ Aff.error $ "Missing compiler version " <> Version.printVersion compiler

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -148,11 +148,10 @@ main = Aff.launchAff_ do
     liftEffect $ Console.log "Found the following uploads eligible for inclusion in package set:"
     liftEffect $ Console.log (show uploads)
 
-    buildPackageSet tmpDir (unsafeFromRight packageSetResult) >>= case _ of
+    buildPackageSet (unsafeFromRight packageSetResult) >>= case _ of
       Left MissingCompiler -> logShow "Missing compiler"
-      Left (CompilationError err) -> log $ "Failed compilation: " <> err
-      Left (UnknownError err) -> log $ "Unknown error: " <> err
-      Right _ -> log "All good!"
+      Left (UnknownError err) -> log err
+      Right str -> log str
 
     pure unit
 

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -522,6 +522,8 @@ compilerVersions = do
         Left err -> case err of
           MissingCompiler ->
             Assert.fail "MissingCompiler"
+          CompilationError err' ->
+            Assert.fail ("CompilationError: " <> err')
           UnknownError err' ->
             Assert.fail ("UnknownError: " <> err')
         Right stdout ->


### PR DESCRIPTION
This PR introduces `processBatch`, which is a function you can use to install the current package set, build it, and then attempt to integrate a batch of new packages to the package set. It reports which packages could be added, which ones couldn't, and returns a new package set with the additions that is ready to be published.

Notably, the compiler does not report compilation errors to `stderr`, so I needed to add another constructor to our `callCompiler` output to capture that case.

Using the 1.0.0 package set from the registry-preview repository this successfully compiles the set. In addition, with the below manual batch, we produce a new package set:

```purs
   let
      testPackages = Map.fromFoldable
        [ mkEntry "datetime" "6.1.0"
        ]
        where
        mkEntry name version =
          Tuple (unsafeFromRight (PackageName.parse name)) (unsafeFromRight (Version.parseVersion Version.Lenient version))
```

Once this is merged we should be able to use this to bridge the gap between finding packages to upload and actually publishing the new set.