### PR TITLE
Legacy Importer: Refer to package set dependencies for packages with Spago files

### DIFF
--- a/ci/src/Foreign/GitHub.purs
+++ b/ci/src/Foreign/GitHub.purs
@@ -415,6 +415,15 @@ data GitHubError
 derive instance Eq GitHubError
 derive instance Ord GitHubError
 
+instance RegistryJson GitHubError where
+  encode = case _ of
+    APIError value -> Json.encode { tag: "APIError", value }
+    DecodeError value -> Json.encode { tag: "DecodeError", value }
+  decode = Json.decode >=> \obj -> (obj .: "tag") >>= case _ of
+    "APIError" -> map APIError $ obj .: "value"
+    "DecodeError" -> map DecodeError $ obj .: "value"
+    tag -> Left $ "Unexpected tag: " <> tag
+
 printGitHubError :: GitHubError -> String
 printGitHubError = case _ of
   APIError fields -> Array.fold

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -342,7 +342,15 @@ addOrUpdate { updateRef, buildPlan, packageName } inputMetadata = do
       Left _ -> throwWithComment $ "Not a valid registry version: " <> updateRef
       Right result -> pure result
 
-    Except.runExceptT (Legacy.Manifest.fetchLegacyManifest address (RawVersion updateRef)) >>= case _ of
+    legacyPackageSets <- Legacy.Manifest.fetchLegacyPackageSets
+
+    let
+      packageSetDeps = do
+        versions <- Map.lookup packageName legacyPackageSets
+        deps <- Map.lookup (RawVersion updateRef) versions
+        pure deps
+
+    Except.runExceptT (Legacy.Manifest.fetchLegacyManifest packageSetDeps address (RawVersion updateRef)) >>= case _ of
       Left manifestError -> do
         let formatError { error, reason } = reason <> " " <> Legacy.Manifest.printLegacyManifestError error
         throwWithComment $ String.joinWith "\n"
@@ -951,7 +959,7 @@ copyPackageSourceFiles files { source, destination } = do
 
   let
     copyFiles = userFiles <> includedFiles.succeeded <> includedInsensitiveFiles.succeeded
-    makePaths path = { from: Path.concat [ source, path ], to: Path.concat [ destination, path ], preserveTimestamps: false }
+    makePaths path = { from: Path.concat [ source, path ], to: Path.concat [ destination, path ], preserveTimestamps: true }
 
   liftAff $ traverse_ (makePaths >>> FS.Extra.copy) copyFiles
 


### PR DESCRIPTION
There are many packages imported into the registry which have issues with their Spago dependencies. If those packages have valid Bower dependencies then we take them, but there are quite a few (~70) package versions where there is no valid Bowerfile -- including some popular packages like `halogen-hooks`. Many of those packages have issues because the Spago file is used for local development only, with the "production" version hosted in the package-sets repository.

Six packages are barred from the registry altogether because of their local Spago files, even though they are in the current package sets (ocarina, rito, envparse, etc). Others have some versions affected (halogen-hooks, etc.).

But there are other issues, too. Some packages have technically valid Spago.dhall files, but if you go to resolve their dependencies you find they're pointing to forks or otherwise can't actually be used (bolson, deku, for example).

Many of these issues can be resolved by the following process (which this PR does):

1. If a package has a spago.dhall file, then attempt to look up the package version in the package sets.
2. If the version is there, then use those dependencies (they've been validated and checked in CI and, for the community, serve as the de facto "real" dependencies of the package).
3. If the version isn't there, then use the dependencies listed in the spago.dhall + packages.dhall for the package.

Of course, if the package has a valid Bower file that's up-to-date, then we use that as the dependency list. Still, implementing the process described above produces improved manifests for a lot of packages.