### PR TITLE
Rework version ranges

### DIFF
--- a/src/Registry/Version.purs
+++ b/src/Registry/Version.purs
@@ -19,6 +19,7 @@ module Registry.Version
   , rangeIncludes
   , rawRange
   , rawVersion
+  , union
   ) where
 
 import Registry.Prelude
@@ -172,6 +173,17 @@ printRange range =
     , " <"
     , printVersion (lessThan range)
     ]
+
+union :: Range -> Range -> Range
+union (Range r1) (Range r2) = do
+  let lhs = min r1.lhs r2.lhs
+  let rhs = max r1.rhs r2.rhs
+  Range
+    { lhs
+    , rhs
+    , mode: Lenient
+    , raw: Array.fold [ ">=", printVersion lhs, " <", printVersion rhs ]
+    }
 
 intersect :: Range -> Range -> Maybe Range
 intersect (Range r1) (Range r2)


### PR DESCRIPTION
Fixes #491. Specifically, we now:

1. Prioritize the package sets, then the bower.json file, and finally the spago.dhall file when determining what dependencies the project is using.
2. Take the union of the version ranges represented in all three files, rather than prioritize any given one.

I've run this to regenerate the registry index, which can be seen in this PR:
https://github.com/purescript/registry-index/pull/4

On review, these changes look good and properly pick up some of the wide (but acceptable) ranges represented in packages like `unsafe-coerce` which work with multiple compiler versions.