### PR TITLE
Inline node-crypto in preparation for PureScript 0.15

### DIFF
--- a/ci/spago.dhall
+++ b/ci/spago.dhall
@@ -11,7 +11,6 @@
   , "console"
   , "control"
   , "convertable-options"
-  , "crypto"
   , "datetime"
   , "dodo-printer"
   , "dotenv"

--- a/ci/src/Foreign/Node/Crypto.js
+++ b/ci/src/Foreign/Node/Crypto.js
@@ -1,0 +1,7 @@
+var crypto = require("crypto");
+
+exports.createHash = (algorithm) => () => crypto.createHash(algorithm);
+
+exports.updateHash = (buffer) => (hash) => () => hash.update(buffer);
+
+exports.digestHash = (hash) => () => hash.digest();

--- a/ci/src/Foreign/Node/Crypto.purs
+++ b/ci/src/Foreign/Node/Crypto.purs
@@ -1,0 +1,19 @@
+-- Adapted from:
+-- https://github.com/oreshinya/purescript-crypto/blob/v4.0.0/src/Node/Crypto/Hash.purs
+module Foreign.Node.Crypto
+  ( Hash
+  , createHash
+  , updateHash
+  , digestHash
+  ) where
+
+import Effect (Effect)
+import Node.Buffer (Buffer)
+
+foreign import data Hash :: Type
+
+foreign import createHash :: String -> Effect Hash
+
+foreign import updateHash :: Buffer -> Hash -> Effect Hash
+
+foreign import digestHash :: Hash -> Effect Buffer

--- a/ci/src/Registry/Hash.purs
+++ b/ci/src/Registry/Hash.purs
@@ -11,8 +11,8 @@ import Registry.Prelude
 import Data.Array as Array
 import Data.List.Lazy as List.Lazy
 import Data.String.CodeUnits as CodeUnits
+import Foreign.Node.Crypto as Crypto
 import Node.Buffer as Buffer
-import Node.Crypto.Hash as Hash
 import Node.FS.Aff as FS
 import Registry.Json as Json
 import Text.Parsing.StringParser (ParseError)
@@ -49,9 +49,9 @@ sha256String string = do
 -- | Hash a buffer using SHA256
 sha256Buffer :: Buffer -> Effect Sha256
 sha256Buffer buffer = do
-  newHash <- Hash.createHash "sha256"
-  hash <- Hash.update buffer newHash
-  digest <- Hash.digest hash
+  newHash <- Crypto.createHash "sha256"
+  hash <- Crypto.updateHash buffer newHash
+  digest <- Crypto.digestHash hash
   string <- Buffer.toString Base64 digest
   let sriString = "sha256-" <> string
   pure $ Sha256 sriString


### PR DESCRIPTION
We have three dependencies that are not available in the current package sets:

- sunde
- crypto
- dotenv

I have updated [sunde](https://github.com/justinwoo/purescript-sunde/pull/2) and [dotenv](https://github.com/nsaunders/purescript-dotenv/pull/37), but the crypto module is significantly larger due to extensive use of the FFI and the author hasn't responded to the two existing PRs that update it to PureScript 0.15. Since we're only using a single function from the crypto Node module (createHash), I have just written our own FFI here so we're unblocked.