### PR TITLE
Add CLI args to package set import

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,15 @@
               spago run -m Registry.Scripts.LegacyImporter --node-args $1
             '';
 
+            registry-package-set = ''
+              if [ -z "$1" ]; then
+                echo "No arguments supplied. Expected one of: generate, commit"
+                exit 1
+              fi
+
+              spago run -m Registry.Scripts.PublishPackageSet --node-args $1
+            '';
+
             # This script checks that there are no duplicate entries in the two json files listing packages
             registry-verify-unique = ''
               set -euxo pipefail


### PR DESCRIPTION
This PR adds CLI arguments similar to those used for the legacy importer. This is in preparation for running the package sets importer in CI.

When running locally (for example, to test things out, or to manage committing to upstream yourself), use `generate`:

```console
$ registry-package-set generate
```

To have the script generate a new package set and commit it upstream, following the full CI process:

```console
$ registry-package-set commit
```