### PR TITLE
Automatic Package Sets: Write package set files to upstream repo

### DIFF
--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -1157,7 +1157,7 @@ callCompiler compilerArgs = do
         | errorMessage == String.joinWith " " [ "spawn", cmd, "ENOENT" ] -> MissingCompiler
         | otherwise -> UnknownError errorMessage
     Right { exit: NodeProcess.Normally 0, stdout } -> Right $ String.trim stdout
-    Right { stderr, stdout } -> Left do
+    Right { stdout } -> Left do
       case Json.parseJson (String.trim stdout) of
         Left err -> UnknownError $ String.joinWith "\n" [ stdout, err ]
         Right ({ errors } :: { errors :: Array CompilerError })

--- a/ci/src/Registry/Schema.purs
+++ b/ci/src/Registry/Schema.purs
@@ -84,7 +84,12 @@ derive newtype instance Eq PackageSet
 derive newtype instance Show PackageSet
 
 instance RegistryJson PackageSet where
-  encode (PackageSet set) = Json.encode (set { published = Formatter.DateTime.format dateFormatter set.published })
+  -- This instance is manually encoded so we can control the order of fields.
+  encode (PackageSet set) = Json.encodeObject do
+    "version" := set.version
+    "compiler" := set.compiler
+    "published" := Formatter.DateTime.format dateFormatter set.published
+    "packages" := set.packages
   decode json = do
     fields <- Json.decode json
     published <- Formatter.DateTime.unformat dateFormatter fields.published

--- a/ci/src/Registry/Scripts/LegacyImporter.purs
+++ b/ci/src/Registry/Scripts/LegacyImporter.purs
@@ -87,6 +87,7 @@ main = launchAff_ do
         , closeIssue: log "Running locally, not closing issue..."
         , commitMetadataFile: API.pacchettiBottiPushToRegistryMetadata
         , commitIndexFile: API.pacchettiBottiPushToRegistryIndex
+        , commitPackageSetFile: \_ _ -> log "Not committing package set in legacy import." $> Right unit
         , uploadPackage: Upload.upload
         , deletePackage: Upload.delete
         , packagesMetadata: metadataRef

--- a/ci/src/Registry/Scripts/PublishPackageSet.purs
+++ b/ci/src/Registry/Scripts/PublishPackageSet.purs
@@ -17,7 +17,6 @@ import Data.String as String
 import Data.Time.Duration (Hours(..))
 import Dotenv as Dotenv
 import Effect.Aff as Aff
-import Effect.Console as Console
 import Effect.Exception (throw)
 import Effect.Now as Now
 import Effect.Ref as Ref
@@ -39,7 +38,7 @@ import Registry.Json as Json
 import Registry.PackageGraph as PackageGraph
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
-import Registry.RegistryM (Env, RegistryM, readPackagesMetadata, runRegistryM)
+import Registry.RegistryM (Env, RegistryM, commitPackageSetFile, readPackagesMetadata, runRegistryM)
 import Registry.Schema (Manifest(..), PackageSet(..))
 import Registry.Version (Version)
 import Registry.Version as Version
@@ -48,7 +47,7 @@ main :: Effect Unit
 main = Aff.launchAff_ do
   _ <- Dotenv.loadFile
 
-  liftEffect $ Console.log "Starting package set publishing..."
+  log "Starting package set publishing..."
 
   githubToken <- liftEffect do
     Process.lookupEnv "GITHUB_TOKEN"
@@ -69,6 +68,7 @@ main = Aff.launchAff_ do
       , closeIssue: mempty
       , commitMetadataFile: \_ _ -> pure (Right unit)
       , commitIndexFile: \_ _ -> pure (Right unit)
+      , commitPackageSetFile: API.pacchettiBottiPushToRegistryPackageSets
       , uploadPackage: mempty
       , deletePackage: mempty
       , octokit
