### PR TITLE
Make repo urls configurable

### DIFF
--- a/src/Foreign/GitHub.purs
+++ b/src/Foreign/GitHub.purs
@@ -24,7 +24,6 @@ module Foreign.GitHub
   , parseRepo
   , printGitHubError
   , printRateLimit
-  , registryAddress
   ) where
 
 import Registry.Prelude
@@ -62,6 +61,7 @@ import Parsing.String as Parsing.String
 import Parsing.String.Basic as Parsing.String.Basic
 import Registry.Cache (Cache)
 import Registry.Cache as Cache
+import Registry.Constants as Constants
 import Registry.Json ((.:))
 import Registry.Json as Json
 
@@ -199,7 +199,7 @@ createComment octokit issue body = do
   pure unit
   where
   route :: Route
-  route = Route $ i "POST /repos/" registryAddress.owner "/" registryAddress.repo "/issues/" (unwrap issue) "/comments"
+  route = Route $ i "POST /repos/" Constants.registryRepo.owner "/" Constants.registryRepo.repo "/issues/" (unwrap issue) "/comments"
 
 -- | Close an issue in the registry repo.
 -- | https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/v5.16.0/docs/issues/update.md
@@ -210,7 +210,7 @@ closeIssue octokit issue = do
   pure unit
   where
   route :: Route
