### PR TITLE
Fix duplicate module compilation failure

### DIFF
--- a/src/Foreign/Purs.purs
+++ b/src/Foreign/Purs.purs
@@ -91,7 +91,7 @@ callCompiler compilerArgs = do
     Right { exit: NodeProcess.Normally 0, stdout } -> Right $ String.trim stdout
     Right { stdout } -> Left do
       case Json.parseJson (String.trim stdout) of
-        Left err -> UnknownError stdout
+        Left err -> UnknownError $ String.joinWith "\n" [ stdout, err ]
         Right ({ errors } :: { errors :: Array CompilerError })
           | Array.null errors -> UnknownError "Non-normal exit code, but no errors reported."
           | otherwise -> CompilationError errors

--- a/src/Foreign/Purs.purs
+++ b/src/Foreign/Purs.purs
@@ -53,8 +53,7 @@ printCompilerErrors errors = do
   printCompilerError :: CompilerError -> String
   printCompilerError { moduleName, filename, message, errorLink } =
     String.joinWith "\n"
-      [ foldMap (\name -> "  Module: " <> name) moduleName
-      , "  File: " <> filename
+      [ foldMap (\name -> "  Module: " <> name <> "\n") moduleName <> "  File: " <> filename
       , "  Message:"
       , ""
       , "  " <> message


### PR DESCRIPTION
When the compiler fails to build a package because of a duplicate module, the resulting error has no module name set. Our JSON decoding for these errors always expected a module name to be present, so instead of reporting a compilation failure we'd get an "unknown compiler error" and crash.

Here's what the JSON looks like for a duplicate module error:

```json
{
  "warnings": [],
  "errors": [
    {
      "position": {
        "startLine": 1,
        "startColumn": 1,
        "endLine": 1,
        "endColumn": 18
      },
      "message": "  Module Main has been defined multiple times\n",
      "errorCode": "DuplicateModule",
      "errorLink": "https://github.com/purescript/documentation/blob/master/errors/DuplicateModule.md",
      "filename": "src/Main.purs",
      "moduleName": null,
      "suggestion": null
}
```

I've tested out this change, and duplicate module errors now properly report as compilation failures.