### PR TITLE
Implement legacy package set mirroring

### DIFF
--- a/src/Foreign/Git.purs
+++ b/src/Foreign/Git.purs
@@ -2,8 +2,17 @@ module Foreign.Git where
 
 import Registry.Prelude
 
+import Affjax as Http
+import Control.Monad.Except as Except
+import Data.JSDate as JSDate
+import Data.PreciseDateTime as PDT
+import Data.RFC3339String (RFC3339String)
 import Data.String as String
+import Effect.Aff as Aff
+import Effect.Exception as Exception
+import Foreign.GitHub as GitHub
 import Node.ChildProcess as NodeProcess
+import Node.Process as Env
 import Sunde as Process
 
 runGit_ :: Array String -> Maybe FilePath -> ExceptT String Aff Unit
@@ -30,3 +39,32 @@ runGitSilent args cwd = ExceptT do
       let stdout = String.trim result.stdout
       pure $ Right stdout
     _ -> pure $ Left $ "Failed to run git command via runGitSilent."
+
+-- | Clone a package from a Git location to the provided directory.
+cloneGitTag :: Http.URL -> String -> FilePath -> Aff Unit
+cloneGitTag url ref targetDir = do
+  let args = [ "clone", url, "--branch", ref, "--single-branch", "-c", "advice.detachedHead=false" ]
+  withBackoff' (Except.runExceptT (runGit args (Just targetDir))) >>= case _ of
+    Nothing -> Aff.throwError $ Aff.error $ "Timed out attempting to clone git tag: " <> url <> " " <> ref
+    Just (Left err) -> Aff.throwError $ Aff.error err
+    Just (Right _) -> log "Successfully cloned package."
+
+-- | Read the published time of the checked-out commit.
+gitGetRefTime :: String -> FilePath -> ExceptT String Aff RFC3339String
+gitGetRefTime ref repoDir = do
+  timestamp <- runGit [ "log", "-1", "--date=iso8601-strict", "--format=%cd", ref ] (Just repoDir)
+  jsDate <- liftEffect $ JSDate.parse timestamp
+  dateTime <- Except.except $ note "Failed to convert JSDate to DateTime" $ JSDate.toDateTime jsDate
+  pure $ PDT.toRFC3339String $ PDT.fromDateTime dateTime
+
+configurePacchettiBotti :: Maybe FilePath -> ExceptT String Aff GitHub.GitHubToken
+configurePacchettiBotti cwd = do
+  pacchettiBotti <- liftEffect do
+    Env.lookupEnv "PACCHETTIBOTTI_TOKEN"
+      >>= maybe (Exception.throw "PACCHETTIBOTTI_TOKEN not defined in the environment") pure
+  runGit_ [ "config", "user.name", "PacchettiBotti" ] cwd
+  runGit_ [ "config", "user.email", "<" <> pacchettiBottiEmail <> ">" ] cwd
+  pure (GitHub.GitHubToken pacchettiBotti)
+
+pacchettiBottiEmail :: String
+pacchettiBottiEmail = "pacchettibotti@purescript.org"

--- a/src/Registry/Legacy/PackageSet.purs
+++ b/src/Registry/Legacy/PackageSet.purs
@@ -1,25 +1,49 @@
-module Registry.Legacy.PackageSet where
+module Registry.Legacy.PackageSet
+  ( ConvertedLegacyPackageSet
+  , LegacyPackageSet(..)
+  , LegacyPackageSetEntry
+  , PscTag(..)
+  , fromPackageSet
+  , mirrorLegacySet
+  , parsePscTag
+  , printDhall
+  , printPscTag
+  ) where
 
 import Registry.Prelude
 
+import Control.Monad.Except as Except
+import Control.Monad.Reader (ask)
 import Data.Array as Array
 import Data.Compactable (separate)
+import Data.DateTime (DateTime)
 import Data.Formatter.DateTime (FormatterCommand(..))
