### PR TITLE
Add removals to batch package set API

### DIFF
--- a/ci/src/Foreign/GitHub.purs
+++ b/ci/src/Foreign/GitHub.purs
@@ -196,7 +196,7 @@ createComment octokit issue body = do
 -- | https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/v5.16.0/docs/issues/update.md
 closeIssue :: Octokit -> IssueNumber -> ExceptT GitHubError Aff Unit
 closeIssue octokit issue = do
-  let args = { status: "closed" }
+  let args = { state: "closed" }
   _ <- Except.withExceptT APIError $ uncachedRequest { octokit, route, headers: Object.empty, args }
   pure unit
   where

--- a/ci/src/Foreign/GitHub.purs
+++ b/ci/src/Foreign/GitHub.purs
@@ -196,7 +196,7 @@ createComment octokit issue body = do
 -- | https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/v5.16.0/docs/issues/update.md
 closeIssue :: Octokit -> IssueNumber -> ExceptT GitHubError Aff Unit
 closeIssue octokit issue = do
-  let args = { status: "closed " }
+  let args = { status: "closed" }
   _ <- Except.withExceptT APIError $ uncachedRequest { octokit, route, headers: Object.empty, args }
   pure unit
   where

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -258,7 +258,7 @@ runOperation operation = case operation of
     registryIndex <- liftAff $ Index.readRegistryIndex registryIndexPath
     let candidates = PackageSet.validatePackageSetCandidates registryIndex latestPackageSet packages
 