@@ -105,41 +105,36 @@ main = Aff.launchAff_ do
         versions <- Array.fromFoldable (NonEmptyArray.fromArray versions')
         pure (Tuple packageName versions)
 
-    liftEffect $ Console.log "Fetching latest package set..."
+    log "Fetching latest package set..."
 
     registryPath <- asks _.registry
     packageSets <- liftAff $ FS.Aff.readdir (Path.concat [ registryPath, "package-sets" ])
 
     let
+      buildPackageSetPath :: Version -> FilePath
+      buildPackageSetPath version = Path.concat [ registryPath, "package-sets", Version.printVersion version <> ".json" ]
+
       packageSetVersions :: Array Version
       packageSetVersions = packageSets # Array.mapMaybe \s -> do
         let versionString = String.take (String.length s - 5) s
         hush $ Version.parseVersion Version.Lenient versionString
 
-      latestPackageSet :: Maybe FilePath
-      latestPackageSet = do
-        latestVersion <- Array.last (Array.sort packageSetVersions)
-        pure $ Path.concat
-          [ "registry"
-          , "package-sets"
-          , Version.printVersion latestVersion <> ".json"
-          ]
+      latestPackageSetPath :: Maybe FilePath
+      latestPackageSetPath = buildPackageSetPath <$> Array.last (Array.sort packageSetVersions)
 
-    packageSetPath :: FilePath <- case latestPackageSet of
+    packageSetPath <- case latestPackageSetPath of
       Nothing -> unsafeCrashWith "ERROR: No existing package set."
       Just packageSetPath -> pure packageSetPath
 
-    packageSetResult :: Either String PackageSet <- liftAff $ Json.readJsonFile packageSetPath
-
-    packageSet@(PackageSet { packages }) <- case packageSetResult of
+    prevPackageSet@(PackageSet { packages }) <- liftAff (Json.readJsonFile packageSetPath) >>= case _ of
       Left err -> unsafeCrashWith err
       Right packageSet -> pure packageSet
 
-    liftEffect $ Console.log "Computing candidates for inclusion in package set..."
+    log "Computing candidates for inclusion in package set..."
 
     let
-      uploads :: Array (Tuple PackageName Version)
-      uploads = do
+      uploads :: Map PackageName Version
+      uploads = Map.fromFoldable do
         Tuple packageName versions' <- recentUploads
         -- We only care about the latest version
         let version = NonEmptyArray.last (NonEmptyArray.sort versions')
@@ -150,11 +145,29 @@ main = Aff.launchAff_ do
           _ -> []
         pure (Tuple packageName checkedVersion)
 
-    liftEffect $ Console.log "Found the following uploads eligible for inclusion in package set:"
-    liftEffect $ Console.log (show uploads)
-
-    result <- processBatch packageSet (Map.fromFoldable uploads)
-    logShow result
+    if Map.isEmpty uploads then do
+      log "No new uploads eligible for inclusion in the package set."
+    else do
+      let format name version = PackageName.print name <> "@" <> Version.printVersion version
+      log "Found the following uploads eligible for inclusion in package set:"
+      forWithIndex_ uploads (\name version -> log $ format name version)
+      processBatch prevPackageSet uploads >>= case _ of
+        Nothing -> do
+          log "No packages could be added to the set. All packages failed:"
+          forWithIndex_ uploads (\name version -> log $ format name version)
+        Just { success, fail, packageSet } -> do
+          unless (Map.isEmpty fail) do
+            log "Some packages could not be added to the set:"
+            forWithIndex_ fail (\name version -> log $ format name version)
+          log "New packages were added to the set!"
+          forWithIndex_ success (\name version -> log $ format name version)
+          let
+            newVersion = (un PackageSet packageSet).version
+            newPath = buildPackageSetPath newVersion
+          liftAff $ Json.writeJsonFile newPath packageSet
+          commitPackageSetFile packageSet >>= case _ of
+            Left err -> throwError $ Aff.error $ "Failed to commit package set file: " <> err
+            Right _ -> pure unit
 
 type BatchResult =
   { fail :: Map PackageName Version
@@ -164,7 +177,7 @@ type BatchResult =
 
 -- | Attempt to produce a new package set from the given package set by adding
 -- | the provided packages.
-processBatch :: PackageSet -> Map PackageName Version -> RegistryM BatchResult
+processBatch :: PackageSet -> Map PackageName Version -> RegistryM (Maybe BatchResult)
 processBatch prevSet@(PackageSet set) batch = do
   let
     handleCompilerError = case _ of
@@ -181,10 +194,19 @@ processBatch prevSet@(PackageSet set) batch = do
       throwError $ Aff.error $ "Starting package set must compile in order to process a batch."
     Right _ -> pure unit
 
+  let
+    mkNewPackageSet :: PackageSet -> Map PackageName Version -> RegistryM PackageSet
+    mkNewPackageSet (PackageSet new) successes = do
+      now <- liftEffect Now.nowDateTime
+      let newVersion = computeVersion prevSet successes
+      pure $ PackageSet $ new { version = newVersion, published = now }
+
   -- First we attempt to add the entire batch.
   log "Compiling new batch..."
   liftAff (tryBatch prevSet batch) >>= case _ of
-    Right newSet -> pure { fail: Map.empty, success: batch, packageSet: newSet }
+    Right newSet -> do
+      packageSet <- mkNewPackageSet newSet batch
+      pure $ Just { fail: Map.empty, success: batch, packageSet }
     Left batchCompilerError -> do
       log "Batch failed to process: \n"
       handleCompilerError batchCompilerError
@@ -210,8 +232,8 @@ processBatch prevSet@(PackageSet set) batch = do
 
       -- Then we attempt to add them one-by-one.
       for_ sortedBatch \(Manifest { name, version }) -> do
-        set <- liftEffect $ Ref.read packageSetRef
-        result <- liftAff (tryPackage set name version)
+        currentSet <- liftEffect $ Ref.read packageSetRef
+        result <- liftAff (tryPackage currentSet name version)
         case result of
           -- If the package could not be added, then the state of the filesystem
           -- is rolled back. We just need to insert the package into the
@@ -228,11 +250,13 @@ processBatch prevSet@(PackageSet set) batch = do
             liftEffect $ Ref.write newSet packageSetRef
             log $ "Added " <> formatName name version
 
-      liftEffect do
-        fail <- Ref.read failRef
-        success <- Ref.read successRef
-        packageSet <- Ref.read packageSetRef
-        pure { fail, success, packageSet }
+      fail <- liftEffect $ Ref.read failRef
+      success <- liftEffect $ Ref.read successRef
+      newSet <- liftEffect $ Ref.read packageSetRef
+      if Map.isEmpty success then pure Nothing
+      else do
+        packageSet <- mkNewPackageSet newSet success
+        pure $ Just { fail, success, packageSet }
 
 -- | Attempt to add or update a collection of packages in the package set. This
 -- | operation will be rolled back if the addition fails.

--- a/ci/test/RegistrySpec.purs
+++ b/ci/test/RegistrySpec.purs
@@ -21,6 +21,7 @@ defaultTestEnv =
   , comment: mempty
   , commitMetadataFile: \_ _ -> pure (Right unit)
   , commitIndexFile: \_ _ -> pure (Right unit)
+  , commitPackageSetFile: \_ _ -> pure (Right unit)
   , deletePackage: mempty
   , uploadPackage: mempty
   , packagesMetadata: unsafePerformEffect (Ref.new Map.empty)

--- a/ci/test/scripts/PublishPursuit.purs
+++ b/ci/test/scripts/PublishPursuit.purs
@@ -39,6 +39,7 @@ main = launchAff_ $ do
       , closeIssue: mempty
       , commitMetadataFile: \_ _ -> pure (Right unit)
       , commitIndexFile: \_ _ -> pure (Right unit)
+      , commitPackageSetFile: \_ _ -> pure (Right unit)
       , uploadPackage: mempty
       , deletePackage: mempty
       , packagesMetadata: unsafePerformEffect (Ref.new Map.empty)


### PR DESCRIPTION
Partially addresses #387 by writing the new package set to disk and then committing that result upstream to the registry repo.

See: https://github.com/purescript/registry-preview/commit/e0f65691f213d9810dedab291c5f724a2c5b1cba