-import Data.Formatter.DateTime as Formatter.DateTime
+import Data.Formatter.DateTime as Format.DateTime
 import Data.FunctorWithIndex (mapWithIndex)
-import Data.List as List
+import Data.List (List(..), (:))
 import Data.Map as Map
+import Data.Set as Set
 import Data.String as String
 import Dodo as Dodo
 import Dodo.Common as Dodo.Common
+import Foreign.Git as Git
+import Foreign.GitHub as GitHub
+import Foreign.Tmp as Tmp
+import Node.FS.Aff as FS.Aff
+import Node.Path as Path
+import Parsing as Parsing
+import Parsing.String as Parsing.String
 import Registry.Index (RegistryIndex)
 import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
+import Registry.RegistryM (RegistryM)
+import Registry.RegistryM as RegistryM
 import Registry.Schema (Location(..), Manifest(..), Metadata, PackageSet(..))
 import Registry.Version (Version)
 import Registry.Version as Version
 
+-- | The format of a legacy packages.json package set file
 newtype LegacyPackageSet = LegacyPackageSet (Map PackageName LegacyPackageSetEntry)
 
 derive instance Newtype LegacyPackageSet _
@@ -30,6 +54,8 @@ instance RegistryJson LegacyPackageSet where
   encode (LegacyPackageSet plan) = Json.encode plan
   decode = map LegacyPackageSet <<< Json.decode
 
+-- | The format of a legacy packages.json package set entry for an individual
+-- | package.
 type LegacyPackageSetEntry =
   { dependencies :: Array PackageName
   , repo :: String
@@ -37,10 +63,42 @@ type LegacyPackageSetEntry =
   }
 
 type ConvertedLegacyPackageSet =
