### PR TITLE
Make registry scripts runnable from any directory in the project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,11 +46,11 @@ jobs:
       - name: "Check that all Dhall compiles, and examples correctly conform to a Manifest"
         run: nix develop --command 'registry-verify-dhall'
 
+      - name: "Install dependencies"
+        run: nix develop --command 'registry-install'
+
       - name: "Run tests"
-        run: |
-          cd ci
-          nix develop --command 'registry-install'
-          nix develop --command 'registry-test'
+        run: nix develop --command 'registry-install'
 
       - name: "Verify CI code formats"
-        run: cd ci && nix develop --command 'registry-check-format'
+        run: nix develop --command 'registry-check-format'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: nix develop --command 'registry-install'
 
       - name: "Run tests"
-        run: nix develop --command 'registry-install'
+        run: nix develop --command 'registry-test'
 
       - name: "Verify CI code formats"
         run: nix develop --command 'registry-check-format'

--- a/flake.nix
+++ b/flake.nix
@@ -83,23 +83,29 @@
           name = "scripts";
           paths = pkgs.lib.mapAttrsToList pkgs.writeShellScriptBin {
             registry-install = ''
+              cd $(git rev-parse --show-toplevel)/ci
               npm ci
               spago install
             '';
 
             registry-test = ''
+              cd $(git rev-parse --show-toplevel)/ci
               spago test
             '';
 
             registry-check-format = ''
+              cd $(git rev-parse --show-toplevel)/ci
               purs-tidy check src test
             '';
 
             registry-api = ''
+              cd $(git rev-parse --show-toplevel)/ci
               spago run -m Registry.API
             '';
 
             registry-importer = ''
+              cd $(git rev-parse --show-toplevel)/ci
+
               if [ -z "$1" ]; then
                 echo "No arguments supplied. Expected one of: generate, update"
                 exit 1
@@ -109,6 +115,8 @@
             '';
 
             registry-package-set-updater = ''
+              cd $(git rev-parse --show-toplevel)/ci
+
               if [ -z "$1" ]; then
                 echo "No arguments supplied. Expected one of: generate, commit"
                 exit 1
@@ -118,11 +126,13 @@
             '';
 
             registry-package-transferrer = ''
+              cd $(git rev-parse --show-toplevel)/ci
               spago run -m Registry.Scripts.PackageTransferrer
             '';
 
             # This script checks that there are no duplicate entries in the two json files listing packages
             registry-verify-unique = ''
+              cd $(git rev-parse --show-toplevel)
               set -euxo pipefail
 
               total=$(cat bower-packages.json new-packages.json | jq -s "add | length")
@@ -146,6 +156,7 @@
             # - all the dhall we have in the repo actually compiles
             # - all the example manifests actually typecheck as Manifests
             registry-verify-dhall = ''
+              cd $(git rev-parse --show-toplevel)
               set -euo pipefail
 
               for FILE in $(find v1 -iname "*.dhall")


### PR DESCRIPTION
The registry scripts (`verify-registry-unique`, `registry-importer`, and so on) are expected to be run from different locations in the repository. For example, of the two scripts mentioned, the former must run in the root and the latter must run in the `ci` directory.

This commit updates the scripts so that they are always run in the location they are supposed to be, regardless of where you executed the command from. For example, I can now execute `registry-importer` in the root of the project and it will work, or execute `verify-registry-unique` from within `ci`, and so on.