-  route = Route $ i "PATCH /repos/" registryAddress.owner "/" registryAddress.repo "/issues/" (unwrap issue)
+  route = Route $ i "PATCH /repos/" Constants.registryRepo.owner "/" Constants.registryRepo.repo "/issues/" (unwrap issue)
 
 type RateLimit =
   { limit :: Int
@@ -428,9 +428,6 @@ instance RegistryJson Event where
     pure $ Event { body, username, issueNumber: IssueNumber issueNumber }
 
 type Address = { owner :: String, repo :: String }
-
-registryAddress :: Address
-registryAddress = { owner: "purescript", repo: "registry-preview" }
 
 type Tag = { name :: String, sha :: String, url :: Http.URL }
 

--- a/src/Registry/API.purs
+++ b/src/Registry/API.purs
@@ -55,6 +55,7 @@ import Node.Process as Node.Process
 import Parsing as Parsing
 import Registry.Cache (Cache)
 import Registry.Cache as Cache
+import Registry.Constants as Constants
 import Registry.Hash as Hash
 import Registry.Index as Index
 import Registry.Json as Json
@@ -414,13 +415,13 @@ runOperation operation = case operation of
       closeIssue
 
 registryMetadataPath :: FilePath -> FilePath
-registryMetadataPath registryPath = Path.concat [ registryPath, "metadata" ]
+registryMetadataPath registryPath = Path.concat [ registryPath, Constants.metadataPath ]
 
 registryPackageSetsPath :: FilePath -> FilePath
-registryPackageSetsPath registryPath = Path.concat [ registryPath, "package-sets" ]
+registryPackageSetsPath registryPath = Path.concat [ registryPath, Constants.packageSetsPath ]
 
 metadataFile :: FilePath -> PackageName -> FilePath
-metadataFile registryPath packageName = Path.concat [ registryPath, "metadata", PackageName.print packageName <> ".json" ]
+metadataFile registryPath packageName = Path.concat [ registryPath, Constants.metadataPath, PackageName.print packageName <> ".json" ]
 
 addOrUpdate :: UpdateData -> Metadata -> RegistryM Unit
 addOrUpdate { updateRef, buildPlan, packageName } inputMetadata = do
@@ -686,7 +687,7 @@ publishToPursuit { packageSourceDir, buildPlan: buildPlan@(BuildPlan { compiler,
       -- unpacked, ie. package-name-major.minor.patch
       filename = PackageName.print packageName <> "-" <> Version.printVersion version <> ".tar.gz"
       filepath = dependenciesDir <> Path.sep <> filename
-    liftAff (Wget.wget ("packages.registry.purescript.org/" <> PackageName.print packageName <> "/" <> Version.printVersion version <> ".tar.gz") filepath) >>= case _ of
+    liftAff (Wget.wget (Constants.registryPackagesUrl <> "/" <> PackageName.print packageName <> "/" <> Version.printVersion version <> ".tar.gz") filepath) >>= case _ of
       Left err -> throwWithComment $ "Error while fetching tarball: " <> err
       Right _ -> pure unit
     liftEffect $ Tar.extract { cwd: dependenciesDir, archive: filename }
@@ -904,14 +905,13 @@ fetchRegistryIndex :: RegistryM Unit
 fetchRegistryIndex = do
   registryIndexPath <- asks _.registryIndex
   log "Fetching the most recent registry index..."
-  liftAff $ fetchRepo { owner: "purescript", repo: "registry-index" } registryIndexPath
+  liftAff $ fetchRepo Constants.registryIndexRepo registryIndexPath
 
 fetchRegistry :: RegistryM Unit
 fetchRegistry = do
   registryPath <- asks _.registry
   log "Fetching the most recent registry ..."
-  -- TODO: When the registry is migrated, rename this to 'registry'
-  liftAff $ fetchRepo { owner: "purescript", repo: "registry-preview" } registryPath
+  liftAff $ fetchRepo Constants.registryRepo registryPath
 
 data PursPublishMethod = LegacyPursPublish | PursPublish
 
@@ -1003,7 +1003,8 @@ pacchettiBottiPushToRegistryIndex packageName registryIndexDir = Except.runExcep
   Git.runGit_ [ "pull", "--rebase", "--autostash" ] (Just registryIndexDir)
   Git.runGit_ [ "add", Index.getIndexPath packageName ] (Just registryIndexDir)
   Git.runGit_ [ "commit", "-m", "Update manifests for package " <> PackageName.print packageName ] (Just registryIndexDir)
-  let origin = "https://pacchettibotti:" <> token <> "@github.com/purescript/registry-index.git"
+  let upstreamRepo = Constants.registryIndexRepo.owner <> "/" <> Constants.registryIndexRepo.repo
+  let origin = "https://pacchettibotti:" <> token <> "@github.com/" <> upstreamRepo <> ".git"
   void $ Git.runGitSilent [ "push", origin, "main" ] (Just registryIndexDir)
 
 pacchettiBottiPushToRegistryMetadata :: PackageName -> FilePath -> Aff (Either String Unit)
@@ -1012,16 +1013,18 @@ pacchettiBottiPushToRegistryMetadata packageName registryDir = Except.runExceptT
   Git.runGit_ [ "pull", "--rebase", "--autostash" ] (Just registryDir)
   Git.runGit_ [ "add", Path.concat [ "metadata", PackageName.print packageName <> ".json" ] ] (Just registryDir)
   Git.runGit_ [ "commit", "-m", "Update metadata for package " <> PackageName.print packageName ] (Just registryDir)
-  let origin = "https://pacchettibotti:" <> token <> "@github.com/purescript/registry-preview.git"
+  let upstreamRepo = Constants.registryRepo.owner <> "/" <> Constants.registryRepo.repo
+  let origin = "https://pacchettibotti:" <> token <> "@github.com/" <> upstreamRepo <> ".git"
   void $ Git.runGitSilent [ "push", origin, "main" ] (Just registryDir)
 
 pacchettiBottiPushToRegistryPackageSets :: Version -> String -> FilePath -> Aff (Either String Unit)
 pacchettiBottiPushToRegistryPackageSets version commitMessage registryDir = Except.runExceptT do
   GitHubToken token <- configurePacchettiBotti (Just registryDir)
   Git.runGit_ [ "pull", "--rebase", "--autostash" ] (Just registryDir)
-  Git.runGit_ [ "add", Path.concat [ "package-sets", Version.printVersion version <> ".json" ] ] (Just registryDir)
+  Git.runGit_ [ "add", Path.concat [ Constants.packageSetsPath, Version.printVersion version <> ".json" ] ] (Just registryDir)
   Git.runGit_ [ "commit", "-m", commitMessage ] (Just registryDir)
-  let origin = "https://pacchettibotti:" <> token <> "@github.com/purescript/registry-preview.git"
+  let upstreamRepo = Constants.registryRepo.owner <> "/" <> Constants.registryRepo.repo
+  let origin = "https://pacchettibotti:" <> token <> "@github.com/" <> upstreamRepo <> ".git"
   void $ Git.runGitSilent [ "push", origin, "main" ] (Just registryDir)
 
 -- | The absolute maximum bytes allowed in a package

--- a/src/Registry/Constants.purs
+++ b/src/Registry/Constants.purs
@@ -1,0 +1,31 @@
+module Registry.Constants
+  ( legacyPackageSetsRepo
+  , metadataPath
+  , packageSetsPath
+  , registryIndexRepo
+  , registryPackagesUrl
+  , registryRepo
+  ) where
+
+import Affjax as Http
+import Node.Path (FilePath)
+
+type Repository = { owner :: String, repo :: String }
+
+registryRepo :: Repository
+registryRepo = { owner: "purescript", repo: "registry-preview" }
+
+packageSetsPath :: FilePath
+packageSetsPath = "package-sets"
+
+metadataPath :: FilePath
+metadataPath = "metadata"
+
+registryIndexRepo :: Repository
+registryIndexRepo = { owner: "purescript", repo: "registry-index" }
+
+legacyPackageSetsRepo :: Repository
+legacyPackageSetsRepo = { owner: "purescript", repo: "package-sets" }
+
+registryPackagesUrl :: Http.URL
+registryPackagesUrl = "https://packages.registry.purescript.org"

--- a/src/Registry/PackageSet.purs
+++ b/src/Registry/PackageSet.purs
@@ -34,6 +34,7 @@ import Foreign.Wget as Wget
 import Node.FS.Aff as FS.Aff
 import Node.FS.Aff as FSA
 import Node.Path as Path
+import Registry.Constants as Constants
 import Registry.Index (RegistryIndex)
 import Registry.Json as Json
 import Registry.PackageGraph as PackageGraph
@@ -47,7 +48,7 @@ import Registry.Version as Version
 getPackageSetsPath :: RegistryM FilePath
 getPackageSetsPath = do
   registryPath <- asks _.registry
-  pure $ Path.concat [ registryPath, "package-sets" ]
+  pure $ Path.concat [ registryPath, Constants.packageSetsPath ]
 
 getPackageSetPath :: Version -> RegistryM FilePath
 getPackageSetPath version = do
@@ -298,7 +299,8 @@ installPackage name version = do
 
   registryUrl :: Http.URL
   registryUrl = Array.fold
-    [ "https://packages.registry.purescript.org/"
+    [ Constants.registryPackagesUrl
+    , "/"
     , PackageName.print name
     , "/"
     , Version.printVersion version


### PR DESCRIPTION
This PR exposes the various repositories and file paths we use for the registry via a Constants module (one that we can add other things to, such as the S3 bucket location, so that package managers can reuse them). When it comes time to do the repository migration we'll just have to update the Constants module.