### PR TITLE
Minor package set bugfixes

### DIFF
--- a/ci/src/Foreign/GitHub.purs
+++ b/ci/src/Foreign/GitHub.purs
@@ -421,7 +421,7 @@ instance RegistryJson Event where
 type Address = { owner :: String, repo :: String }
 
 registryAddress :: Address
-registryAddress = { owner: "purescript", repo: "registry" }
+registryAddress = { owner: "purescript", repo: "registry-preview" }
 
 type Tag = { name :: String, sha :: String }
 

--- a/ci/src/Registry/Scripts/PackageSetUpdater.purs
+++ b/ci/src/Registry/Scripts/PackageSetUpdater.purs
@@ -54,10 +54,11 @@ main = Aff.launchAff_ do
       >>= maybe (Exception.throw "GITHUB_TOKEN not defined in the environment") (pure <<< GitHubToken)
 
   octokit <- liftEffect $ GitHub.mkOctokit githubToken
-  cache <- Cache.useCache
 
   tmpDir <- liftEffect $ Tmp.mkTmpDir
   liftEffect $ Node.Process.chdir tmpDir
+
+  cache <- Cache.useCache
 
   metadataRef <- liftEffect $ Ref.new Map.empty
 

--- a/ci/src/Registry/Scripts/PackageSetUpdater.purs
+++ b/ci/src/Registry/Scripts/PackageSetUpdater.purs
@@ -16,7 +16,6 @@ import Foreign.Tmp as Tmp
 import Node.Process as Node.Process
 import Node.Process as Process
 import Registry.API as API
-import Registry.Cache as Cache
 import Registry.Index as Index
 import Registry.Json as Json
 import Registry.PackageName as PackageName
@@ -58,8 +57,6 @@ main = Aff.launchAff_ do
   tmpDir <- liftEffect $ Tmp.mkTmpDir
   liftEffect $ Node.Process.chdir tmpDir
 
-  cache <- Cache.useCache
-
   metadataRef <- liftEffect $ Ref.new Map.empty
 
   let
@@ -73,7 +70,7 @@ main = Aff.launchAff_ do
       , uploadPackage: mempty
       , deletePackage: mempty
       , octokit
-      , cache
+      , cache: { write: mempty, read: \_ -> pure (Left mempty), remove: mempty }
       , username: mempty
       , packagesMetadata: metadataRef
       , registry: "registry"


### PR DESCRIPTION
While testing the batch package set updates I noticed two issues:

1. We were commenting on GitHub issues in _this_ repository, but needed to be commenting in the registry-preview repository.
2. In the package set scripts we're reading the cache, then moving to a tmp directory, and continuing from there. This doesn't work, because once we move to the tmp directory the file path of the cache is no longer correct. We don't use the cache anyway so I've removed this.