### PR TITLE
Commit the package and version failures

### DIFF
--- a/failed/README.md
+++ b/failed/README.md
@@ -1,0 +1,7 @@
+# Package & Version Failures
+
+This directory lists packages and package versions that are present in the `bower-packages.json` and `new-packages.json` files, but which could not be added to the new registry. Their package names have been reserved (no one can register any of the packages listed below).
+
+Packages with failures that prevented us from processing any versions for them are listed in the `package-failures.json` file. For example, we can't process packages that no longer exist at their repo URL.
+
+Package versions with errors are listed in the `version-failures.json` file.

--- a/failed/package-failures.json
+++ b/failed/package-failures.json
@@ -1,0 +1,201 @@
+{
+  "TypeAhead": {
+    "reason": "Package name should start with a lower case char or a digit; pos = 0",
+    "tag": "InvalidPackageName"
+  },
+  "arb-instances": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "purescript/purescript-arb-instances"
+  },
+  "big-integer": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "athanclark/purescript-big-integer"
+  },
+  "bitstrings": {
+    "reason": "No version contains a 'src' directory.",
+    "tag": "DisabledPackage"
+  },
+  "chosen": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "michael-swan/purescript-chosen"
+  },
+  "chosen-halogen": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "michael-swan/purescript-chosen-halogen"
+  },
+  "combinators": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "awkure/purescript-combinators"
+  },
+  "constraint-kanren": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "raduom/purescript-constraint-kanren"
+  },
+  "datareify": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "alexknvl/purescript-datareify"
+  },
+  "dynamic": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "raduom/purescript-dynamic"
+  },
+  "flux-store": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "KolesnichenkoDS/purescript-flux-store"
+  },
+  "focus-ui": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "mbid/purescript-focus-ui"
+  },
+  "fussy": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "garyb/purescript-fussy"
+  },
+  "globals-safe": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "nsaunders/purescript-globals-safe"
+  },
+  "hashable": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "paf31/purescript-hashable"
+  },
+  "hubot": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "mcoffin/purescript-hubot"
+  },
+  "mailgun": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "piq9117/purescript-mailgun"
+  },
+  "mdcss": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "askasp/purescript-mdcss"
+  },
+  "metadata": {
+    "reason": "Reserved package which cannot be uploaded.",
+    "tag": "DisabledPackage"
+  },
+  "node-args": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "purescript/purescript-node-args"
+  },
+  "node-readline-question": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "i-am-tom/purescript-node-readline-question"
+  },
+  "nunjucks": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "plippe/purescript-nunjucks"
+  },
+  "org": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "birdgg/purescript-org"
+  },
+  "phantomjs": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "cxfreeio/purescript-phantomjs"
+  },
+  "photons": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "slamdata/purescript-photons"
+  },
+  "plaid-node": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "piq9117/purescript-plaid-node"
+  },
+  "pouchdb-ffi": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "fehrenbach/purescript-pouchdb-ffi"
+  },
+  "purveyor": {
+    "reason": "No version contains a 'src' directory.",
+    "tag": "DisabledPackage"
+  },
+  "pux-router": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "alvart/purescript-pux-router"
+  },
+  "reactive": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "purescript/purescript-reactive"
+  },
+  "reactive-jquery": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "purescript/purescript-reactive-jquery"
+  },
+  "slack": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "saksdirect/purescript-slack"
+  },
+  "stablename": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "alexknvl/purescript-stablename"
+  },
+  "stm": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "rightfold/purescript-stm"
+  },
+  "styled-components": {
+    "reason": "No version contains a 'src' directory.",
+    "tag": "DisabledPackage"
+  },
+  "styled-system": {
+    "reason": "No version contains a 'src' directory.",
+    "tag": "DisabledPackage"
+  },
+  "subtype": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "rightfold/purescript-subtype"
+  },
+  "toastr": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "dbushenko/purescript-toastr"
+  },
+  "uport": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "f-o-a-m/purescript-uport"
+  },
+  "web-page-visibility": {
+    "reason": "Expected 'git@github.com:'.; pos = 0",
+    "tag": "InvalidPackageURL",
+    "value": "https://git.sr.ht/~toastal/purescript-web-page-visibility"
+  },
+  "yaml": {
+    "reason": "GitHub API error with status code 404",
+    "tag": "CannotAccessRepo",
+    "value": "CapillarySoftware/purescript-yaml"
+  }
+}