-    when (not Map.isEmpty candidates.rejected) do
+    unless (Map.isEmpty candidates.rejected) do
       throwWithComment $ String.joinWith "\n"
         [ "One or more packages in the suggested batch cannot be processed.\n"
         , PackageSet.printRejections candidates.rejected

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -259,7 +259,7 @@ runOperation operation = case operation of
     let candidates = PackageSet.validatePackageSetCandidates registryIndex latestPackageSet packages
 
     when (not Map.isEmpty candidates.rejected) do
-      comment $ String.joinWith "\n"
+      throwWithComment $ String.joinWith "\n"
         [ "One or more packages in the suggested batch cannot be processed:"
         , PackageSet.printRejections candidates.rejected
         ]

--- a/ci/src/Registry/API.purs
+++ b/ci/src/Registry/API.purs
@@ -260,7 +260,7 @@ runOperation operation = case operation of
 
     when (not Map.isEmpty candidates.rejected) do
       throwWithComment $ String.joinWith "\n"
-        [ "One or more packages in the suggested batch cannot be processed:"
+        [ "One or more packages in the suggested batch cannot be processed.\n"
         , PackageSet.printRejections candidates.rejected
         ]
 

--- a/ci/src/Registry/PackageSet.purs
+++ b/ci/src/Registry/PackageSet.purs
@@ -415,7 +415,7 @@ validatePackageSetCandidates index (PackageSet { packages: previousPackages }) c
     -- stop compiling, namely because they depend on this package. The
     -- dependents must also be removed if the removal must be processed.
     let otherPackages = Map.delete name updatedPackages
-    case Array.filter (not <<< dependsOn name) (Map.toUnfoldable otherPackages) of
+    case Array.filter (dependsOn name) (Map.toUnfoldable otherPackages) of
       [] -> pure unit
       dependents -> case Array.filter (fst >>> flip Set.member removals) dependents of
         -- A package can be removed if the only packages that depend on it are also being removed.

--- a/ci/src/Registry/PackageSet.purs
+++ b/ci/src/Registry/PackageSet.purs
@@ -417,7 +417,7 @@ validatePackageSetCandidates index (PackageSet { packages: previousPackages }) c
     let otherPackages = Map.delete name updatedPackages
     case Array.filter (dependsOn name) (Map.toUnfoldable otherPackages) of
       [] -> pure unit
-      dependents -> case Array.filter (fst >>> flip Set.member removals) dependents of
+      dependents -> case Array.filter (fst >>> flip (not Set.member) removals) dependents of
         -- A package can be removed if the only packages that depend on it are also being removed.
         [] -> pure unit
         missing -> do

--- a/ci/src/Registry/Scripts/PackageSetUpdater.purs
+++ b/ci/src/Registry/Scripts/PackageSetUpdater.purs
@@ -128,7 +128,7 @@ main = Aff.launchAff_ do
               Left err -> throwWithComment $ "Failed to commit package set file: " <> err
               Right _ -> pure unit
 
-findRecentUploads :: Hours -> RegistryM (Map PackageName (NonEmptyArray Version))
+findRecentUploads :: Hours -> RegistryM { accepted :: Map PackageName Version, rejected :: Map PackageName (NonEmptyArray Version) }
 findRecentUploads limit = do
   metadata <- readPackagesMetadata
   now <- liftEffect Now.nowDateTime
@@ -144,7 +144,7 @@ findRecentUploads limit = do
         pure version
       pure (Tuple packageName versions)
 
-    deduplicated = packageUploads # foldlWithIndex { rejected: Map.empty, accepted: Map.empty } \name acc versions -> do
+    deduplicated = packageUploads # flip foldlWithIndex { rejected: Map.empty, accepted: Map.empty } \name acc versions -> do
       let { init, last } = NonEmptyArray.unsnoc versions
       case NonEmptyArray.fromArray init of
         Nothing -> acc { accepted = Map.insert name last acc.accepted }

--- a/ci/src/Registry/Scripts/PackageSetUpdater.purs
+++ b/ci/src/Registry/Scripts/PackageSetUpdater.purs
@@ -144,7 +144,7 @@ findRecentUploads limit = do
         pure version
       pure (Tuple packageName versions)
 
-    deduplicated = flip foldlWithIndex { rejected: Map.empty, accepted: Map.empty } \name acc versions -> do
+    deduplicated = packageUploads # foldlWithIndex { rejected: Map.empty, accepted: Map.empty } \name acc versions -> do
       let { init, last } = NonEmptyArray.unsnoc versions
       case NonEmptyArray.fromArray init of
         Nothing -> acc { accepted = Map.insert name last acc.accepted }

--- a/ci/src/Registry/Scripts/PackageSetUpdater.purs
+++ b/ci/src/Registry/Scripts/PackageSetUpdater.purs
@@ -4,11 +4,16 @@ import Registry.Prelude
 
 import Control.Monad.Reader (asks)
 import Data.Array as Array
+import Data.Array.NonEmpty as NonEmptyArray
+import Data.DateTime as DateTime
 import Data.Map as Map
+import Data.PreciseDateTime as PDT
 import Data.String as String
+import Data.Time.Duration (Hours(..))
 import Dotenv as Dotenv
 import Effect.Aff as Aff
 import Effect.Exception as Exception
+import Effect.Now as Now
 import Effect.Ref as Ref
 import Foreign.GitHub (GitHubToken(..))
 import Foreign.GitHub as GitHub
@@ -18,10 +23,12 @@ import Node.Process as Process
 import Registry.API as API
 import Registry.Index as Index
 import Registry.Json as Json
+import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.PackageSet as PackageSet
-import Registry.RegistryM (Env, commitPackageSetFile, runRegistryM, throwWithComment)
+import Registry.RegistryM (Env, RegistryM, commitPackageSetFile, readPackagesMetadata, runRegistryM, throwWithComment)
 import Registry.Schema (PackageSet(..))
+import Registry.Version (Version)
 import Registry.Version as Version
 
 data PublishMode = GeneratePackageSet | CommitPackageSet
@@ -86,18 +93,25 @@ main = Aff.launchAff_ do
     registryIndex <- liftAff $ Index.readRegistryIndex registryIndexPath
 
     prevPackageSet <- PackageSet.readLatestPackageSet
-    candidates <- PackageSet.findPackageSetCandidates registryIndex prevPackageSet
+    recentUploads <- findRecentUploads (Hours 24.0)
 
-    if Map.isEmpty candidates then do
-      log "No new package versions eligible for inclusion in the package set."
+    let filteredUploads = removeDuplicates recentUploads
+    let candidates = PackageSet.validatePackageSetCandidates registryIndex prevPackageSet (map Just filteredUploads.accepted)
+
+    log $ PackageSet.printRejections candidates.rejected
+
+    if Map.isEmpty candidates.accepted then do
+      log "No eligible additions, updates, or removals to produce a new package set."
     else do
+      -- There are no removals in the automated packag sets.
+      let updates = Map.catMaybes candidates.accepted
       let logPackage name version = log (PackageName.print name <> "@" <> Version.printVersion version)
       log "Found the following package versions eligible for inclusion in package set:"
-      forWithIndex_ candidates logPackage
-      PackageSet.processBatch registryIndex prevPackageSet Nothing candidates >>= case _ of
+      forWithIndex_ updates logPackage
+      PackageSet.processBatch registryIndex prevPackageSet Nothing updates >>= case _ of
         Nothing -> do
           log "\n----------\nNo packages could be added to the set. All packages failed:"
-          forWithIndex_ candidates logPackage
+          forWithIndex_ updates logPackage
         Just { success, fail, packageSet } -> do
           unless (Map.isEmpty fail) do
             log "\n----------\nSome packages could not be added to the set:"
@@ -111,3 +125,27 @@ main = Aff.launchAff_ do
             CommitPackageSet -> commitPackageSetFile packageSet >>= case _ of
               Left err -> throwWithComment $ "Failed to commit package set file: " <> err
               Right _ -> pure unit
+
+findRecentUploads :: Hours -> RegistryM (Map PackageName (NonEmptyArray Version))
+findRecentUploads limit = do
+  metadata <- readPackagesMetadata
+  now <- liftEffect Now.nowDateTime
+  let
+    packageUploads = Map.fromFoldable do
+      Tuple packageName packageMetadata <- Map.toUnfoldable metadata
+      versions <- Array.fromFoldable $ NonEmptyArray.fromArray do
+        Tuple version { publishedTime } <- Map.toUnfoldable packageMetadata.published
+        published <- maybe [] (pure <<< PDT.toDateTimeLossy) (PDT.fromRFC3339String publishedTime)
+        let diff = DateTime.diff now published
+        guardA (diff <= limit)
+        pure version
+      pure (Tuple packageName versions)
+  pure packageUploads
+
+removeDuplicates :: Map PackageName (NonEmptyArray Version) -> { rejected :: Map PackageName (NonEmptyArray Version), accepted :: Map PackageName Version }
+removeDuplicates =
+  flip foldlWithIndex { rejected: Map.empty, accepted: Map.empty } \name acc versions -> do
+    let { init, last } = NonEmptyArray.unsnoc versions
+    case NonEmptyArray.fromArray init of
+      Nothing -> acc { accepted = Map.insert name last acc.accepted }
+      Just entries -> acc { accepted = Map.insert name last acc.accepted, rejected = Map.insert name entries acc.rejected }


### PR DESCRIPTION
Closes #438 by adding the last piece: support for package removals. To that end:

1. I've modified our existing package sets processing code to work on a `Map PackageName (Maybe Version)` instead of always having package versions available. No version indicates that a package is being removed.
2. I have added validation (with @colinwahl) for package removals. The rule: you can remove a package only so long as nothing in the package set depends on it, _unless_ that package is also being removed.
3. I've beefed up our error reporting so we can be clear about why exactly an addition, update, or removal did not go through.
4. I have split the batch processing function, `processBatch`, into two separate functions: `processBatchAtomic`, which fails if the entire batch can't go through, and `processBatchSequential`, which attempts to find the maximal set of packages from the candidates that can go into the next set. The batch API should fail if the whole suggested batch doesn't work, so that you can manually fix it. No one is manually fixing the automatic package sets, so those should find as many packages as possible.

Also, I fixed a bug in which we were reusing some logic from the automatic package sets and only considering packages from the last 24 hours. There's no reason to do that in the batch API — someone is specifically asking for _these_ packages to be considered, regardless of when they were published.

With this in place the batch API should be complete.