### PR TITLE
Add support for generating legacy package sets

### DIFF
--- a/ci/spago.dhall
+++ b/ci/spago.dhall
@@ -13,6 +13,7 @@
   , "convertable-options"
   , "crypto"
   , "datetime"
+  , "dodo-printer"
   , "dotenv"
   , "effect"
   , "either"

--- a/ci/src/Registry/Legacy/PackageSet.purs
+++ b/ci/src/Registry/Legacy/PackageSet.purs
@@ -83,7 +83,7 @@ fromPackageSet index metadata (PackageSet { compiler, packages, published, versi
 
     pure
       { version: RawVersion metadataEntry.ref
-      , dependencies: Array.sort $ Array.fromFoldable $ Map.keys $ manifest.dependencies
+      , dependencies: Array.fromFoldable $ Map.keys $ manifest.dependencies
       , repo
       }
     where

--- a/ci/src/Registry/Legacy/PackageSet.purs
+++ b/ci/src/Registry/Legacy/PackageSet.purs
@@ -106,7 +106,7 @@ printDhall (LegacyPackageSet entries) = do
     Dodo.Common.jsCurlies
       $ Dodo.foldWithSeparator Dodo.Common.leadingComma
       $ map printPackage packages
-  
+
   quoteReserved :: String -> String
   quoteReserved input = do
     -- We can't use any reserved keywords:

--- a/ci/src/Registry/Legacy/PackageSet.purs
+++ b/ci/src/Registry/Legacy/PackageSet.purs
@@ -106,13 +106,20 @@ printDhall (LegacyPackageSet entries) = do
     Dodo.Common.jsCurlies
       $ Dodo.foldWithSeparator Dodo.Common.leadingComma
       $ map printPackage packages
+  
+  quoteReserved :: String -> String
+  quoteReserved input = do
+    -- We can't use any reserved keywords:
+    -- https://docs.dhall-lang.org/references/Built-in-types.html#built-in-types-functions-and-operators
+    if input `Array.elem` [ "assert", "let", "using", "missing", "merge", "if", "then", "else" ] then
+      Array.fold [ "`", input, "`" ]
+    else
+      input
 
   printPackage :: forall a. Tuple PackageName LegacyPackageSetEntry -> Dodo.Doc a
   printPackage (Tuple name entry) =
     Array.fold
-      [ Dodo.text do
-          let nameStr = PackageName.print name
-          if nameStr == "assert" then "`assert`" else nameStr
+      [ Dodo.text (quoteReserved (PackageName.print name))
       , Dodo.text " ="
       , Dodo.break
       , Dodo.indent (printEntry entry)

--- a/ci/src/Registry/Legacy/PackageSet.purs
+++ b/ci/src/Registry/Legacy/PackageSet.purs
@@ -2,8 +2,23 @@ module Registry.Legacy.PackageSet where
 
 import Registry.Prelude
 
+import Data.Array as Array
+import Data.Compactable (separate)
+import Data.Formatter.DateTime (FormatterCommand(..))
+import Data.Formatter.DateTime as Formatter.DateTime
+import Data.FunctorWithIndex (mapWithIndex)
+import Data.List as List
+import Data.Map as Map
+import Data.String as String
+import Dodo as Dodo
+import Dodo.Common as Dodo.Common
+import Registry.Index (RegistryIndex)
 import Registry.Json as Json
 import Registry.PackageName (PackageName)
+import Registry.PackageName as PackageName
+import Registry.Schema (Location(..), Manifest(..), Metadata, PackageSet(..))
+import Registry.Version (Version)
+import Registry.Version as Version
 
 newtype LegacyPackageSet = LegacyPackageSet (Map PackageName LegacyPackageSetEntry)
 
@@ -15,16 +30,117 @@ instance RegistryJson LegacyPackageSet where
   encode (LegacyPackageSet plan) = Json.encode plan
   decode = map LegacyPackageSet <<< Json.decode
 
-newtype LegacyPackageSetEntry = LegacyPackageSetEntry
+type LegacyPackageSetEntry =
   { dependencies :: Array PackageName
   , repo :: String
   , version :: RawVersion
   }
 
-derive instance Newtype LegacyPackageSetEntry _
-derive newtype instance Eq LegacyPackageSetEntry
-derive newtype instance Show LegacyPackageSetEntry
+type ConvertedLegacyPackageSet =
+  { name :: String
+  , upstream :: Version
+  , packageSet :: LegacyPackageSet
+  }
 
-instance RegistryJson LegacyPackageSetEntry where
-  encode (LegacyPackageSetEntry plan) = Json.encode plan
-  decode = map LegacyPackageSetEntry <<< Json.decode
+fromPackageSet :: RegistryIndex -> Map PackageName Metadata -> PackageSet -> Either String ConvertedLegacyPackageSet
+fromPackageSet index metadata (PackageSet { compiler, packages, published, version }) = do
+  converted <- case separate $ mapWithIndex convertPackage packages of
+    { left, right } | Map.isEmpty left -> Right right
+    { left } -> do
+      let toValues = Array.fromFoldable <<< Map.values
+      Left $ String.joinWith "\n" $ Array.cons "Failed to convert packages:" $ toValues left
+
+  let converted' = Map.insert (unsafeFromRight (PackageName.parse "metadata")) metadataPackage converted
+  pure { name, upstream: version, packageSet: LegacyPackageSet converted' }
+  where
+  name :: String
+  name = do
+    let dateFormat = List.fromFoldable [ YearFull, MonthTwoDigits, DayOfMonthTwoDigits ]
+    "psc-" <> Version.printVersion compiler <> "-" <> Formatter.DateTime.format dateFormat published
+
+  -- Legacy package sets determine their compiler version by the version of
+  -- the 'metadata' package.
+  metadataPackage :: LegacyPackageSetEntry
+  metadataPackage =
+    { repo: "https://github.com/purescript/purescript-metadata.git"
+    , version: RawVersion ("v" <> Version.printVersion compiler)
+    , dependencies: []
+    }
+
+  convertPackage :: PackageName -> Version -> Either String LegacyPackageSetEntry
+  convertPackage packageName packageVersion = do
+    versions <- note noIndexPackageError $ Map.lookup packageName index
+    Manifest manifest <- note noIndexVersionError $ Map.lookup packageVersion versions
+
+    metadataEntries <- note noMetadataPackageError $ Map.lookup packageName metadata
+    metadataEntry <- note noMetadataVersionError $ Map.lookup packageVersion metadataEntries.published
+
+    repo <- case metadataEntries.location of
+      GitHub { owner, repo, subdir: Nothing } -> Right $ "https://github.com/" <> owner <> "/" <> repo <> ".git"
+      Git { gitUrl, subdir: Nothing } -> Right gitUrl
+      GitHub _ -> Left usesSubdirError
+      Git _ -> Left usesSubdirError
+
+    pure
+      { version: RawVersion metadataEntry.ref
+      , dependencies: Array.sort $ Array.fromFoldable $ Map.keys $ manifest.dependencies
+      , repo
+      }
+    where
+    nameStr = PackageName.print packageName
+    versionStr = Version.printVersion packageVersion
+    noIndexPackageError = "No registry index entry found for " <> nameStr
+    noIndexVersionError = "Found registry index entry for " <> nameStr <> " but none for version " <> versionStr
+    noMetadataPackageError = "No metadata entry found for " <> nameStr
+    noMetadataVersionError = "Found metadata entry for " <> nameStr <> " but no published version for " <> versionStr
+    usesSubdirError = "Package " <> nameStr <> " uses the 'subdir' key, which is not supported for legacy package sets."
+
+printDhall :: LegacyPackageSet -> String
+printDhall (LegacyPackageSet entries) = do
+  let format = Dodo.twoSpaces { pageWidth = 80 }
+  let inputs = Map.toUnfoldable entries
+  Dodo.print Dodo.plainText format (printPackageSet inputs)
+  where
+  printPackageSet :: forall a. Array (Tuple PackageName LegacyPackageSetEntry) -> Dodo.Doc a
+  printPackageSet packages =
+    Dodo.Common.jsCurlies
+      $ Dodo.foldWithSeparator Dodo.Common.leadingComma
+      $ map printPackage packages
+
+  printPackage :: forall a. Tuple PackageName LegacyPackageSetEntry -> Dodo.Doc a
+  printPackage (Tuple name entry) =
+    Array.fold
+      [ Dodo.text do
+          let nameStr = PackageName.print name
+          if nameStr == "assert" then "`assert`" else nameStr
+      , Dodo.text " ="
+      , Dodo.break
+      , Dodo.indent (printEntry entry)
+      ]
+
+  printEntry :: forall a. LegacyPackageSetEntry -> Dodo.Doc a
+  printEntry entry =
+    Dodo.Common.pursCurlies $ Dodo.foldWithSeparator Dodo.Common.leadingComma
+      [ Dodo.text "dependencies =" <> breakAlign (printDependencies entry.dependencies)
+      , Dodo.text "repo =" <> breakAlign (quoteString entry.repo)
+      , Dodo.text "version =" <> breakAlign (printVersion entry.version)
+      ]
+
+  breakAlign :: forall a. Dodo.Doc a -> Dodo.Doc a
+  breakAlign doc =
+    Dodo.flexGroup (Dodo.spaceBreak <> Dodo.align 4 doc)
+
+  printDependencies :: forall a. Array PackageName -> Dodo.Doc a
+  printDependencies dependencies =
+    if Array.null dependencies then
+      Dodo.text "[] : List Text"
+    else
+      Dodo.Common.pursSquares
+        $ Dodo.foldWithSeparator Dodo.Common.leadingComma
+        $ map (quoteString <<< PackageName.print) dependencies
+
+  printVersion :: forall a. RawVersion -> Dodo.Doc a
+  printVersion (RawVersion version) = quoteString version
+
+  quoteString :: forall a. String -> Dodo.Doc a
+  quoteString = Dodo.enclose (Dodo.text "\"") (Dodo.text "\"") <<< Dodo.text

--- a/ci/test/Main.purs
+++ b/ci/test/Main.purs
@@ -34,6 +34,7 @@ import Test.Foreign.JsonRepair as Foreign.JsonRepair
 import Test.Foreign.Licensee (licensee)
 import Test.Registry.Hash as Registry.Hash
 import Test.Registry.Index as Registry.Index
+import Test.Registry.PackageSet as PackageSet
 import Test.Registry.SSH as SSH
 import Test.Registry.Version as TestVersion
 import Test.RegistrySpec as RegistrySpec
@@ -94,6 +95,8 @@ main = launchAff_ do
       TestVersion.testRange
     Spec.describe "Glob" do
       safeGlob
+    Spec.describe "Package Set" do
+      PackageSet.spec
 
 -- | Check all the example Manifests roundtrip (read+write) through PureScript
 manifestExamplesRoundtrip :: Array FilePath -> Spec.Spec Unit

--- a/ci/test/Registry/PackageSet.purs
+++ b/ci/test/Registry/PackageSet.purs
@@ -1,0 +1,210 @@
+module Test.Registry.PackageSet
+  ( spec
+  ) where
+
+import Registry.Prelude
+
+import Data.DateTime (DateTime)
+import Data.Formatter.DateTime as Formatter.DateTime
+import Data.Map as Map
+import Data.RFC3339String (RFC3339String(..))
+import Registry.Hash (unsafeSha256)
+import Registry.Json as Json
+import Registry.Legacy.PackageSet (ConvertedLegacyPackageSet)
+import Registry.Legacy.PackageSet as Legacy.PackageSet
+import Registry.PackageName (PackageName)
+import Registry.PackageName as PackageName
+import Registry.Schema (Location(..), Manifest, Metadata, PackageSet(..))
+import Registry.Schema as Schema
+import Registry.Version (Version)
+import Registry.Version as Version
+import Test.Fixture.Manifest (fixture, setDependencies, setName, setVersion)
+import Test.Spec as Spec
+import Test.Spec.Assertions as Assert
+
+spec :: Spec.Spec Unit
+spec = do
+  Spec.it "Decodes package set" do
+    Json.parseJson packageSetJson `Assert.shouldContain` packageSet
+
+  Spec.it "Encodes package set" do
+    Json.printJson packageSet `Assert.shouldEqual` packageSetJson
+
+  Spec.it "Produces correct legacy package set name" do
+    convertedPackageSet.name `Assert.shouldEqual` "psc-0.15.2-20220725"
+
+  Spec.it "Decodes legacy package set" do
+    Json.parseJson legacyPackageSetJson `Assert.shouldContain` convertedPackageSet.packageSet
+
+  Spec.it "Encodes legacy package set as JSON" do
+    Json.printJson convertedPackageSet.packageSet `Assert.shouldEqual` legacyPackageSetJson
+
+  Spec.it "Encodes legacy package set as Dhall" do
+    Legacy.PackageSet.printDhall convertedPackageSet.packageSet `Assert.shouldEqual` legacyPackageSetDhall
+
+packageSet :: PackageSet
+packageSet = PackageSet
+  { compiler: unsafeVersion "0.15.2"
+  , published: unsafeDate "2022-07-25"
+  , version: unsafeVersion "4.2.0"
+  , packages: Map.fromFoldable $ map (bimap unsafeName unsafeVersion) do
+      [ assert
+      , console
+      , effect
+      , prelude
+      ]
+  }
+
+packageSetJson :: String
+packageSetJson =
+  """{
+  "version": "4.2.0",
+  "compiler": "0.15.2",
+  "published": "2022-07-25",
+  "packages": {
+    "assert": "6.0.0",
+    "console": "6.0.0",
+    "effect": "4.0.0",
+    "prelude": "6.0.0"
+  }
+}"""
+
+convertedPackageSet :: ConvertedLegacyPackageSet
+convertedPackageSet =
+  case Legacy.PackageSet.fromPackageSet index metadata packageSet of
+    Left err -> unsafeCrashWith err
+    Right value -> value
+  where
+  index = Map.fromFoldable
+    [ unsafeIndexEntry assert [ console, effect, prelude ]
+    , unsafeIndexEntry console [ effect, prelude ]
+    , unsafeIndexEntry effect [ prelude ]
+    , unsafeIndexEntry prelude []
+    ]
+
+  metadata = Map.fromFoldable
+    [ unsafeMetadataEntry assert
+    , unsafeMetadataEntry console
+    , unsafeMetadataEntry effect
+    , unsafeMetadataEntry prelude
+    ]
+
+legacyPackageSetJson :: String
+legacyPackageSetJson =
+  """{
+  "assert": {
+    "dependencies": [
+      "console",
+      "effect",
+      "prelude"
+    ],
+    "repo": "https://github.com/purescript/purescript-assert.git",
+    "version": "v6.0.0"
+  },
+  "console": {
+    "dependencies": [
+      "effect",
+      "prelude"
+    ],
+    "repo": "https://github.com/purescript/purescript-console.git",
+    "version": "v6.0.0"
+  },
+  "effect": {
+    "dependencies": [
+      "prelude"
+    ],
+    "repo": "https://github.com/purescript/purescript-effect.git",
+    "version": "v4.0.0"
+  },
+  "metadata": {
+    "dependencies": [],
+    "repo": "https://github.com/purescript/purescript-metadata.git",
+    "version": "v0.15.2"
+  },
+  "prelude": {
+    "dependencies": [],
+    "repo": "https://github.com/purescript/purescript-prelude.git",
+    "version": "v6.0.0"
+  }
+}"""
+
+legacyPackageSetDhall :: String
+legacyPackageSetDhall =
+  """{
+  `assert` =
+    { dependencies = [ "console", "effect", "prelude" ]
+    , repo = "https://github.com/purescript/purescript-assert.git"
+    , version = "v6.0.0"
+    }
+  , console =
+    { dependencies = [ "effect", "prelude" ]
+    , repo = "https://github.com/purescript/purescript-console.git"
+    , version = "v6.0.0"
+    }
+  , effect =
+    { dependencies = [ "prelude" ]
+    , repo = "https://github.com/purescript/purescript-effect.git"
+    , version = "v4.0.0"
+    }
+  , metadata =
+    { dependencies = [] : List Text
+    , repo = "https://github.com/purescript/purescript-metadata.git"
+    , version = "v0.15.2"
+    }
+  , prelude =
+    { dependencies = [] : List Text
+    , repo = "https://github.com/purescript/purescript-prelude.git"
+    , version = "v6.0.0"
+    }
+}"""
+
+assert :: Tuple String String
+assert = Tuple "assert" "6.0.0"
+
+console :: Tuple String String
+console = Tuple "console" "6.0.0"
+
+effect :: Tuple String String
+effect = Tuple "effect" "4.0.0"
+
+prelude :: Tuple String String
+prelude = Tuple "prelude" "6.0.0"
+
+unsafeName :: String -> PackageName
+unsafeName = unsafeFromRight <<< PackageName.parse
+
+unsafeVersion :: String -> Version
+unsafeVersion = unsafeFromRight <<< Version.parseVersion Version.Lenient
+
+unsafeDate :: String -> DateTime
+unsafeDate = unsafeFromRight <<< Formatter.DateTime.unformat Schema.dateFormatter
+
+unsafeIndexEntry :: Tuple String String -> Array (Tuple String String) -> Tuple PackageName (Map Version Manifest)
+unsafeIndexEntry (Tuple name version) deps = do
+  let
+    manifest =
+      fixture
+        # setName name
+        # setVersion version
+        # setDependencies deps
+
+  unsafeName name /\ Map.singleton (unsafeVersion version) manifest
+
+unsafeMetadataEntry :: Tuple String String -> Tuple PackageName Metadata
+unsafeMetadataEntry (Tuple name version) = do
+  let
+    published =
+      { ref: "v" <> version
+      , hash: unsafeSha256 "sha256-gb24ZRec6mgR8TFBVR2eIh5vsMdhuL+zK9VKjWP74Cw="
+      , bytes: 0.0
+      , publishedTime: RFC3339String ""
+      }
+
+    metadata =
+      { location: GitHub { owner: "purescript", repo: "purescript-" <> name, subdir: Nothing }
+      , owners: Nothing
+      , published: Map.singleton (unsafeVersion version) published
+      , unpublished: Map.empty
+      }
+
+  Tuple (unsafeName name) metadata


### PR DESCRIPTION
Closes #329 by adding the ability to generate legacy package package sets from a new-style package set. Specifically, given a package set, we can generate a `packages.json` file and a `packages-dhall` file which each conform to the existing formats.

With this and the automatic package sets publishing we can officially migrate repositories, deprecate the existing package-sets publishing process, and replace it with mirrors from the registry proper.