--- a/failed/version-failures.json
+++ b/failed/version-failures.json
@@ -1,0 +1,9433 @@
+{
+  "abc-parser": {
+    "1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "1.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "ace": {
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-simple-dom: 6358414013eb3106d695e3e19488609f82d903e9}, Expected '>='.; pos = 0])"
+    }
+  },
+  "ace-halogen": {
+    "v5.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.1"
+    }
+  },
+  "ace-halogen-012": {
+    "purs-0.13": {
+      "reason": "Character 'p' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "purs-0.13"
+    },
+    "purs012": {
+      "reason": "Character 'p' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "purs012"
+    },
+    "v5.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.1"
+    }
+  },
+  "aff": {
+    "v4.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.1"
+    },
+    "v4.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.2"
+    },
+    "v4.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.3"
+    },
+    "v4.0.0-rc.4": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.4"
+    },
+    "v4.0.0-rc.5": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.5"
+    },
+    "v4.0.0-rc.6": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.6"
+    }
+  },
+  "aff-promise": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "ajax": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "algebra": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "amazons": {
+    "v0.1.5-alpha": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.5-alpha"
+    },
+    "v1.0.0-beta.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-beta.1"
+    },
+    "v1.0.0-beta.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-beta.2"
+    }
+  },
+  "angular": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-simple-dom: aktowns/purescript-simple-dom#2b6f81d9fe9e161b8ffc3a3885483c8859a475a8}, Expected '>='.; pos = 0])"
+    },
+    "0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-simple-dom: aktowns/purescript-simple-dom#2b6f81d9fe9e161b8ffc3a3885483c8859a475a8}, Expected '>='.; pos = 0])"
+    }
+  },
+  "ansi": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "apexcharts": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hedwig"
+    },
+    "v0.1.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hedwig"
+    },
+    "v0.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hedwig"
+    },
+    "v0.3.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hedwig"
+    },
+    "v0.4.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hedwig"
+    }
+  },
+  "apparch": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "argonaut": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.7.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "optics"
+    }
+  },
+  "argonaut-traversals": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "optics"
+    }
+  },
+  "array-shuffle": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "arraybuffer": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "arraybuffer-types": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    }
+  },
+  "arrays": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v0.4.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    },
+    "v1.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.3"
+    },
+    "v1.0.0-rc.4": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.4"
+    },
+    "v1.0.0-rc.5": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.5"
+    },
+    "v1.0.0-rc.6": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.6"
+    },
+    "v1.0.0-rc.7": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.7"
+    }
+  },
+  "arrows": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.6.0-rc.1"
+    }
+  },
+  "asap": {
+    "1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "assert": {
+    "v0.1.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "audiograph": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-webaudio: https://github.com/newlandsvalley/purescript-webaudio.git}, Expected '>='.; pos = 0])"
+    }
+  },
+  "aui": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "autocomplete": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "aws": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-parallel: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "aws-sdk": {
+    "0.0.27": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.0.33": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "aws-sdk-basic": {
+    "v0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: e443bde}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: e443bde}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: e443bde}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: e443bde}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: e443bde}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: 4f84ba6}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: 4f84ba6}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: 4f84ba6}, Expected '>='.; pos = 0])"
+    },
+    "v0.7.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: 4f84ba6}, Expected '>='.; pos = 0])"
+    },
+    "v0.7.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: 4f84ba6}, Expected '>='.; pos = 0])"
+    },
+    "v0.8.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: 4f84ba6}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ justifill: 4f84ba6}, Expected '>='.; pos = 0])"
+    }
+  },
+  "backtrack": {
+    "v0.1": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1"
+    },
+    "v0.3": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.3"
+    }
+  },
+  "base64": {
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "batteries": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-these: tfausak/purescript-these#1173df88f940bfd6790056d55708a59857957205}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-these: tfausak/purescript-these#1173df88f940bfd6790056d55708a59857957205}, Expected '>='.; pos = 0])"
+    }
+  },
+  "batteries-core": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uri: git+https://github.com/paluh/purescript-uri}, Expected '>='.; pos = 0])"
+    }
+  },
+  "batteries-env": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-polyform-batteries-core: https://github.com/purescript-polyform/batteries-core.git#master}, Expected '>='.; pos = 0], [{ purescript-polyform: https://github.com/purescript-polyform/polyform.git#master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "batteries-urlencoded": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-js-uri: https://github.com/srghma/purescript-js-uri.git#d25d83390ba9cf948f46695b55a5511895b0068c}, Expected '>='.; pos = 0])"
+    }
+  },
+  "benchotron": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-node-fs: master}, Expected '>='.; pos = 0])"
+    },
+    "v2.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "bifunctors": {
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "bigints": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "bignumber": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-record: git@github.com:athanclark/purescript-record.git#850360dbfa1bf765a19b3ec207a706622fa47ac7}, Expected '>='.; pos = 0])"
+    }
+  },
+  "bip39": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "boomerang": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "bouzuya-http-method": {
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "bouzuya-http-status-code": {
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "canvas": {
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    }
+  },
+  "carpenter": {
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "catenable-lists": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "chanterelle": {
+    "delete": {
+      "reason": "Character 'd' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "delete"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-web3-generator: git://github.com/f-o-a-m/purescript-web3-generator#deploying}, Expected '>='.; pos = 0], [{ purescript-web3: git://github.com/f-o-a-m/purescript-web3#deploying}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-web3-generator: git://github.com/f-o-a-m/purescript-web3-generator#deploying}, Expected '>='.; pos = 0], [{ purescript-web3: git://github.com/f-o-a-m/purescript-web3#deploying}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-web3-generator: git+https://github.com/f-o-a-m/purescript-web3-generator.git#0.17.2-beta}, Expected '>='.; pos = 0])"
+    },
+    "v0.8.2.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.8.2.1"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mkdirp: joshuahhh/purescript-mkdirp#48ecb4039d5fe3be82d0e82c3a9f2338d1af82d2}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mkdirp: joshuahhh/purescript-mkdirp#48ecb4039d5fe3be82d0e82c3a9f2338d1af82d2}, Expected '>='.; pos = 0])"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mkdirp: joshuahhh/purescript-mkdirp#48ecb4039d5fe3be82d0e82c3a9f2338d1af82d2}, Expected '>='.; pos = 0])"
+    },
+    "v2.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mkdirp: joshuahhh/purescript-mkdirp#48ecb4039d5fe3be82d0e82c3a9f2338d1af82d2}, Expected '>='.; pos = 0])"
+    },
+    "v2.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mkdirp: joshuahhh/purescript-mkdirp#48ecb4039d5fe3be82d0e82c3a9f2338d1af82d2}, Expected '>='.; pos = 0])"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mkdirp: joshuahhh/purescript-mkdirp#48ecb4039d5fe3be82d0e82c3a9f2338d1af82d2}, Expected '>='.; pos = 0])"
+    }
+  },
+  "checked-exceptions": {
+    "V3.0.0": {
+      "reason": "Character 'V' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "V3.0.0"
+    }
+  },
+  "client-routing": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "cofree-react-router": {
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-dynamic: git://github.com/coot/purescript-dynamic.git#fix}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-dynamic: git://github.com/coot/purescript-dynamic.git#fix}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-dynamic: git://github.com/coot/purescript-dynamic.git#fix}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-dynamic: git://github.com/coot/purescript-dynamic.git#fix}, Expected '>='.; pos = 0])"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-routing: git://github.com/coot/purescript-routing#purescript-0.11}, Expected '>='.; pos = 0])"
+    }
+  },
+  "colehaus-graphs": {
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "colorpicker-halogen": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-number-input-halogen: git://github.com/safareli/purescript-number-input-halogen.git#initial-props}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-number-input-halogen: git://github.com/safareli/purescript-number-input-halogen.git#initial-props}, Expected '>='.; pos = 0])"
+    }
+  },
+  "colors": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "concur-core": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-io: https://github.com/ajnsit/purescript-io.git#v5.0.0-patch1}, Expected '>='.; pos = 0], [{ purescript-free: https://github.com/ajnsit/purescript-free.git#v4.2.0-concur}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.9": {
+      "reason": "Does not contain a 'src' directory.",
+      "tag": "DisabledVersion"
+    }
+  },
+  "concur-react": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-io: https://github.com/ajnsit/purescript-io.git#v5.0.0-patch1}, Expected '>='.; pos = 0], [{ purescript-free: https://github.com/ajnsit/purescript-free.git#v4.2.0-concur}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.9": {
+      "reason": "Does not contain a 'src' directory.",
+      "tag": "DisabledVersion"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "confusables": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: michaelficarra/purescript-strings#codepoints}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: michaelficarra/purescript-strings#codepoints}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: michaelficarra/purescript-strings#codepoints}, Expected '>='.; pos = 0])"
+    }
+  },
+  "console": {
+    "v0.1.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "console-foreign": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "const": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.5.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "contravariant": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "control": {
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    },
+    "v0.3.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "cookies": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: latest}, Expected '>='.; pos = 0])"
+    }
+  },
+  "coproducts": {
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    }
+  },
+  "coroutines": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "couchdb-aff-coroutines": {
+    "v1.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "sequential-aff-coroutines"
+    },
+    "v2.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "sequential-aff-coroutines"
+    }
+  },
+  "css": {
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-nonempty-arrays: garyb/purescript-nonempty-array#0.7-updates}, Expected '>='.; pos = 0])"
+    }
+  },
+  "cssom": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "csv": {
+    "rm": {
+      "reason": "Character 'r' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "rm"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.2": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v1.2"
+    },
+    "v1.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "csv-rk": {
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.2": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v1.2"
+    },
+    "v1.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "date-helpers": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "json"
+    },
+    "v0.11.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "foreign-helpers"
+    }
+  },
+  "datetime": {
+    "v0.6.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.6.0-rc.1"
+    }
+  },
+  "debugger": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "debuggest": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "deku": {
+    "v0.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "phantom-event"
+    }
+  },
+  "difflists": {
+    "1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "2.1.0-pursuit": {
+      "reason": "Expected EOF; pos = 5",
+      "tag": "InvalidTag",
+      "value": "2.1.0-pursuit"
+    },
+    "v3.0.1-pursuit": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v3.0.1-pursuit"
+    }
+  },
+  "distributions": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "distributive": {
+    "v0.5.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "dom-keyboard": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "drawing": {
+    "v0.3.5.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.5.1"
+    }
+  },
+  "dual-tree": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "easy-ffi": {
+    "purescript-0.7-prerelease": {
+      "reason": "Character 'p' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "purescript-0.7-prerelease"
+    }
+  },
+  "echarts": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-signal: https://github.com/bodil/purescript-signal.git#df34ba55e8cefbeee9dcd20167db80ca6491a325}, Expected '>='.; pos = 0], [{ purescript-random: https://github.com/cryogenian/purescript-random.git#573de58651264a2b04636eed8f4bf09364fbca02}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-signal: https://github.com/bodil/purescript-signal.git#df34ba55e8cefbeee9dcd20167db80ca6491a325}, Expected '>='.; pos = 0], [{ purescript-random: https://github.com/cryogenian/purescript-random.git#573de58651264a2b04636eed8f4bf09364fbca02}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-signal: https://github.com/bodil/purescript-signal.git#df34ba55e8cefbeee9dcd20167db80ca6491a325}, Expected '>='.; pos = 0], [{ purescript-random: https://github.com/cryogenian/purescript-random.git#573de58651264a2b04636eed8f4bf09364fbca02}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-simple-dom: 6358414013eb3106d695e3e19488609f82d903e9}, Expected '>='.; pos = 0])"
+    }
+  },
+  "eff": {
+    "v0.1.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.0-rc.1"
+    },
+    "v0.1.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "eff-functions": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "either": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "ejson": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "elm-basics": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "elm-color": {
+    "0.3.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "elm-basics"
+    },
+    "0.3.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "elm-basics"
+    },
+    "0.3.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "elm-basics"
+    }
+  },
+  "elm-compat": {
+    "elm-0.17": {
+      "reason": "Character 'e' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "elm-0.17"
+    },
+    "elm-0.18": {
+      "reason": "Character 'e' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "elm-0.18"
+    },
+    "v4.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v4.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v4.0.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v4.0.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v4.0.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    }
+  },
+  "enchantjs": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "endpoints-express": {
+    "0.0.1": {
+      "reason": "Does not contain a 'src' directory.",
+      "tag": "DisabledVersion"
+    },
+    "0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-datetime: https://github.com/parsonsmatt/purescript-datetime.git#iso8601}, Expected '>='.; pos = 0])"
+    },
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "enums": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "envparse": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ boxes: master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "error": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "eth-core": {
+    "V8.0.0": {
+      "reason": "Character 'V' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "V8.0.0"
+    },
+    "v6.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v6.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v7.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v8.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v8.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "events": {
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-reactive: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-reactive: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-reactive: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-reactive: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "exceptions": {
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "execa": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-options: purescript-contrib/purescript-options#3123fcdcde26df92229811cfeada649d21ac7d93}, Expected '>='.; pos = 0])"
+    }
+  },
+  "exists": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "express": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-parsing: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-easy-ffi: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "extensions": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foldable-traversable: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foldable-traversable: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foldable-traversable: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foldable-traversable: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foldable-traversable: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.9": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.2": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.2"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.2.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.2.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.2.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.2.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.2.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v2.3": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v2.3"
+    }
+  },
+  "fedger": {
+    "0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "json"
+    },
+    "0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-simple-request: latest}, Expected '>='.; pos = 0], [{ purescript-prelude: latest}, Expected '>='.; pos = 0], [{ purescript-node-http: latest}, Expected '>='.; pos = 0], [{ purescript-lens: latest}, Expected '>='.; pos = 0], [{ purescript-json: latest}, Expected '>='.; pos = 0], [{ purescript-console: latest}, Expected '>='.; pos = 0], [{ purescript-affjax: latest}, Expected '>='.; pos = 0], [{ purescript-aff: latest}, Expected '>='.; pos = 0])"
+    },
+    "0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-simple-request: latest}, Expected '>='.; pos = 0], [{ purescript-prelude: latest}, Expected '>='.; pos = 0], [{ purescript-node-http: latest}, Expected '>='.; pos = 0], [{ purescript-lens: latest}, Expected '>='.; pos = 0], [{ purescript-console: latest}, Expected '>='.; pos = 0], [{ purescript-affjax: latest}, Expected '>='.; pos = 0], [{ purescript-aff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-simple-request: latest}, Expected '>='.; pos = 0], [{ purescript-prelude: latest}, Expected '>='.; pos = 0], [{ purescript-node-http: latest}, Expected '>='.; pos = 0], [{ purescript-lens: latest}, Expected '>='.; pos = 0], [{ purescript-json: latest}, Expected '>='.; pos = 0], [{ purescript-console: latest}, Expected '>='.; pos = 0], [{ purescript-affjax: latest}, Expected '>='.; pos = 0], [{ purescript-aff: latest}, Expected '>='.; pos = 0])"
+    }
+  },
+  "firebase": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-spec: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-spec: *}, Expected '>='.; pos = 0])"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-spec: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "flaredoc": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "flarecheck"
+    },
+    "v2.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "flarecheck"
+    },
+    "v3.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "flarecheck"
+    }
+  },
+  "flow": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidLicense (Invalid SPDX identifier: AGPL\nDid you mean AGPL-1.0-only?)"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidLicense (Invalid SPDX identifier: AGPL\nDid you mean AGPL-1.0-only?)"
+    }
+  },
+  "flow-id": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "foldable-traversable": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v0.4.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    },
+    "v1.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.3"
+    }
+  },
+  "folds": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "foreign": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-globals: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-globals: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-globals: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-globals: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.1"
+    },
+    "v0.5.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "foreign-extra": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-globals: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-globals: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-globals: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-globals: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.1"
+    },
+    "v0.5.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.2"
+    },
+    "v1.0.0-extra": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-extra"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "foreign-generic": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "foreign-helpers": {
+    "v0.11.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "foreign-lens": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "foreign-options": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "form-urlencoded": {
+    "v0.1": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.1-dummy": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.1-dummy"
+    }
+  },
+  "formulate": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "framer-motion": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-untagged-union: https://github.com/working-group-purescript-es/purescript-untagged-union.git#es-modules}, Expected '>='.; pos = 0], [{ purescript-react-basic-hooks: https://github.com/working-group-purescript-es/purescript-react-basic-hooks.git#es-modules}, Expected '>='.; pos = 0], [{ purescript-react-basic-dom: https://github.com/working-group-purescript-es/purescript-react-basic-dom.git#es-modules}, Expected '>='.; pos = 0], [{ purescript-react-basic: https://github.com/working-group-purescript-es/purescript-react-basic.git#es-modules}, Expected '>='.; pos = 0], [{ purescript-literals: https://github.com/working-group-purescript-es/purescript-literals.git#es-modules}, Expected '>='.; pos = 0])"
+    }
+  },
+  "free": {
+    "0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0])"
+    },
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0])"
+    },
+    "0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0])"
+    },
+    "0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0])"
+    },
+    "0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0])"
+    },
+    "0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0])"
+    },
+    "0.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: 64fa7200dc328fc79090426cddb64ed6e4ccffc9}, Expected '>='.; pos = 0])"
+    },
+    "0.0.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: 64fa7200dc328fc79090426cddb64ed6e4ccffc9}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-exists: *}, Expected '>='.; pos = 0])"
+    },
+    "0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-exists: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-exists: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-exists: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    },
+    "v1.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.3"
+    }
+  },
+  "free-canvas": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-free: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-free: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "freeap": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "freer-free": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "function-checked": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "functions": {
+    "v0.1.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "functor-compose": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "functor-coproducts": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "functor-products": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "generics": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "geometry": {
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "geometry-plane": {
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "globals": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "gomtang-basic": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "graphql": {
+    "1.0.0-beta": {
+      "reason": "Expected EOF; pos = 5",
+      "tag": "InvalidTag",
+      "value": "1.0.0-beta"
+    },
+    "v1.0.0-rc": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc"
+    },
+    "v1.0.0-rc1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc1"
+    },
+    "v1.0.0-rc2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc2"
+    }
+  },
+  "graphql-gen": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ graphql-parser: master}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-graphql-parser: git://github.com/meeshkan/purescript-graphql-parser.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-graphql-parser: git://github.com/meeshkan/purescript-graphql-parser.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-graphql-parser: git://github.com/meeshkan/purescript-graphql-parser.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-graphql-parser: git://github.com/meeshkan/purescript-graphql-parser.git}, Expected '>='.; pos = 0])"
+    }
+  },
+  "graphql-validator": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ graphql-parser: master}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ graphql-parser: master}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ graphql-parser: master}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ graphql-parser: master}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-graphql-parser: git://github.com/meeshkan/purescript-graphql-parser.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-graphql-parser: git://github.com/meeshkan/purescript-graphql-parser.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-graphql-parser: git://github.com/meeshkan/purescript-graphql-parser.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-graphql-parser: git://github.com/meeshkan/purescript-graphql-parser.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-graphql-parser: git://github.com/meeshkan/purescript-graphql-parser.git}, Expected '>='.; pos = 0])"
+    }
+  },
+  "graphqlclient": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "graphs": {
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "halogen": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    },
+    "v1.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.3"
+    },
+    "v1.0.0-rc.4": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.4"
+    },
+    "v1.0.0-rc.5": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.5"
+    },
+    "v1.0.0-rc.6": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.6"
+    },
+    "v4.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.1"
+    },
+    "v5.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.1"
+    },
+    "v5.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.2"
+    },
+    "v5.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.3"
+    },
+    "v5.0.0-rc.4": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.4"
+    },
+    "v5.0.0-rc.5": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.5"
+    },
+    "v5.0.0-rc.6": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.6"
+    },
+    "v5.0.0-rc.7": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.7"
+    },
+    "v5.0.0-rc.8": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.8"
+    },
+    "v5.0.0-rc.9": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.9"
+    }
+  },
+  "halogen-bootstrap": {
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: master}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v5.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.1"
+    }
+  },
+  "halogen-css": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 4ad7f1e605c84d6eda8a9924fceca437695e658e}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 4be794a56a9910bcac4d8760eefc408c714d8d40}, Expected '>='.; pos = 0])"
+    },
+    "v5.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.1"
+    },
+    "v5.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.2"
+    },
+    "v5.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.3"
+    }
+  },
+  "halogen-echarts": {
+    "v4.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.1"
+    }
+  },
+  "halogen-formless": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "halogen-menu": {
+    "0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "4.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 5",
+      "tag": "InvalidTag",
+      "value": "4.0.0-rc.2"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v4.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.1"
+    },
+    "v4.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.2"
+    }
+  },
+  "halogen-monaco": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-monaco: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2-alpha": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.0.2-alpha"
+    },
+    "v0.0.3-alpha": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.0.3-alpha"
+    }
+  },
+  "halogen-select": {
+    "v5.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.1"
+    },
+    "v5.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.2"
+    },
+    "v5.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.3"
+    },
+    "v5.0.0-rc.4": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v5.0.0-rc.4"
+    }
+  },
+  "halogen-storybook": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-js-uri: master}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "halogen-svg": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "handlebars": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-jquery: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "hedwig": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "hibachi": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-variant: #compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-prelude: #compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-console: #compiler/0.12}, Expected '>='.; pos = 0])"
+    }
+  },
+  "history": {
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-reactive: *}, Expected '>='.; pos = 0], [{ purescript-events: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-reactive: *}, Expected '>='.; pos = 0], [{ purescript-events: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-reactive: *}, Expected '>='.; pos = 0], [{ purescript-events: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-reactive: *}, Expected '>='.; pos = 0], [{ purescript-events: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-reactive: *}, Expected '>='.; pos = 0], [{ purescript-events: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "howler": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-nullable: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-eff: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "html-parser-halogen": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "http": {
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-parsing: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "httpure-middleware": {
+    "v3.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-httpure: 0.8.3 || 0.9.0}, Expected '>='.; pos = 0])"
+    },
+    "v3.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-httpure: 0.8.3 || 0.9.0 || 0.10.0}, Expected '>='.; pos = 0])"
+    }
+  },
+  "hypertrout": {
+    "v0.6.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hyper-routing"
+    },
+    "v0.7.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hyper-routing"
+    }
+  },
+  "hyrule": {
+    "v.1.4.0": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.1.4.0"
+    }
+  },
+  "ide-purescript-core": {
+    "minor": {
+      "reason": "Character 'm' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "minor"
+    },
+    "patch": {
+      "reason": "Character 'p' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "patch"
+    },
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-psc-ide: git@github.com:kRITZCREEK/purescript-psc-ide.git#import}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-psc-ide: git@github.com:kRITZCREEK/purescript-psc-ide.git#import}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-psc-ide: git@github.com:kRITZCREEK/purescript-psc-ide.git#start-multiple-servers}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-psc-ide: git@github.com:kRITZCREEK/purescript-psc-ide.git#\td2a8bfc}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-psc-ide: https://github.com/kRITZCREEK/purescript-psc-ide.git#unify-completion}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-psc-ide: https://github.com/kRITZCREEK/purescript-psc-ide.git#6609dfeb69b37bdfc6681d97f82304985dddadc5}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-psc-ide: https://github.com/kRITZCREEK/purescript-psc-ide.git#ee60b3019ac4a639a6311dff73e295b797311493}, Expected '>='.; pos = 0])"
+    }
+  },
+  "identity": {
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "idiomatic-node-buffer": {
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.3.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.3.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "idiomatic-node-crypto": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "idiomatic-node-errors": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "idiomatic-node-events": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-exceptions: https://github.com/natefaubion/purescript-exceptions.git#df042ac0feebcb8d9ca4a1a5e1fc23757cd8c7b9}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-exceptions: https://github.com/natefaubion/purescript-exceptions.git#df042ac0feebcb8d9ca4a1a5e1fc23757cd8c7b9}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "idiomatic-node-http": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "idiomatic-node-process": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "idiomatic-node-server": {
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "idiomatic-node-stream": {
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.5.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "index": {
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-sets: joneshf/purescript-sets#master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "inject": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "integers": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "intmaps": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "invariant": {
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "io": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v4.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v5.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "ips": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "isomorphisms": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "jack": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "jarilo": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "jquery": {
+    "v.0.1.0": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.0.1.0"
+    },
+    "v0.5.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.1"
+    }
+  },
+  "jquery-ajax": {
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-jquery: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "js": {
+    "v0.1": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1"
+    },
+    "v0.1-alpha": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1-alpha"
+    },
+    "v0.1-alpha.2": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1-alpha.2"
+    },
+    "v0.1-alpha.3": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1-alpha.3"
+    },
+    "v0.1-alpha.4": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1-alpha.4"
+    }
+  },
+  "js-fileio": {
+    "1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "2.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "2.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "2.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "js-history": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "json-minify": {
+    "v1.0.0+b2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0+b2"
+    }
+  },
+  "jsonrpc": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "jtable": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: master}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: master}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: b1636e2537526963f89134c7b4fd8005c1b62e37}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v4.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.1"
+    }
+  },
+  "keys": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "kushiyaki": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-record-format: kcsongor/purescript-record-format#compiler/0.12}, Expected '>='.; pos = 0])"
+    }
+  },
+  "language-purescript-parser-lexer": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-parsing: file:///home/illabout/git/purescript-parsing/.git#token}, Expected '>='.; pos = 0])"
+    }
+  },
+  "lazy": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-control: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-arrays: >=0.2.0}, Unexpected EOF; pos = 7])"
+    },
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "leaflet": {
+    "0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "leibniz": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "lens": {
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-profunctor: joneshf/purescript-profunctors#master}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-profunctor: joneshf/purescript-profunctors#master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "lens-simple": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "list-zipper": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "lists": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-unfoldable: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-unfoldable: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-unfoldable: *}, Expected '>='.; pos = 0], [{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-lazy: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-unfoldable: *}, Expected '>='.; pos = 0], [{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-quickcheck: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-lazy: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-unfoldable: *}, Expected '>='.; pos = 0], [{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-quickcheck: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-lazy: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-unfoldable: *}, Expected '>='.; pos = 0], [{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-lazy: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.6.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.6.1"
+    },
+    "v0.7.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.7.0-rc.1"
+    },
+    "v0.7.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.7.0-rc.2"
+    },
+    "v0.7.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.7.0-rc.3"
+    },
+    "v0.7.0-rc.4": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.7.0-rc.4"
+    },
+    "v0.7.0-rc.5": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.7.0-rc.5"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    },
+    "v1.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.3"
+    }
+  },
+  "literals": {
+    "v": {
+      "reason": "Unexpected EOF; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v"
+    }
+  },
+  "lnforum-api": {
+    "v0.11.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "foreign-helpers"
+    }
+  },
+  "localstorage": {
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-var: zudov/purescript-var#dc6238dbc20af0e3d53a5397b57c4c96b7040180}, Expected '>='.; pos = 0])"
+    }
+  },
+  "logic": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "logoot-core": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "lp": {
+    "v0.1": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1"
+    }
+  },
+  "lumi-components": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.1.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.10.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.11.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.11.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.12.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.12.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.12.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.12.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.12.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.13.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.14.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.14.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.15.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.15.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.16.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.17.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.18.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.18.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.19.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.19.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.2.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.2.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.20.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.21.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.22.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.23.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.24.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.24.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.25.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.25.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.26.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.26.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.26.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.26.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.26.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.26.5": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.26.6": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.27.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.28.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.28.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.28.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.28.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.28.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.28.5": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.29.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.29.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.29.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.29.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.3.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.4.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.4.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.4.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.4.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.4.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.4.5": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.4.6": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.4.7": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.4.8": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.5.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.6.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.7.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.8.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v0.9.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v1.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v1.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v1.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v1.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v1.2.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v1.2.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v1.2.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v1.2.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v1.2.5": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v10.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v10.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v11.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v11.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v12.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v12.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v12.0.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v13.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v13.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v13.0.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v13.0.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v13.0.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v14.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v14.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v14.0.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v14.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v14.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v15.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v15.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v15.1.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v15.1.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v16.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v16.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v16.0.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v16.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v16.1.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v16.1.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v16.1.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v2.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v2.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v2.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v3.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v3.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v3.0.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v3.0.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v3.0.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v3.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v3.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v4.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v4.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v4.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v4.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v5.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v5.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v6.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v7.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v7.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v7.0.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v7.0.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v7.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v8.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v8.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    },
+    "v9.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "react-dnd-basic"
+    }
+  },
+  "lunapark": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-xpath: cryogenian/purescript-xpath#master}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-xpath: cryogenian/purescript-xpath#compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-run: cryogenian/purescript-run#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-xpath: cryogenian/purescript-xpath#compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-run: cryogenian/purescript-run#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-xpath: cryogenian/purescript-xpath#compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-run: cryogenian/purescript-run#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-xpath: cryogenian/purescript-xpath#compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-run: cryogenian/purescript-run#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v1.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-xpath: cryogenian/purescript-xpath#compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-run: cryogenian/purescript-run#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-xpath: cryogenian/purescript-xpath#compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-run: cryogenian/purescript-run#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-xpath: cryogenian/purescript-xpath#compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-run: cryogenian/purescript-run#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-xpath: cryogenian/purescript-xpath#compiler/0.12}, Expected '>='.; pos = 0])"
+    }
+  },
+  "makkori": {
+    "pre-0.1.0": {
+      "reason": "Character 'p' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "pre-0.1.0"
+    },
+    "pre-0.1.0-2": {
+      "reason": "Character 'p' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "pre-0.1.0-2"
+    }
+  },
+  "maps": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v0.4.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "markdown": {
+    "v1.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: master}, Expected '>='.; pos = 0])"
+    },
+    "v1.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: master}, Expected '>='.; pos = 0])"
+    },
+    "v1.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: master}, Expected '>='.; pos = 0])"
+    },
+    "v6.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-functor-compose: #384edff4e5606f0db7b5f06903b3defd807d8a27}, Expected '>='.; pos = 0])"
+    }
+  },
+  "markdown-halogen": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: b1636e2537526963f89134c7b4fd8005c1b62e37}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: b1636e2537526963f89134c7b4fd8005c1b62e37}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: b1636e2537526963f89134c7b4fd8005c1b62e37}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-halogen: 30e8b2c7174a1eeda73f67cc42c739ca24a1e218}, Expected '>='.; pos = 0])"
+    },
+    "v4.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.2"
+    },
+    "v4.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc.3"
+    }
+  },
+  "markup": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "markup-incdom": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "mason-prelude": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "math": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v0.2.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v2.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v2.0.0-rc.1"
+    },
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "mathjs": {
+    "v0.1": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1"
+    },
+    "v0.2": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.2"
+    }
+  },
+  "matrix": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.11": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-generics: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-generics: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-generics: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "maybe": {
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "memoize": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "metajelo": {
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "metajelo-web": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "midi": {
+    "1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "milkis": {
+    "v4.0.0-pre": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-pre"
+    }
+  },
+  "minimist": {
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.5.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "mmorph": {
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: #compiler/0.12}, Expected '>='.; pos = 0], [{ purescript-functors: #compiler/0.12}, Expected '>='.; pos = 0])"
+    }
+  },
+  "modules": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "monaco": {
+    "v.0.0.1-alpha": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.0.0.1-alpha"
+    },
+    "v.0.0.2-alpha": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.0.0.2-alpha"
+    },
+    "v.0.0.3-alpha": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.0.0.3-alpha"
+    },
+    "v.0.0.4-alpha": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.0.0.4-alpha"
+    },
+    "v.0.0.5-alpha": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.0.0.5-alpha"
+    },
+    "v0.0.6-alpha": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.0.6-alpha"
+    },
+    "v0.0.7-alpha": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.0.7-alpha"
+    }
+  },
+  "monad-control": {
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "monad-fix": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "money": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "mongodbf": {
+    "0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-free: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0])"
+    },
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-free: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0])"
+    },
+    "0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-free: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0])"
+    },
+    "0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-free: *}, Expected '>='.; pos = 0], [{ purescript-foreign: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "monoid": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    },
+    "v0.3.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "mote-runner": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mote: cryogenian/purescript-mote#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mote: cryogenian/purescript-mote#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-optlicative: garyb/purescript-optlicative#6eb14679770828bc7df68daf54c814e3805e64fa}, Expected '>='.; pos = 0])"
+    }
+  },
+  "mtproto": {
+    "v0.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "foreign-options"
+    }
+  },
+  "neon": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "node-buffer": {
+    "v0.1.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.0-rc.1"
+    }
+  },
+  "node-child-process": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    }
+  },
+  "node-datagrams": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "node-domain": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    }
+  },
+  "node-electron": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "node-events": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    },
+    "v0.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    }
+  },
+  "node-fs": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-node-path: >=0.1.0}, Unexpected EOF; pos = 7], [{ purescript-node-buffer: *}, Expected '>='.; pos = 0], [{ purescript-maybe: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foreign: >=0.1.1}, Unexpected EOF; pos = 7], [{ purescript-either: >=0.1.2}, Unexpected EOF; pos = 7], [{ purescript-datetime: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-node-path: >=0.1.0}, Unexpected EOF; pos = 7], [{ purescript-node-buffer: *}, Expected '>='.; pos = 0], [{ purescript-maybe: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-foreign: >=0.1.1}, Unexpected EOF; pos = 7], [{ purescript-either: >=0.1.2}, Unexpected EOF; pos = 7], [{ purescript-datetime: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "node-fs-aff-extra": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-node-fs-aff: git://github.com/natefaubion/purescript-node-fs-aff#aff-updates}, Expected '>='.; pos = 0])"
+    }
+  },
+  "node-github": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-node-thunk: git@github.com:andyfriesen/purescript-node-thunk.git#master}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-node-thunk: git@github.com:andyfriesen/purescript-node-thunk.git#master}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "node-mongodb": {
+    "0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uri: master}, Expected '>='.; pos = 0])"
+    },
+    "0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uri: master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "node-path": {
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    }
+  },
+  "node-readline": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    }
+  },
+  "node-sentry": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "node-sqlite3": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "node-webkit": {
+    "v0.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    },
+    "v0.2.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    },
+    "v0.2.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    },
+    "v0.2.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    },
+    "v0.3.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    }
+  },
+  "node-websocket": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "nonempty": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "nullable": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    }
+  },
+  "oak": {
+    "list": {
+      "reason": "Character 'l' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "list"
+    }
+  },
+  "ocarina": {
+    "v0.6.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.5": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.6": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.7": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.8": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.9": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants, row-options"
+    },
+    "v0.8.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants, row-options"
+    },
+    "v1.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v1.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v1.1.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v1.1.10": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.9": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    }
+  },
+  "ocelot": {
+    "dist-0": {
+      "reason": "Character 'd' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "dist-0"
+    },
+    "dist-92": {
+      "reason": "Character 'd' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "dist-92"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.10.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.10.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.10.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.11.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.11.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.11.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.11.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.12.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.13.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.13.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.13.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.14.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.14.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.14.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.14.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.14.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.14.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.15.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.16.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.20.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-svg-parser-halogen: https://github.com/rnons/purescript-svg-parser-halogen.git#ac16a7af82d739b1f9773fbc28fc7e24f0d24550}, Expected '>='.; pos = 0], [{ purescript-html-parser-halogen: https://github.com/rnons/purescript-html-parser-halogen.git#7d37fd6a29bff2a143d91c2ebfe5ca582ca76018}, Expected '>='.; pos = 0])"
+    },
+    "v0.21.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0], [{ halogen-select: v5.0.0-rc.4}, Expected '>='.; pos = 0], [{ halogen: v5.0.0-rc.9}, Expected '>='.; pos = 0])"
+    },
+    "v0.21.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0], [{ halogen-select: v5.0.0-rc.4}, Expected '>='.; pos = 0], [{ halogen: v5.0.0-rc.9}, Expected '>='.; pos = 0])"
+    },
+    "v0.22.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0], [{ halogen-select: v5.0.0-rc.4}, Expected '>='.; pos = 0], [{ halogen: v5.0.0-rc.9}, Expected '>='.; pos = 0])"
+    },
+    "v0.23.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0], [{ halogen-select: v5.0.0-rc.4}, Expected '>='.; pos = 0], [{ halogen: v5.0.0-rc.9}, Expected '>='.; pos = 0])"
+    },
+    "v0.24.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0], [{ halogen-select: v5.0.0-rc.4}, Expected '>='.; pos = 0], [{ halogen: v5.0.0-rc.9}, Expected '>='.; pos = 0])"
+    },
+    "v0.24.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.24.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.24.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.25.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.25.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.25.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.25.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.25.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.25.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.25.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.25.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.26.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.26.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.26.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.27.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.27.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.28.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.28.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.28.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0], [{ halogen-storybook: v1.0.0-rc.1}, Expected '>='.; pos = 0])"
+    },
+    "v0.29.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.30.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.31.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.31.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.31.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.31.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.32.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.32.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.33.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.33.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.33.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.33.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ svg-parser-halogen: v2.0.0-rc.1}, Expected '>='.; pos = 0], [{ html-parser-halogen: v1.0.0-rc.2}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.7.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.8.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.9.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "oidc-crypt-utils": {
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "open-folds": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "open-memoize": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "open-mkdirp-aff": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "openapi": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "optic": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-profunctor: joneshf/purescript-profunctors#master}, Expected '>='.; pos = 0], [{ purescript-lens: split}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-profunctor: joneshf/purescript-profunctors#master}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-profunctor: joneshf/purescript-profunctors#master}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "profunctors"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-lens: master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "optic-ui": {
+    "2.0.0-alpha": {
+      "reason": "Expected EOF; pos = 5",
+      "tag": "InvalidTag",
+      "value": "2.0.0-alpha"
+    }
+  },
+  "optlicative": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v4.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "optparse": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-exitcodes: safareli/purescript-exitcodes#patch-2}, Expected '>='.; pos = 0])"
+    },
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ open-memoize: master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "orders": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "outwatch": {
+    "v0.4.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-rxjs: https://github.com/LukaJCB/purescript-rxjs.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-rxjs: https://github.com/LukaJCB/purescript-rxjs.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-rxjs: https://github.com/LukaJCB/purescript-rxjs.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-rxjs: https://github.com/LukaJCB/purescript-rxjs.git}, Expected '>='.; pos = 0])"
+    }
+  },
+  "panda": {
+    "v0.12.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v0.13.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-behaviors: https://github.com/justinwoo/purescript-behaviors.git#compiler/0.12}, Expected '>='.; pos = 0])"
+    },
+    "v0.9": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.9"
+    }
+  },
+  "parallel": {
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "parsing": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    }
+  },
+  "parsing-extras": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "parsing-uuid": {
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-parsing-repetition: markfarrell/purescript-parsing-repetition}, Expected '>='.; pos = 0], [{ purescript-parsing-hexadecimal: markfarrell/purescript-parsing-hexadecimal}, Expected '>='.; pos = 0])"
+    }
+  },
+  "pg": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v1.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "nodey"
+    },
+    "v1.0.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "nodey"
+    }
+  },
+  "phantom": {
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-encoding: dgendill/purescript-encoding#compiler/0.12}, Expected '>='.; pos = 0])"
+    }
+  },
+  "pipes": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mmorph: felixschl/purescript-mmorph#e3cbc72abe8c3dcafdf1648cb63ddb1fac1dcb7f}, Expected '>='.; pos = 0])"
+    },
+    "v2.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mmorph: felixschl/purescript-mmorph#e3cbc72abe8c3dcafdf1648cb63ddb1fac1dcb7f}, Expected '>='.; pos = 0])"
+    },
+    "v2.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mmorph: felixschl/purescript-mmorph#e3cbc72abe8c3dcafdf1648cb63ddb1fac1dcb7f}, Expected '>='.; pos = 0])"
+    },
+    "v4.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v5.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    }
+  },
+  "point-free": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "polyform-validators": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uri: git+https://github.com/paluh/purescript-uri}, Expected '>='.; pos = 0])"
+    }
+  },
+  "postgresql-client": {
+    "v3.0.0-alpha": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v3.0.0-alpha"
+    },
+    "v3.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "polyform-batteries-core, polyform-batteries-env"
+    },
+    "v3.3.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "polyform-batteries-core, polyform-batteries-env"
+    }
+  },
+  "prelude": {
+    "v0.1.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    },
+    "v1.0.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.3"
+    },
+    "v1.0.0-rc.4": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.4"
+    },
+    "v1.0.0-rc.5": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.5"
+    },
+    "v1.0.0-rc.6": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.6"
+    }
+  },
+  "presto": {
+    "0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidLicense (Invalid SPDX identifier: AGPL\nDid you mean AGPL-1.0-only?)"
+    },
+    "v0.1": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.1"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidLicense (Invalid SPDX identifier: AGPL\nDid you mean AGPL-1.0-only?)"
+    }
+  },
+  "presto-backend": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-sequelize: https://github.com/juspay/purescript-sequelize.git}, Expected '>='.; pos = 0], [{ purescript-redis: https://github.com/juspay/purescript-redis.git}, Expected '>='.; pos = 0], [{ purescript-body-parser: https://github.com/juspay/purescript-body-parser.git}, Expected '>='.; pos = 0])"
+    },
+    "0.1": {
+      "reason": "Could not match character '.'; pos = 3",
+      "tag": "InvalidTag",
+      "value": "0.1"
+    },
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-sequelize: https://github.com/juspay/purescript-sequelize.git}, Expected '>='.; pos = 0], [{ purescript-redis: https://github.com/juspay/purescript-redis.git}, Expected '>='.; pos = 0], [{ purescript-body-parser: https://github.com/juspay/purescript-body-parser.git}, Expected '>='.; pos = 0])"
+    },
+    "0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidLicense (Invalid SPDX identifier: https://github.com/juspay/purescript-presto-backend/blob/master/LICENSE)"
+    },
+    "0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidLicense (Invalid SPDX identifier: https://github.com/juspay/purescript-presto-backend/blob/master/LICENSE)"
+    },
+    "0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidLicense (Invalid SPDX identifier: https://github.com/juspay/purescript-presto-backend/blob/master/LICENSE)"
+    },
+    "0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidLicense (Invalid SPDX identifier: https://github.com/juspay/purescript-presto-backend/blob/master/LICENSE)"
+    }
+  },
+  "probability": {
+    "v5.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-ordered-collections: >=1.5.0}, Unexpected EOF; pos = 7])"
+    }
+  },
+  "profunctor": {
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "profunctor-lenses": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "ps-cst": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ dodo-printer: master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "psc-ide": {
+    "1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "psci-support": {
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "pspec": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.6.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.6.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.7.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "pux-clappr": {
+    "v0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-clappr: git@github.com:paluh/purescript-clappr.git#master}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-clappr: git@github.com:paluh/purescript-clappr.git#master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "pux-css": {
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-css: slamdata/purescript-css#3fe427e}, Expected '>='.; pos = 0])"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-pux: https://github.com/chexxor/purescript-pux.git#6d1d846c5ab65a1e845437df2bffcb9038cc24cc}, Expected '>='.; pos = 0], [{ purescript-css: https://github.com/chexxor/purescript-css.git#d7a98aac25226852fe24e67b6c5b5976d256c4c1}, Expected '>='.; pos = 0])"
+    },
+    "v3.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-css: https://github.com/slamdata/purescript-css.git#81d1c353eb0f072a212512242e5a8d55cf8f89db}, Expected '>='.; pos = 0])"
+    }
+  },
+  "pux-devtool": {
+    "v5.0.0": {
+      "reason": "Does not contain a 'src' directory.",
+      "tag": "DisabledVersion"
+    }
+  },
+  "pux-redux": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-records: https://gitlab.com/lightandlight/purescript-records.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "pux-spectacle": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "pux-undo": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: https://github.com/DavidHarrison/purescript-list-zipper.git#889f1e}, Expected '>='.; pos = 0])"
+    }
+  },
+  "puxing-bob": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-routing-bob: https://github.com/paluh/purescript-routing-bob.git#master}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-routing-bob: https://github.com/paluh/purescript-routing-bob.git#master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "queue": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "quickcheck": {
+    "0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-random: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-transformers: *}, Expected '>='.; pos = 0], [{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.6.0-rc.1"
+    },
+    "v0.6.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.6.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "radix64": {
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "radox": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "random": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "rationals": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "rdkafka": {
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "react-basic": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "react-mui": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.10": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.11": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.9": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tscompat: doolse/purescript-tscompat#master}, Expected '>='.; pos = 0])"
+    },
+    "v3.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tscompat: doolse/purescript-tscompat#master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "react-redox": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.7.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-redox: git://github.com/coot/purescript-redox#effects}, Expected '>='.; pos = 0])"
+    }
+  },
+  "react-redux": {
+    "v6.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-record: athanclark/purescript-record#850360dbfa1bf765a19b3ec207a706622fa47ac7}, Expected '>='.; pos = 0])"
+    }
+  },
+  "react-simpleaction": {
+    "0.9.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-react: purescript-contrib/purescript-react}, Expected '>='.; pos = 0])"
+    },
+    "0.9.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "react-stylesheet": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "react-testing-library": {
+    "v4.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-spec: https://github.com/purescript-spec/purescript-spec.git#master}, Expected '>='.; pos = 0], [{ purescript-react-basic: https://github.com/working-group-purescript-es/purescript-react-basic.git#es-modules}, Expected '>='.; pos = 0])"
+    }
+  },
+  "reactnative": {
+    "0.9.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "record-extra-srghma": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "redux-saga": {
+    "v0.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v0.3.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v0.3.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v0.3.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v0.4.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v0.5.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v1.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    }
+  },
+  "refined": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "reflection": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "refract": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "refractor": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-lens: split}, Expected '>='.; pos = 0])"
+    }
+  },
+  "refs": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "remotecallback": {
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "rest": {
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "ring-modules": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "rito": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ fast-vect: main}, Expected '>='.; pos = 0])"
+    }
+  },
+  "rnx": {
+    "v0.1.1-alpha": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.1-alpha"
+    },
+    "v0.1.2-alpha": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.2-alpha"
+    }
+  },
+  "router": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-eff: latest}, Expected '>='.; pos = 0])"
+    }
+  },
+  "routing-bob": {
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uri: git://github.com/paluh/purescript-uri.git#master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "safely": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "sammy": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-jquery: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "school-of-music": {
+    "1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "screeps": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "screeps-classy": {
+    "v1.0": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v1.0"
+    }
+  },
+  "semirings": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "sequelize": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-records: athanclark/purescript-records#214a78e65feda4328ab7245ed8edb10b9b8dd0d8}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-records: athanclark/purescript-records#214a78e65feda4328ab7245ed8edb10b9b8dd0d8}, Expected '>='.; pos = 0])"
+    }
+  },
+  "sequences": {
+    "v0.3.0-pre": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-pre"
+    }
+  },
+  "sequential-aff-coroutines": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "servant-support": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-nullable: *}, Expected '>='.; pos = 0], [{ purescript-globals: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-dom: *}, Expected '>='.; pos = 0], [{ purescript-batteries: *}, Expected '>='.; pos = 0], [{ purescript-argonaut-core: *}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.0.0": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.9.0.0"
+    },
+    "v0.9.0.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.9.0.1"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "servant-support-012": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-nullable: *}, Expected '>='.; pos = 0], [{ purescript-globals: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-dom: *}, Expected '>='.; pos = 0], [{ purescript-batteries: *}, Expected '>='.; pos = 0], [{ purescript-argonaut-core: *}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.0.0": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.9.0.0"
+    },
+    "v0.9.0.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.9.0.1"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "sets": {
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v0.4.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "sigment": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    }
+  },
+  "signal": {
+    "2.2.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "asap"
+    },
+    "v.10.0.0": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.10.0.0"
+    }
+  },
+  "signal-loop": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "simple-ajax": {
+    "v2.0.0-alpha": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v2.0.0-alpha"
+    }
+  },
+  "simple-dom": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-sets: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-dom: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "simple-parser": {
+    "v3.0.0-pursuit": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v3.0.0-pursuit"
+    },
+    "v4.0.0-pursuit": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-pursuit"
+    }
+  },
+  "simple-request": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "simple-templates": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "sketch": {
+    "v1.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: latest}, Expected '>='.; pos = 0], [{ purescript-foreign-generic: latest}, Expected '>='.; pos = 0], [{ purescript-foreign: latest}, Expected '>='.; pos = 0], [{ purescript-effect: latest}, Expected '>='.; pos = 0], [{ purescript-console: latest}, Expected '>='.; pos = 0], [{ purescript-aff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v1.3.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: latest}, Expected '>='.; pos = 0], [{ purescript-foreign-generic: latest}, Expected '>='.; pos = 0], [{ purescript-foreign: latest}, Expected '>='.; pos = 0], [{ purescript-effect: latest}, Expected '>='.; pos = 0], [{ purescript-console: latest}, Expected '>='.; pos = 0], [{ purescript-aff: latest}, Expected '>='.; pos = 0])"
+    },
+    "v1.3.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: latest}, Expected '>='.; pos = 0], [{ purescript-foreign-generic: latest}, Expected '>='.; pos = 0], [{ purescript-foreign: latest}, Expected '>='.; pos = 0], [{ purescript-effect: latest}, Expected '>='.; pos = 0], [{ purescript-console: latest}, Expected '>='.; pos = 0], [{ purescript-aff: latest}, Expected '>='.; pos = 0])"
+    }
+  },
+  "slamdown-smolder": {
+    "v2.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-markdown: poorscript/purescript-markdown#b51ee0e4aa04c9e6a5a70f2552a400c3f9cad439}, Expected '>='.; pos = 0])"
+    },
+    "v2.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-markdown: poorscript/purescript-markdown#b51ee0e4aa04c9e6a5a70f2552a400c3f9cad439}, Expected '>='.; pos = 0])"
+    }
+  },
+  "slides": {
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-halogen: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-list-zipper: *}, Expected '>='.; pos = 0], [{ purescript-halogen: *}, Expected '>='.; pos = 0], [{ purescript-generics: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: git://github.com/DavidHarrison/purescript-list-zipper.git#62517ee}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: git://github.com/DavidHarrison/purescript-list-zipper.git#62517ee}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: git://github.com/soupi/purescript-list-zipper.git#d4f3730}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: git://github.com/soupi/purescript-list-zipper.git#d4f3730}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: git://github.com/soupi/purescript-list-zipper.git#d4f3730}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: git://github.com/soupi/purescript-list-zipper.git#d4f3730}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: git://github.com/soupi/purescript-list-zipper.git#d4f3730}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: git://github.com/soupi/purescript-list-zipper.git#d4f3730}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-list-zipper: git://github.com/soupi/purescript-list-zipper.git#d4f3730}, Expected '>='.; pos = 0])"
+    }
+  },
+  "slides-remember": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-slides: latest}, Expected '>='.; pos = 0], [{ purescript-prelude: latest}, Expected '>='.; pos = 0])"
+    }
+  },
+  "slug": {
+    "v.3.0.1": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.3.0.1"
+    }
+  },
+  "snail": {
+    "v5.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-node-os: thimoteus/purescript-node-os#master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "social-icons": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-records: athanclark/purescript-records#214a78e65feda4328ab7245ed8edb10b9b8dd0d8}, Expected '>='.; pos = 0])"
+    }
+  },
+  "solc": {
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v2.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v3.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "son-of-a-j": {
+    "v0.3.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "js-unsafe-stringify"
+    }
+  },
+  "sorted-arrays": {
+    "v.0.1.2": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.0.1.2"
+    }
+  },
+  "soundfonts": {
+    "1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "1.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "1.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "sparrow": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uuid: git://github.com/athanclark/purescript-uuid.git#2e563284ee5c41d75bf9010de3c4cded9f0223db}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uuid: git://github.com/athanclark/purescript-uuid.git#2e563284ee5c41d75bf9010de3c4cded9f0223db}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uuid: git://github.com/athanclark/purescript-uuid.git#2e563284ee5c41d75bf9010de3c4cded9f0223db}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uuid: git://github.com/athanclark/purescript-uuid.git#2e563284ee5c41d75bf9010de3c4cded9f0223db}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-uuid: git://github.com/athanclark/purescript-uuid.git#2e563284ee5c41d75bf9010de3c4cded9f0223db}, Expected '>='.; pos = 0])"
+    }
+  },
+  "sparrow-queue": {
+    "v0.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-sparrow: git@git.localcooking.com:tooling/purescript-sparrow.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-sparrow: git@git.localcooking.com:tooling/purescript-sparrow.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-sparrow: git@git.localcooking.com:tooling/purescript-sparrow.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-sparrow: git@git.localcooking.com:tooling/purescript-sparrow.git}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-sparrow: git@git.localcooking.com:tooling/purescript-sparrow.git}, Expected '>='.; pos = 0])"
+    }
+  },
+  "spec": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.7.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: >=0.7.0}, Unexpected EOF; pos = 7], [{ purescript-prelude: >=0.1.2}, Unexpected EOF; pos = 7], [{ purescript-exceptions: >=0.3.0}, Unexpected EOF; pos = 7], [{ purescript-console: >=0.1.0}, Unexpected EOF; pos = 7], [{ purescript-aff: >=0.13.0}, Unexpected EOF; pos = 8])"
+    },
+    "v4.0.0-rc1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v4.0.0-rc1"
+    }
+  },
+  "specular": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v0.1.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v0.11.0-purs0.13-1": {
+      "reason": "Expected EOF; pos = 7",
+      "tag": "InvalidTag",
+      "value": "v0.11.0-purs0.13-1"
+    },
+    "v0.13.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-spec-mocha: https://github.com/restaumatic/purescript-spec-mocha.git#v4.0.0-restaumatic2}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    },
+    "v0.8.1-incremental1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.8.1-incremental1"
+    },
+    "v0.8.2-incremental1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.8.2-incremental1"
+    },
+    "v0.8.3-incremental1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.8.3-incremental1"
+    },
+    "v0.9.1-profiling1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.9.1-profiling1"
+    }
+  },
+  "spidermonkey-ast": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "st": {
+    "v0.1.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "stackless": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "stackless-cont": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "string-parsers": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-strings: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.1"
+    }
+  },
+  "strings": {
+    "v0.5.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.1"
+    },
+    "v0.5.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.2"
+    },
+    "v0.5.0-rc.3": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.5.0-rc.3"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "strongcheck-generics": {
+    "0.2": {
+      "reason": "Could not match character '.'; pos = 3",
+      "tag": "InvalidTag",
+      "value": "0.2"
+    }
+  },
+  "stsequence": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-st: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-functions: }, Expected '>='.; pos = 0], [{ purescript-extensions: }, Expected '>='.; pos = 0], [{ purescript-eff: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-st: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-functions: }, Expected '>='.; pos = 0], [{ purescript-extensions: }, Expected '>='.; pos = 0], [{ purescript-eff: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-st: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-functions: }, Expected '>='.; pos = 0], [{ purescript-extensions: }, Expected '>='.; pos = 0], [{ purescript-eff: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-st: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-functions: }, Expected '>='.; pos = 0], [{ purescript-extensions: }, Expected '>='.; pos = 0], [{ purescript-eff: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-st: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-functions: }, Expected '>='.; pos = 0], [{ purescript-extensions: }, Expected '>='.; pos = 0], [{ purescript-eff: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-st: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-functions: }, Expected '>='.; pos = 0], [{ purescript-extensions: }, Expected '>='.; pos = 0], [{ purescript-eff: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.0.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-st: }, Expected '>='.; pos = 0], [{ purescript-integers: }, Expected '>='.; pos = 0], [{ purescript-functions: }, Expected '>='.; pos = 0], [{ purescript-extensions: }, Expected '>='.; pos = 0], [{ purescript-eff: }, Expected '>='.; pos = 0], [{ purescript-arrays: }, Expected '>='.; pos = 0])"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "stuff": {
+    "v1.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v1.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v1.2.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v1.3.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v1.4.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v10.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v2.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v3.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v4.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v5.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v6.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v7.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v8.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v8.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    },
+    "v9.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "io"
+    }
+  },
+  "suggest": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "psa"
+    },
+    "v0.1.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "psa"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-psa: https://github.com/nwolverson/purescript-psa.git#json-suggestion-position}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-psa: https://github.com/nwolverson/purescript-psa.git#json-suggestion-position}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "psa"
+    }
+  },
+  "super-spec": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "svg-parser-halogen": {
+    "v2.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v2.0.0-rc.1"
+    }
+  },
+  "sync-websockets": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.3.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.3.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.10": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-debug: *}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.11": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-debug: *}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.12": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-debug: *}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.13": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-debug: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    },
+    "0.4.9": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-websocket-simple: zudov/purescript-websocket-simple}, Expected '>='.; pos = 0], [{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-json: philopon/purescript-json}, Expected '>='.; pos = 0], [{ purescript-affjax: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "tailrec": {
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "telegraf": {
+    "v.0.5.0": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.0.5.0"
+    }
+  },
+  "test-pontificate": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "thermite": {
+    "v0.8.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.8.0-rc.1"
+    }
+  },
+  "these": {
+    "v0.3.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.3.0-rc.1"
+    }
+  },
+  "tiny-emitter": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "events"
+    }
+  },
+  "toppokki": {
+    "0.2.0-pre2": {
+      "reason": "Expected EOF; pos = 5",
+      "tag": "InvalidTag",
+      "value": "0.2.0-pre2"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-node-buffer: >3.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-node-buffer: >3.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0-pre": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-pre"
+    }
+  },
+  "trace": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "transformerless": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "transformers": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-control: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.6.0-rc.1"
+    },
+    "v0.6.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.6.0-rc.2"
+    },
+    "v0.7.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.7.0-rc.1"
+    },
+    "v0.7.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.7.0-rc.2"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "tropical": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "trout-client": {
+    "v0.4.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hyper-routing"
+    },
+    "v0.6.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hyper-routing"
+    }
+  },
+  "tscompat": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "tuples": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-monoid: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-monoid: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-monoid: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-monoid: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "typeahead": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foreign-callbacks: https://github.com/fluffynukeit/purescript-foreign-callbacks.git#master}, Expected '>='.; pos = 0])"
+    }
+  },
+  "typed-wire": {
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "typedarray": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.9": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "typelevel-measures": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    }
+  },
+  "typelevel-peano": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-arrays: >2.0.0}, Expected '>='.; pos = 0])"
+    }
+  },
+  "uk-modulo": {
+    "6.1": {
+      "reason": "Could not match character '.'; pos = 3",
+      "tag": "InvalidTag",
+      "value": "6.1"
+    }
+  },
+  "undefined": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "NoManifests"
+    }
+  },
+  "unfoldable": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.4.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    },
+    "v1.0.0-rc.2": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.2"
+    }
+  },
+  "unordered-collections": {
+    "v0.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "hashable"
+    },
+    "v1.8.0-patch": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.8.0-patch"
+    }
+  },
+  "unsafe-coerce": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "untagged-union": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ literal: 7b2ae20f77c67b7e419a92fdd0dc7a09b447b18e}, Expected '>='.; pos = 0])"
+    }
+  },
+  "uri": {
+    "v0.1.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.0-rc.1"
+    }
+  },
+  "url-regex-safe": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "validation": {
+    "v0.2.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.2.0-rc.1"
+    },
+    "v1.0.0-rc.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v1.0.0-rc.1"
+    }
+  },
+  "vault": {
+    "v.0.1": {
+      "reason": "Character '.' is not a digit; pos = 1",
+      "tag": "InvalidTag",
+      "value": "v.0.1"
+    }
+  },
+  "vdom-worker": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-webworkers: https://github.com/FrigoEU/purescript-webworkers.git#master}, Expected '>='.; pos = 0], [{ purescript-unsafe-coerce: *}, Expected '>='.; pos = 0], [{ purescript-refs: *}, Expected '>='.; pos = 0], [{ purescript-maps: *}, Expected '>='.; pos = 0], [{ purescript-lists: *}, Expected '>='.; pos = 0], [{ purescript-argonaut-codecs: *}, Expected '>='.; pos = 0])"
+    },
+    "0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-webworkers: https://github.com/FrigoEU/purescript-webworkers.git#master}, Expected '>='.; pos = 0], [{ purescript-unsafe-coerce: *}, Expected '>='.; pos = 0], [{ purescript-refs: *}, Expected '>='.; pos = 0], [{ purescript-maps: *}, Expected '>='.; pos = 0], [{ purescript-lists: *}, Expected '>='.; pos = 0], [{ purescript-argonaut-codecs: *}, Expected '>='.; pos = 0])"
+    },
+    "0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.2.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-argonaut-generic: *}, Expected '>='.; pos = 0])"
+    },
+    "3.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-argonaut-generic: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "vector": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-either: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-either: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-either: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-generics: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-generics: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-proxy: *}, Expected '>='.; pos = 0], [{ purescript-prelude: *}, Expected '>='.; pos = 0], [{ purescript-math: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-either: *}, Expected '>='.; pos = 0], [{ purescript-arrays: *}, Expected '>='.; pos = 0])"
+    },
+    "v2.10": {
+      "reason": "Could not match character '.'; pos = 5",
+      "tag": "InvalidTag",
+      "value": "v2.10"
+    }
+  },
+  "verbal-expressions": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "versions": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "virtual-dom-typed": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-virtual-dom: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "wags": {
+    "v0.6.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.5": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.6": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.7": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.8": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.6.9": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.2": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.3": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v0.7.4": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants, row-options"
+    },
+    "v0.8.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants, row-options"
+    },
+    "v1.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v1.1.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v1.1.1": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "everythings-better-with-variants"
+    },
+    "v1.1.10": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.1.9": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    },
+    "v1.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ js-timers: rename-functions}, Expected '>='.; pos = 0])"
+    }
+  },
+  "web3": {
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.1.1a": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.1.1a"
+    },
+    "v0.14.0-alpha": {
+      "reason": "Expected EOF; pos = 7",
+      "tag": "InvalidTag",
+      "value": "v0.14.0-alpha"
+    },
+    "v0.15.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tagged: LiamGoodacre/purescript-tagged#2d8367cec912e048c362f8ecd021fe06feb7b234}, Expected '>='.; pos = 0])"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-coroutine-transducers: blinky3713/purescript-coroutine-transducers#a99537f}, Expected '>='.; pos = 0])"
+    },
+    "v2.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-coroutine-transducers: blinky3713/purescript-coroutine-transducers#a99537f}, Expected '>='.; pos = 0])"
+    },
+    "v3.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "coroutine-transducers"
+    },
+    "v4.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "coroutine-transducers"
+    },
+    "v5.0.0": {
+      "reason": "Contains dependencies that are not registered.",
+      "tag": "UnregisteredDependencies",
+      "value": "coroutine-transducers"
+    }
+  },
+  "web3-generator": {
+    "push": {
+      "reason": "Character 'p' is not a digit; pos = 0",
+      "tag": "InvalidTag",
+      "value": "push"
+    },
+    "v0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-web3: git+https://github.com/martyall/purescript-web3}, Expected '>='.; pos = 0])"
+    },
+    "v0.15.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-web3: f-o-a-m/purescript-web3#overlap}, Expected '>='.; pos = 0])"
+    },
+    "v0.17.2-alpha": {
+      "reason": "Expected EOF; pos = 7",
+      "tag": "InvalidTag",
+      "value": "v0.17.2-alpha"
+    },
+    "v0.17.2-beta": {
+      "reason": "Expected EOF; pos = 7",
+      "tag": "InvalidTag",
+      "value": "v0.17.2-beta"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mkdirp: joshuahhh/purescript-mkdirp#48ecb4039d5fe3be82d0e82c3a9f2338d1af82d2}, Expected '>='.; pos = 0])"
+    },
+    "v2.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mkdirp: joshuahhh/purescript-mkdirp#48ecb4039d5fe3be82d0e82c3a9f2338d1af82d2}, Expected '>='.; pos = 0])"
+    },
+    "v2.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-mkdirp: joshuahhh/purescript-mkdirp#48ecb4039d5fe3be82d0e82c3a9f2338d1af82d2}, Expected '>='.; pos = 0])"
+    }
+  },
+  "webdriver": {
+    "0.15": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "0.15"
+    },
+    "v0.18": {
+      "reason": "Could not match character '.'; pos = 5",
+      "tag": "InvalidTag",
+      "value": "v0.18"
+    }
+  },
+  "weber": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "webgl": {
+    "0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.4.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.5.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.21": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.6.9": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.7.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.8.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.8.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.8.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.8.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.8.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.8.9": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.9": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-integers: *}, Expected '>='.; pos = 0], [{ purescript-functions: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-arraybuffer-types: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.3": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.4": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.5": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.6": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-vector: *}, Expected '>='.; pos = 0], [{ purescript-typedarray: *}, Expected '>='.; pos = 0], [{ purescript-matrix: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0])"
+    },
+    "v2.10": {
+      "reason": "Could not match character '.'; pos = 5",
+      "tag": "InvalidTag",
+      "value": "v2.10"
+    }
+  },
+  "webgl-examples": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-webgl: *}, Expected '>='.; pos = 0], [{ purescript-datetime: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-webgl: *}, Expected '>='.; pos = 0], [{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-datetime: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3": {
+      "reason": "Could not match character '.'; pos = 4",
+      "tag": "InvalidTag",
+      "value": "v0.3"
+    },
+    "v0.4.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-webgl: *}, Expected '>='.; pos = 0], [{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-datetime: *}, Expected '>='.; pos = 0], [{ purescript-console: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.7": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-webgl: *}, Expected '>='.; pos = 0], [{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-datetime: *}, Expected '>='.; pos = 0], [{ purescript-console: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.9.8": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-webgl: *}, Expected '>='.; pos = 0], [{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-datetime: *}, Expected '>='.; pos = 0], [{ purescript-console: *}, Expected '>='.; pos = 0])"
+    },
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-webgl: *}, Expected '>='.; pos = 0], [{ purescript-random: *}, Expected '>='.; pos = 0], [{ purescript-extensions: *}, Expected '>='.; pos = 0], [{ purescript-datetime: *}, Expected '>='.; pos = 0], [{ purescript-console: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "websockets-rpc": {
+    "1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "1.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "1.0.2": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "webworkers": {
+    "0.0.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foreign: *}, Expected '>='.; pos = 0], [{ purescript-exceptions: *}, Expected '>='.; pos = 0], [{ purescript-argonaut-codecs: *}, Expected '>='.; pos = 0])"
+    },
+    "0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "wikitext": {
+    "v0.0.2.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.0.2.1"
+    }
+  },
+  "xhr": {
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0])"
+    },
+    "v0.3.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-tuples: *}, Expected '>='.; pos = 0], [{ purescript-maybe: *}, Expected '>='.; pos = 0], [{ purescript-foldable-traversable: *}, Expected '>='.; pos = 0])"
+    }
+  },
+  "yargs": {
+    "v0.1.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foreign: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-exceptions: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-easy-ffi: >=1.0.0}, Unexpected EOF; pos = 7])"
+    },
+    "v0.1.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foreign: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-exceptions: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-either: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-easy-ffi: >=1.0.0}, Unexpected EOF; pos = 7])"
+    },
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-foreign: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-exceptions: >=0.2.0}, Unexpected EOF; pos = 7], [{ purescript-either: >=0.1.3}, Unexpected EOF; pos = 7], [{ purescript-easy-ffi: >=1.0.0}, Unexpected EOF; pos = 7])"
+    },
+    "v0.6.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-easy-ffi: master}, Expected '>='.; pos = 0])"
+    },
+    "v0.7.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    },
+    "v0.7.1": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "yarn": {
+    "v1.0.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "MissingLicense"
+    }
+  },
+  "zclipboard": {
+    "v0.2.0": {
+      "reason": "Legacy manifest could not be parsed.",
+      "tag": "InvalidManifest",
+      "value": "InvalidDependencies ([{ purescript-simple-dom: 6358414013eb3106d695e3e19488609f82d903e9}, Expected '>='.; pos = 0])"
+    }
+  },
+  "zeromq": {
+    "v0.0.1.1": {
+      "reason": "Expected EOF; pos = 6",
+      "tag": "InvalidTag",
+      "value": "v0.0.1.1"
+    }
+  }
+}


### PR DESCRIPTION
Solves #300 by committing the files that list the package and version failures from what is hopefully our final full registry import. These files can be used by people who are curious why particular packages or versions are not in the registry.