-  { name :: String
+  { tag :: PscTag
   , upstream :: Version
   , packageSet :: LegacyPackageSet
   }
+
+-- | A package set tag for the legacy package sets.
+newtype PscTag = PscTag { compiler :: Version, date :: DateTime }
+
+derive instance Newtype PscTag _
+derive instance Eq PscTag
+derive instance Ord PscTag
+
+instance RegistryJson PscTag where
+  encode = Json.encode <<< printPscTag
+  decode = Json.decode >=> parsePscTag
+
+parsePscTag :: String -> Either String PscTag
+parsePscTag = lmap Parsing.parseErrorMessage <<< flip Parsing.runParser do
+  _ <- Parsing.String.string "psc-"
+  version <- Version.versionParser Version.Lenient
+  _ <- Parsing.String.char '-'
+  date <- Parsing.String.rest
+  case Format.DateTime.unformat (YearFull : MonthTwoDigits : DayOfMonthTwoDigits : Nil) date of
+    Left err ->
+      Parsing.fail $ "Expected an 8-digit date such as '20220101': " <> err
+    Right parsedDate ->
+      pure $ PscTag { compiler: version, date: parsedDate }
+
+printPscTag :: PscTag -> String
+printPscTag (PscTag { compiler, date }) =
+  Array.fold
+    [ "psc-"
+    , Version.printVersion compiler
+    , "-"
+    , Format.DateTime.format (YearFull : MonthTwoDigits : DayOfMonthTwoDigits : Nil) date
+    ]
 
 fromPackageSet :: RegistryIndex -> Map PackageName Metadata -> PackageSet -> Either String ConvertedLegacyPackageSet
 fromPackageSet index metadata (PackageSet { compiler, packages, published, version }) = do
@@ -51,12 +109,10 @@ fromPackageSet index metadata (PackageSet { compiler, packages, published, versi
       Left $ String.joinWith "\n" $ Array.cons "Failed to convert packages:" $ toValues left
 
   let converted' = Map.insert (unsafeFromRight (PackageName.parse "metadata")) metadataPackage converted
-  pure { name, upstream: version, packageSet: LegacyPackageSet converted' }
+  pure { tag, upstream: version, packageSet: LegacyPackageSet converted' }
   where
-  name :: String
-  name = do
-    let dateFormat = List.fromFoldable [ YearFull, MonthTwoDigits, DayOfMonthTwoDigits ]
-    "psc-" <> Version.printVersion compiler <> "-" <> Formatter.DateTime.format dateFormat published
+  tag :: PscTag
+  tag = PscTag { compiler, date: published }
 
   -- Legacy package sets determine their compiler version by the version of
   -- the 'metadata' package.
@@ -151,3 +207,92 @@ printDhall (LegacyPackageSet entries) = do
 
   quoteString :: forall a. String -> Dodo.Doc a
   quoteString = Dodo.enclose (Dodo.text "\"") (Dodo.text "\"") <<< Dodo.text
+
+type LatestCompatibleSets = Map Version PscTag
+
+-- https://github.com/purescript/package-sets/blob/psc-0.15.4-20220829/release.sh
+-- https://github.com/purescript/package-sets/blob/psc-0.15.4-20220829/update-latest-compatible-sets.sh
+mirrorLegacySet :: ConvertedLegacyPackageSet -> RegistryM Unit
+mirrorLegacySet { tag, packageSet, upstream } = do
+  tmp <- liftEffect Tmp.mkTmpDir
+
+  { octokit, cache } <- ask
+
+  let
+    packageSetsRepo = { owner: "purescript", repo: "package-sets" }
+    packageSetsPath = Path.concat [ tmp, "package-sets" ]
+
+  packageSetsTags <- liftAff (Except.runExceptT (GitHub.listTags octokit cache packageSetsRepo)) >>= case _ of
+    Left error -> do
+      let formatted = GitHub.printGitHubError error
+      RegistryM.throwWithComment $ "Could not fetch tags for the package-sets repo: " <> formatted
+    Right tags -> pure $ Set.fromFoldable $ map _.name tags
+
+  let printedTag = printPscTag tag
+
+  when (Set.member printedTag packageSetsTags) do
+    RegistryM.throwWithComment $ "Package set tag " <> printedTag <> "already exists, aborting..."
+
+  let packageSetsUrl = "https://github.com/" <> packageSetsRepo.owner <> "/" <> packageSetsRepo.repo <> ".git"
+  liftAff (Except.runExceptT (Git.runGit [ "clone", packageSetsUrl, "--depth", "1" ] (Just tmp))) >>= case _ of
+    Left error -> RegistryM.throwWithComment error
+    Right _ -> pure unit
+
+  -- We need to write three files to the package sets repository:
+  --
+  -- * latest-compatible-sets.json
+  --   stores a mapping of compiler versions to their highest compatible tag
+  --
+  -- * packages.json
+  --   stores the JSON representation of the latest package set
+  --
+  -- * src/packages.dhall
+  --   stores the Dhall representation of the latest package set
+
+  let latestSetsPath = Path.concat [ packageSetsPath, "latest-compatible-sets.json" ]
+  latestCompatibleSets :: LatestCompatibleSets <- do
+    latestSets <- liftAff (Json.readJsonFile latestSetsPath) >>= case _ of
+      Left err -> RegistryM.throwWithComment $ "Failed to read latest-compatible-sets: " <> err
+      Right parsed -> pure parsed
+    let key = (un PscTag tag).compiler
+    case Map.lookup key latestSets of
+      Just existingTag | existingTag >= tag -> do
+        RegistryM.comment "Not updating latest-compatible sets because this tag (or a higher one) already exists."
+        pure latestSets
+      _ ->
+        pure $ Map.insert key tag latestSets
+
+  let
+    packagesDhallPath = Path.concat [ packageSetsPath, "src", "packages.dhall" ]
+    packagesJsonPath = Path.concat [ packageSetsPath, "packages.json" ]
+    commitFiles =
+      [ Tuple packagesDhallPath (printDhall packageSet)
+      , Tuple packagesJsonPath (Json.printJson packageSet)
+      , Tuple latestSetsPath (Json.printJson latestCompatibleSets)
+      ]
+
+  let
+    -- We push the stable tag (ie. just a compiler version) if one does not yet
+    -- exist. We always push the full tag.
+    printedCompiler = Version.printVersion (un PscTag tag).compiler
+    tagsToPush = Array.catMaybes
+      [ if Set.member printedCompiler packageSetsTags then Nothing else Just printedCompiler
+      , Just printedTag
+      ]
+
+  result <- liftAff $ Except.runExceptT do
+    GitHub.GitHubToken token <- Git.configurePacchettiBotti (Just packageSetsPath)
+    for_ commitFiles \(Tuple path contents) -> do
+      liftAff $ FS.Aff.writeTextFile UTF8 path (contents <> "\n")
+      Git.runGit_ [ "add", path ] (Just packageSetsPath)
+    let commitMessage = "Update to the " <> Version.printVersion upstream <> " package set."
+    Git.runGit_ [ "commit", "-m", commitMessage ] (Just packageSetsPath)
+    let origin = "https://pacchettibotti:" <> token <> "@github.com/purescript/package-sets.git"
+    for_ tagsToPush \pushTag -> do
+      Git.runGit_ [ "tag", pushTag ] (Just packageSetsPath)
+      Git.runGitSilent [ "push", origin, pushTag ] (Just packageSetsPath)
+    void $ Git.runGitSilent [ "push", origin, "master" ] (Just packageSetsPath)
+
+  case result of
+    Left error -> RegistryM.throwWithComment $ "Package set mirroring failed: " <> error
+    Right _ -> pure unit

--- a/src/Registry/Legacy/PackageSet.purs
+++ b/src/Registry/Legacy/PackageSet.purs
@@ -5,7 +5,6 @@ module Registry.Legacy.PackageSet
   , LegacyPackageSetEntry
   , PscTag(..)
   , fromPackageSet
-  , legacyPackageSetsRepo
   , mirrorLegacySet
   , parsePscTag
   , printDhall

--- a/src/Registry/Legacy/PackageSet.purs
+++ b/src/Registry/Legacy/PackageSet.purs
@@ -288,10 +288,10 @@ mirrorLegacySet { tag, packageSet, upstream } = do
     let commitMessage = "Update to the " <> Version.printVersion upstream <> " package set."
     Git.runGit_ [ "commit", "-m", commitMessage ] (Just packageSetsPath)
     let origin = "https://pacchettibotti:" <> token <> "@github.com/purescript/package-sets.git"
+    void $ Git.runGitSilent [ "push", origin, "master" ] (Just packageSetsPath)
     for_ tagsToPush \pushTag -> do
       Git.runGit_ [ "tag", pushTag ] (Just packageSetsPath)
       Git.runGitSilent [ "push", origin, pushTag ] (Just packageSetsPath)
-    void $ Git.runGitSilent [ "push", origin, "master" ] (Just packageSetsPath)
 
   case result of
     Left error -> RegistryM.throwWithComment $ "Package set mirroring failed: " <> error

--- a/src/Registry/Legacy/PackageSet.purs
+++ b/src/Registry/Legacy/PackageSet.purs
@@ -47,9 +47,6 @@ import Registry.Schema (Location(..), Manifest(..), Metadata, PackageSet(..))
 import Registry.Version (Version)
 import Registry.Version as Version
 
-legacyPackageSetsRepo :: GitHub.Address
-legacyPackageSetsRepo = { owner: "purescript", repo: "package-sets-preview" }
-
 -- | The format of a legacy packages.json package set file
 newtype LegacyPackageSet = LegacyPackageSet (Map PackageName LegacyPackageSetEntry)
 
@@ -231,6 +228,9 @@ mirrorLegacySet { tag, packageSet, upstream } = do
   { octokit, cache } <- ask
 
   let packageSetsPath = Path.concat [ tmp, "package-sets" ]
+  -- TODO: FIXME: Replace this once we no longer rely on the 'preview' repository.
+  -- Should be 'Constants.legacyPackageSetsRepo' at that point.
+  let legacyPackageSetsRepo = { owner: "purescript", repo: "package-sets-preview" }
 
   packageSetsTags <- liftAff (Except.runExceptT (GitHub.listTags octokit cache legacyPackageSetsRepo)) >>= case _ of
     Left error -> do

--- a/src/Registry/Legacy/PackageSet.purs
+++ b/src/Registry/Legacy/PackageSet.purs
@@ -1,5 +1,6 @@
 module Registry.Legacy.PackageSet
   ( ConvertedLegacyPackageSet
+  , LatestCompatibleSets
   , LegacyPackageSet(..)
   , LegacyPackageSetEntry
   , PscTag(..)
@@ -84,7 +85,7 @@ instance RegistryJson PscTag where
 parsePscTag :: String -> Either String PscTag
 parsePscTag = lmap Parsing.parseErrorMessage <<< flip Parsing.runParser do
   _ <- Parsing.String.string "psc-"
-  version <- Version.mkVersionParser Version.Lenient =<< charsUntilHyphen
+  version <- Version.mkVersionParser Version.Strict =<< charsUntilHyphen
   date <- Parsing.String.rest
   case Format.DateTime.unformat (YearFull : MonthTwoDigits : DayOfMonthTwoDigits : Nil) date of
     Left err ->

--- a/src/Registry/Scripts/PackageTransferrer.purs
+++ b/src/Registry/Scripts/PackageTransferrer.purs
@@ -104,7 +104,7 @@ transferPackage rawPackageName newPackageLocation = do
     rawPayload = Json.stringifyJson payload
 
   API.runOperation $ Authenticated $ AuthenticatedData
-    { email: API.pacchettiBottiEmail
+    { email: Git.pacchettiBottiEmail
     , payload
     , rawPayload
     , signature: [] -- The API will re-sign using @pacchettibotti credentials.
@@ -193,7 +193,7 @@ commitLegacyRegistryFile :: FilePath -> Aff (Either String Unit)
 commitLegacyRegistryFile sourceFile = Except.runExceptT do
   Git.runGitSilent [ "diff", "--stat" ] Nothing >>= case _ of
     files | String.contains (String.Pattern sourceFile) files -> do
-      GitHubToken token <- API.configurePacchettiBotti Nothing
+      GitHubToken token <- Git.configurePacchettiBotti Nothing
       Git.runGit_ [ "pull" ] Nothing
       Git.runGit_ [ "add", sourceFile ] Nothing
       log "Committing to registry..."

--- a/src/Registry/Version.purs
+++ b/src/Registry/Version.purs
@@ -19,6 +19,7 @@ module Registry.Version
   , rangeIncludes
   , rawRange
   , rawVersion
+  , versionParser
   ) where
 
 import Registry.Prelude

--- a/src/Registry/Version.purs
+++ b/src/Registry/Version.purs
@@ -11,6 +11,7 @@ module Registry.Version
   , lessThan
   , major
   , minor
+  , mkVersionParser
   , parseRange
   , parseVersion
   , patch
@@ -19,7 +20,6 @@ module Registry.Version
   , rangeIncludes
   , rawRange
   , rawVersion
-  , versionParser
   ) where
 
 import Registry.Prelude
@@ -194,9 +194,9 @@ parseRange mode input = do
 
   Parsing.runParser parserInput do
     _ <- Parsing.String.string ">=" <|> Parsing.fail "Ranges must begin with >="
-    lhs <- toVersion mode =<< map String.CodeUnits.fromCharArray charsUntilSpace
+    lhs <- mkVersionParser mode =<< map String.CodeUnits.fromCharArray charsUntilSpace
     _ <- Parsing.String.char '<' <|> Parsing.fail "Ranges must end with <"
-    rhs <- toVersion mode =<< map String.CodeUnits.fromCharArray chars
+    rhs <- mkVersionParser mode =<< map String.CodeUnits.fromCharArray chars
     -- Parsing.String.eof
     -- Trimming prerelease identifiers in lenient mode can produce ranges
     -- where the lhs was less than the rhs, but no longer is. For example:
@@ -255,16 +255,16 @@ convertRange input = fromRight input do
     _ <- Parsing.String.char '>'
     Parsing.Combinators.notFollowedBy (Parsing.String.char '=')
     lhsChars <- map String.CodeUnits.fromCharArray charsUntilSpace
-    lhs <- toVersion Lenient lhsChars
+    lhs <- mkVersionParser Lenient lhsChars
     Parsing.ParseState suffix _ _ <- Parsing.getParserT
     pure $ Array.fold [ ">=", printVersion (bumpPatch lhs), " ", suffix ]
 
   -- Fix ranges that end with '<=' instead of '<'
   fixLtRhs str = fromRight str $ Parsing.runParser str do
     _ <- Parsing.String.string ">="
-    lhs <- toVersion Lenient =<< map String.CodeUnits.fromCharArray charsUntilSpace
+    lhs <- mkVersionParser Lenient =<< map String.CodeUnits.fromCharArray charsUntilSpace
     _ <- Parsing.String.string "<="
-    rhs <- toVersion Lenient =<< map String.CodeUnits.fromCharArray chars
+    rhs <- mkVersionParser Lenient =<< map String.CodeUnits.fromCharArray chars
     Parsing.String.eof
     pure $ Array.fold [ ">=", printVersion lhs, " <", printVersion (bumpPatch rhs) ]
 
@@ -272,7 +272,7 @@ convertRange input = fromRight input do
   fixUpperOnly str = fromRight str $ Parsing.runParser str do
     _ <- Parsing.String.char '<'
     hasEq <- Parsing.Combinators.optionMaybe (Parsing.String.char '=')
-    lhs <- toVersion Lenient =<< map String.CodeUnits.fromCharArray chars
+    lhs <- mkVersionParser Lenient =<< map String.CodeUnits.fromCharArray chars
     Parsing.String.eof
     pure $ Array.fold [ ">=0.0.0 <", printVersion (if isJust hasEq then bumpPatch lhs else lhs) ]
 
@@ -281,8 +281,8 @@ convertRange input = fromRight input do
     version <- parseVersion Lenient str
     pure $ Array.fold [ ">=", printVersion version, " <", printVersion (bumpPatch version) ]
 
-toVersion :: ParseMode -> String -> Parser String Version
-toVersion mode string = Monad.Error.liftEither case mode of
+mkVersionParser :: ParseMode -> String -> Parser String Version
+mkVersionParser mode string = Monad.Error.liftEither case mode of
   Lenient -> do
     let truncate pattern input = fromMaybe input $ Array.head $ String.split pattern input
     let noPrerelease = truncate (String.Pattern "-")

--- a/test/Registry/PackageSet.purs
+++ b/test/Registry/PackageSet.purs
@@ -10,7 +10,7 @@ import Data.Map as Map
 import Data.RFC3339String (RFC3339String(..))
 import Registry.Hash (unsafeSha256)
 import Registry.Json as Json
-import Registry.Legacy.PackageSet (ConvertedLegacyPackageSet)
+import Registry.Legacy.PackageSet (ConvertedLegacyPackageSet, printPscTag)
 import Registry.Legacy.PackageSet as Legacy.PackageSet
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
@@ -32,7 +32,7 @@ spec = do
     Json.printJson packageSet `Assert.shouldEqual` packageSetJson
 
   Spec.it "Produces correct legacy package set name" do
-    convertedPackageSet.name `Assert.shouldEqual` "psc-0.15.2-20220725"
+    printPscTag convertedPackageSet.tag `Assert.shouldEqual` "psc-0.15.2-20220725"
 
   Spec.it "Decodes legacy package set" do
     Json.parseJson legacyPackageSetJson `Assert.shouldContain` convertedPackageSet.packageSet

--- a/test/Registry/PackageSet.purs
+++ b/test/Registry/PackageSet.purs
@@ -11,7 +11,7 @@ import Data.Map as Map
 import Data.RFC3339String (RFC3339String(..))
 import Registry.Hash (unsafeSha256)
 import Registry.Json as Json
-import Registry.Legacy.PackageSet (ConvertedLegacyPackageSet, parsePscTag, printPscTag)
+import Registry.Legacy.PackageSet (ConvertedLegacyPackageSet, LatestCompatibleSets, parsePscTag, printPscTag)
 import Registry.Legacy.PackageSet as Legacy.PackageSet
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
@@ -38,6 +38,13 @@ spec = do
     let roundtrip = map printPscTag <<< parsePscTag
     roundtrip valid `Assert.shouldContain` valid
     roundtrip invalid `Assert.shouldSatisfy` Either.isLeft
+
+  Spec.it "Parses legacy 'latest compatible set' files" do
+    let
+      parsed :: Either _ LatestCompatibleSets
+      parsed = Json.parseJson latestCompatibleSets
+
+    map Json.printJson parsed `Assert.shouldContain` latestCompatibleSets
 
   Spec.it "Produces correct legacy package set name" do
     printPscTag convertedPackageSet.tag `Assert.shouldEqual` "psc-0.15.2-20220725"
@@ -94,6 +101,36 @@ New packages:
 Removed packages:
   - assert@6.0.0
 """
+
+latestCompatibleSets :: String
+latestCompatibleSets =
+  """{
+  "0.12.0": "psc-0.12.0-20181024",
+  "0.12.1": "psc-0.12.1-20190107",
+  "0.12.2": "psc-0.12.2-20190210",
+  "0.12.3": "psc-0.12.3-20190409",
+  "0.12.4": "psc-0.12.4-20190418",
+  "0.12.5": "psc-0.12.5-20190525",
+  "0.13.0": "psc-0.13.0-20190713",
+  "0.13.2": "psc-0.13.2-20190815",
+  "0.13.3": "psc-0.13.3-20191005",
+  "0.13.4": "psc-0.13.4-20191125",
+  "0.13.5": "psc-0.13.5-20200103",
+  "0.13.6": "psc-0.13.6-20200507",
+  "0.13.8": "psc-0.13.8-20210226",
+  "0.14.0": "psc-0.14.0-20210409",
+  "0.14.1": "psc-0.14.1-20210613",
+  "0.14.2": "psc-0.14.2-20210713",
+  "0.14.3": "psc-0.14.3-20210825",
+  "0.14.4": "psc-0.14.4-20211109",
+  "0.14.5": "psc-0.14.5-20220224",
+  "0.14.6": "psc-0.14.6-20220228",
+  "0.14.7": "psc-0.14.7-20220418",
+  "0.15.0": "psc-0.15.0-20220527",
+  "0.15.2": "psc-0.15.2-20220706",
+  "0.15.3": "psc-0.15.3-20220712",
+  "0.15.4": "psc-0.15.4-20220829"
+}"""
 
 packageSet :: PackageSet
 packageSet = PackageSet

--- a/test/Registry/PackageSet.purs
+++ b/test/Registry/PackageSet.purs
@@ -5,12 +5,13 @@ module Test.Registry.PackageSet
 import Registry.Prelude
 
 import Data.DateTime (DateTime)
+import Data.Either as Either
 import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Map as Map
 import Data.RFC3339String (RFC3339String(..))
 import Registry.Hash (unsafeSha256)
 import Registry.Json as Json
-import Registry.Legacy.PackageSet (ConvertedLegacyPackageSet, printPscTag)
+import Registry.Legacy.PackageSet (ConvertedLegacyPackageSet, parsePscTag, printPscTag)
 import Registry.Legacy.PackageSet as Legacy.PackageSet
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
@@ -30,6 +31,13 @@ spec = do
 
   Spec.it "Encodes package set" do
     Json.printJson packageSet `Assert.shouldEqual` packageSetJson
+
+  Spec.it "Parses legacy package set tags" do
+    let valid = "psc-0.12.18-20220102"
+    let invalid = "psc-0.14.3.1-2022-01-02"
+    let roundtrip = map printPscTag <<< parsePscTag
+    roundtrip valid `Assert.shouldContain` valid
+    roundtrip invalid `Assert.shouldSatisfy` Either.isLeft
 
   Spec.it "Produces correct legacy package set name" do
     printPscTag convertedPackageSet.tag `Assert.shouldEqual` "psc-0.15.2-20220725"

--- a/test/scripts/PublishPursuit.purs
+++ b/test/scripts/PublishPursuit.purs
@@ -8,13 +8,14 @@ import Dotenv as Dotenv
 import Effect.Exception (throw)
 import Effect.Ref as Ref
 import Effect.Unsafe (unsafePerformEffect)
+import Foreign.Git as Git
 import Foreign.GitHub (GitHubToken(..))
 import Foreign.GitHub as GitHub
 import Foreign.Tmp as Tmp
 import Node.FS.Aff as FS
 import Node.Path as Path
 import Node.Process as Process
-import Registry.API (cloneGitTag, publishToPursuit)
+import Registry.API (publishToPursuit)
 import Registry.Cache as Cache
 import Registry.PackageName as PackageName
 import Registry.RegistryM (Env, runRegistryM)
@@ -52,7 +53,7 @@ main = launchAff_ $ do
 
   runRegistryM env do
     tmpDir <- liftEffect Tmp.mkTmpDir
-    liftAff $ cloneGitTag ("https://github.com/purescript/purescript-console") "v5.0.0" tmpDir
+    liftAff $ Git.cloneGitTag ("https://github.com/purescript/purescript-console") "v5.0.0" tmpDir
     let
       packageSourceDir = tmpDir <> Path.sep <> "purescript-console"
       pursJson =


### PR DESCRIPTION
This implements legacy package set mirroring so that we can officially deprecate the package-sets publishing process in the `purescript/package-sets` repository. The implementation largely replicates these two scripts:

* https://github.com/purescript/package-sets/blob/psc-0.15.4-20220829/latest-compatible-sets.json
* https://github.com/purescript/package-sets/blob/psc-0.15.4-20220829/release.sh

We will retain the [`release.yml` file that builds release assets](https://github.com/purescript/package-sets/blob/9139d7ee3992040ebf66e4d24d437574b6e9b58c/.github/workflows/release.yml), so that hasn't been included in this PR.

When a new package set is produced via the daily package sets _or_ a manual release, then we convert it to the legacy format and:

* If there has already been a package sets release that day, nothing is mirrored to the legacy sets (in keeping with the existing implementation).
* If there has not been a package sets release, then we write the `latest-compatible-sets.json` file with the new tag, write the `src/packages.dhall` file in Dhall, and write the `packages.json` file in JSON. The three files are committed. Then, we tag the commit with `psc-COMPILER-DATE`. We also tag it with `psc-COMPILER` if this is the first compiler version in the series. The commit and tags are all pushed.

At that point the `release.yml` file picks it up and makes the GitHub release with the proper assets. Therefore, all files in the package sets repo can be removed except:

* `.github/workflows/release.yml`
* `packages.json`
* `latest-compatible-sets.json`
* `src/packages.dhall`
* `default.nix`

(as well as the README and LICENSE files, which aren't directly relevant to the code here).