### PR TITLE
Make build plan resolutions optional

### DIFF
--- a/src/Foreign/Dhall.purs
+++ b/src/Foreign/Dhall.purs
@@ -6,18 +6,6 @@ import Node.ChildProcess as NodeProcess
 import Registry.Json as Json
 import Sunde as Process
 
--- | Attempt to convert a JSON file representing a PureScript manifest into
--- | the corresponding `Manifest.dhall` type using the `json-to-dhall` CLI.
-jsonToDhallManifest :: String -> Aff (Either String String)
-jsonToDhallManifest jsonStr = do
-  let cmd = "json-to-dhall"
-  let stdin = Just jsonStr
-  let args = [ "--records-loose", "--unions-strict", "./v1/Manifest.dhall" ]
-  result <- Process.spawn { cmd, stdin, args } NodeProcess.defaultSpawnOptions
-  pure $ case result.exit of
-    NodeProcess.Normally 0 -> Right jsonStr
-    _ -> Left result.stderr
-
 -- | Convert a string representing a Dhall expression into JSON using the
 -- | `dhall-to-json` CLI.
 dhallToJson :: { dhall :: String, cwd :: Maybe FilePath } -> Aff (Either String Json.Json)

--- a/src/Foreign/Dhall.purs
+++ b/src/Foreign/Dhall.purs
@@ -6,6 +6,16 @@ import Node.ChildProcess as NodeProcess
 import Registry.Json as Json
 import Sunde as Process
 
+jsonToDhallManifest :: String -> Aff (Either String String)
+jsonToDhallManifest jsonStr = do
+  let cmd = "json-to-dhall"
+  let stdin = Just jsonStr
+  let args = [ "--records-loose", "--unions-strict", "./v1/Manifest.dhall" ]
+  result <- Process.spawn { cmd, stdin, args } NodeProcess.defaultSpawnOptions
+  pure $ case result.exit of
+    NodeProcess.Normally 0 -> Right jsonStr
+    _ -> Left result.stderr
+
 -- | Convert a string representing a Dhall expression into JSON using the
 -- | `dhall-to-json` CLI.
 dhallToJson :: { dhall :: String, cwd :: Maybe FilePath } -> Aff (Either String Json.Json)

--- a/src/Registry/API.purs
+++ b/src/Registry/API.purs
@@ -731,7 +731,7 @@ compilePackage { packageSourceDir, buildPlan: BuildPlan plan } = do
   case plan.resolutions of
     Nothing -> do
       compilerOutput <- liftAff $ Purs.callCompiler
-        { args: [ "compile", "src/**/*.purs" ]
+        { command: Purs.Compile { globs: [ "src/**/*.purs" ] }
         , version: Version.printVersion plan.compiler
         , cwd: Just packageSourceDir
         }
@@ -741,7 +741,7 @@ compilePackage { packageSourceDir, buildPlan: BuildPlan plan } = do
       let (packages :: Array _) = Map.toUnfoldable resolved
       for_ packages (uncurry (installPackage dependenciesDir))
       compilerOutput <- liftAff $ Purs.callCompiler
-        { args: [ "compile", "src/**/*.purs", ".registry/*/src/**/*.purs" ]
+        { command: Purs.Compile { globs: [ "src/**/*.purs", ".registry/*/src/**/*.purs" ] }
         , version: Version.printVersion plan.compiler
         , cwd: Just packageSourceDir
         }
@@ -814,7 +814,7 @@ publishToPursuit { packageSourceDir, dependenciesDir, buildPlan: buildPlan@(Buil
   -- The resulting documentation will all use purescript- prefixes in keeping
   -- with the format used by Pursuit in PureScript versions at least up to 0.16
   compilerOutput <- liftAff $ Purs.callCompiler
-    { args: [ "publish", "--manifest", "purs.json", "--resolutions", resolutionsFilePath ]
+    { command: Purs.Publish { resolutions: resolutionsFilePath }
     , version: Version.printVersion compiler
     , cwd: Just packageSourceDir
     }

--- a/src/Registry/API.purs
+++ b/src/Registry/API.purs
@@ -115,9 +115,11 @@ main = launchAff_ $ do
         fillMetadataRef
         runOperation API operation
 
--- | Operations are exercised via the API and the importer. If the importer is
--- | used, then we have relaxed restrictions on the build (ie. the package does
--- | not have to compile).
+-- | Operations are exercised via the API and the legacy importer. If the
+-- | importer is used then we don't compile or publish docs for the package.
+-- | If the API is used for a 'legacy' package (ie. a Spago-based project), then
+-- | we attempt to compile the package and warn if compilation fails. If the API
+-- | is used for a normal package then failed compilation fails the pipeline.
 data Source = API | Importer
 
 derive instance Eq Source

--- a/src/Registry/PackageSet.purs
+++ b/src/Registry/PackageSet.purs
@@ -248,9 +248,9 @@ tryPackage (PackageSet set) package maybeVersion = do
 compileInstalledPackages :: Version -> Aff (Either CompilerFailure String)
 compileInstalledPackages compilerVersion = do
   log "Compiling installed packages..."
-  let args = [ "compile", "packages/**/*.purs" ]
+  let command = Purs.Compile { globs: [ "packages/**/*.purs" ] }
   let version = Version.printVersion compilerVersion
-  Purs.callCompiler { args, version, cwd: Nothing }
+  Purs.callCompiler { command, version, cwd: Nothing }
 
 -- | Delete package source directories in the given installation directory.
 removePackages :: Set PackageName -> Aff Unit

--- a/src/Registry/Schema.purs
+++ b/src/Registry/Schema.purs
@@ -97,11 +97,9 @@ instance RegistryJson PackageSet where
 
 -- | A compiler version and exact dependency versions that should be used to
 -- | compile a newly-uploaded package as an API verification check.
--- |
--- | The build plan verification is NOT used for legacy packages.
 newtype BuildPlan = BuildPlan
   { compiler :: Version
-  , resolutions :: Map PackageName Version
+  , resolutions :: Maybe (Map PackageName Version)
   }
 
 derive instance Newtype BuildPlan _

--- a/src/Registry/Scripts/PackageTransferrer.purs
+++ b/src/Registry/Scripts/PackageTransferrer.purs
@@ -17,6 +17,7 @@ import Foreign.GitHub as GitHub
 import Foreign.Node.FS as FS.Extra
 import Node.Path as Path
 import Node.Process as Node.Process
+import Registry.API (Source(..))
 import Registry.API as API
 import Registry.Cache as Cache
 import Registry.Constants as Constants
@@ -104,7 +105,7 @@ transferPackage rawPackageName newPackageLocation = do
     payload = Transfer { packageName, newPackageLocation }
     rawPayload = Json.stringifyJson payload
 
-  API.runOperation $ Authenticated $ AuthenticatedData
+  API.runOperation Importer $ Authenticated $ AuthenticatedData
     { email: Git.pacchettiBottiEmail
     , payload
     , rawPayload

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -354,7 +354,7 @@ decodeEventsToOps = do
         , updateRef: "v1.2.3"
         , buildPlan: BuildPlan
             { compiler: mkUnsafeVersion "0.15.0"
-            , resolutions: Map.fromFoldable [ mkUnsafePackage "prelude" /\ mkUnsafeVersion "1.0.0" ]
+            , resolutions: Just $ Map.fromFoldable [ mkUnsafePackage "prelude" /\ mkUnsafeVersion "1.0.0" ]
             }
         }
 
@@ -371,7 +371,7 @@ decodeEventsToOps = do
         , newPackageLocation: GitHub { subdir: Nothing, owner: "purescript", repo: "purescript-prelude" }
         , buildPlan: BuildPlan
             { compiler: mkUnsafeVersion "0.15.0"
-            , resolutions: Map.fromFoldable [ mkUnsafePackage "prelude" /\ mkUnsafeVersion "1.0.0" ]
+            , resolutions: Just $ Map.fromFoldable [ mkUnsafePackage "prelude" /\ mkUnsafeVersion "1.0.0" ]
             }
         }
 
@@ -494,7 +494,7 @@ checkDependencyResolution = do
 
   exactBuildPlan = BuildPlan
     { compiler: mkUnsafeVersion "0.14.2"
-    , resolutions: Map.fromFoldable
+    , resolutions: Just $ Map.fromFoldable
         [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
         , Tuple (mkUnsafePackage "package-two") (mkUnsafeVersion "3.0.0")
         ]
@@ -502,7 +502,7 @@ checkDependencyResolution = do
 
   extraBuildPlan = BuildPlan
     { compiler: mkUnsafeVersion "0.14.2"
-    , resolutions: Map.fromFoldable
+    , resolutions: Just $ Map.fromFoldable
         [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
         , Tuple (mkUnsafePackage "package-two") (mkUnsafeVersion "3.0.0")
         , Tuple (mkUnsafePackage "package-three") (mkUnsafeVersion "7.0.0")
@@ -511,7 +511,7 @@ checkDependencyResolution = do
 
   buildPlanMissingPackage = BuildPlan
     { compiler: mkUnsafeVersion "0.14.2"
-    , resolutions: Map.fromFoldable
+    , resolutions: Just $ Map.fromFoldable
         [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
         , Tuple (mkUnsafePackage "package-three") (mkUnsafeVersion "7.0.0")
         ]
@@ -519,7 +519,7 @@ checkDependencyResolution = do
 
   buildPlanWrongVersion = BuildPlan
     { compiler: mkUnsafeVersion "0.14.2"
-    , resolutions: Map.fromFoldable
+    , resolutions: Just $ Map.fromFoldable
         [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
         , Tuple (mkUnsafePackage "package-two") (mkUnsafeVersion "7.0.0")
         ]
@@ -540,7 +540,7 @@ checkBuildPlanToResolutions = do
 
   generatedResolutions =
     API.buildPlanToResolutions
-      { buildPlan: BuildPlan { compiler: mkUnsafeVersion "0.14.2", resolutions }
+      { buildPlan: BuildPlan { compiler: mkUnsafeVersion "0.14.2", resolutions: Just resolutions }
       , dependenciesDir
       }
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -492,38 +492,26 @@ checkDependencyResolution = do
   packageTwoName = mkUnsafePackage "package-two"
   packageTwoRange = unsafeFromJust $ Map.lookup packageTwoName dependencies
 
-  exactBuildPlan = BuildPlan
-    { compiler: mkUnsafeVersion "0.14.2"
-    , resolutions: Just $ Map.fromFoldable
-        [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
-        , Tuple (mkUnsafePackage "package-two") (mkUnsafeVersion "3.0.0")
-        ]
-    }
+  exactBuildPlan = Map.fromFoldable
+    [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
+    , Tuple (mkUnsafePackage "package-two") (mkUnsafeVersion "3.0.0")
+    ]
 
-  extraBuildPlan = BuildPlan
-    { compiler: mkUnsafeVersion "0.14.2"
-    , resolutions: Just $ Map.fromFoldable
-        [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
-        , Tuple (mkUnsafePackage "package-two") (mkUnsafeVersion "3.0.0")
-        , Tuple (mkUnsafePackage "package-three") (mkUnsafeVersion "7.0.0")
-        ]
-    }
+  extraBuildPlan = Map.fromFoldable
+    [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
+    , Tuple (mkUnsafePackage "package-two") (mkUnsafeVersion "3.0.0")
+    , Tuple (mkUnsafePackage "package-three") (mkUnsafeVersion "7.0.0")
+    ]
 
-  buildPlanMissingPackage = BuildPlan
-    { compiler: mkUnsafeVersion "0.14.2"
-    , resolutions: Just $ Map.fromFoldable
-        [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
-        , Tuple (mkUnsafePackage "package-three") (mkUnsafeVersion "7.0.0")
-        ]
-    }
+  buildPlanMissingPackage = Map.fromFoldable
+    [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
+    , Tuple (mkUnsafePackage "package-three") (mkUnsafeVersion "7.0.0")
+    ]
 
-  buildPlanWrongVersion = BuildPlan
-    { compiler: mkUnsafeVersion "0.14.2"
-    , resolutions: Just $ Map.fromFoldable
-        [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
-        , Tuple (mkUnsafePackage "package-two") (mkUnsafeVersion "7.0.0")
-        ]
-    }
+  buildPlanWrongVersion = Map.fromFoldable
+    [ Tuple (mkUnsafePackage "package-one") (mkUnsafeVersion "2.0.0")
+    , Tuple (mkUnsafePackage "package-two") (mkUnsafeVersion "7.0.0")
+    ]
 
 checkBuildPlanToResolutions :: Spec.Spec Unit
 checkBuildPlanToResolutions = do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -546,7 +546,7 @@ compilerVersions = do
   where
   testVersion version =
     Spec.it ("Calls compiler version " <> version) do
-      Purs.callCompiler { args: [ "--version" ], cwd: Nothing, version } >>= case _ of
+      Purs.callCompiler { command: Purs.Version, cwd: Nothing, version } >>= case _ of
         Left err -> case err of
           MissingCompiler ->
             Assert.fail "MissingCompiler"
@@ -559,7 +559,7 @@ compilerVersions = do
 
   testMissingVersion version =
     Spec.it ("Handles failure when compiler is missing " <> version) do
-      result <- Purs.callCompiler { args: [ "--version" ], cwd: Nothing, version }
+      result <- Purs.callCompiler { command: Purs.Version, cwd: Nothing, version }
       case result of
         Left MissingCompiler -> pure unit
         _ -> Assert.fail "Should have failed with MissingCompiler"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -401,7 +401,7 @@ decodeEventsToOps = do
         , newPackageLocation: GitHub { subdir: Nothing, owner: "purescript", repo: "purescript-prelude" }
         , buildPlan: BuildPlan
             { compiler: mkUnsafeVersion "0.15.0"
-            , resolutions: Map.empty
+            , resolutions: Nothing
             }
         }
 
@@ -593,7 +593,7 @@ preludeAdditionString =
       "githubOwner": "purescript",
       "githubRepo": "purescript-prelude"
     },
-    "buildPlan": { "compiler": "0.15.0", "resolutions": {} }
+    "buildPlan": { "compiler": "0.15.0" }
   }
   ```
 

--- a/test/scripts/PublishPursuit.purs
+++ b/test/scripts/PublishPursuit.purs
@@ -75,7 +75,7 @@ main = launchAff_ $ do
 
       buildPlan = BuildPlan
         { compiler: unsafeFromRight (Version.parseVersion Version.Lenient "v0.14.7")
-        , resolutions: Map.fromFoldable
+        , resolutions: Just $ Map.fromFoldable
             [ Tuple (unsafeFromRight (PackageName.parse "prelude")) (unsafeFromRight (Version.parseVersion Version.Lenient "v5.0.0"))
             , Tuple (unsafeFromRight (PackageName.parse "effect")) (unsafeFromRight (Version.parseVersion Version.Lenient "v3.0.0"))
             ]

--- a/test/scripts/PublishPursuit.purs
+++ b/test/scripts/PublishPursuit.purs
@@ -15,10 +15,10 @@ import Foreign.Tmp as Tmp
 import Node.FS.Aff as FS
 import Node.Path as Path
 import Node.Process as Process
-import Registry.API (publishToPursuit)
+import Registry.API (compilePackage, publishToPursuit)
 import Registry.Cache as Cache
 import Registry.PackageName as PackageName
-import Registry.RegistryM (Env, runRegistryM)
+import Registry.RegistryM (Env, runRegistryM, throwWithComment)
 import Registry.Schema (BuildPlan(..))
 import Registry.Version as Version
 
@@ -52,10 +52,10 @@ main = launchAff_ $ do
       }
 
   runRegistryM env do
-    tmpDir <- liftEffect Tmp.mkTmpDir
-    liftAff $ Git.cloneGitTag ("https://github.com/purescript/purescript-console") "v5.0.0" tmpDir
+    tmp <- liftEffect Tmp.mkTmpDir
+    liftAff $ Git.cloneGitTag ("https://github.com/purescript/purescript-console") "v5.0.0" tmp
     let
-      packageSourceDir = tmpDir <> Path.sep <> "purescript-console"
+      packageSourceDir = Path.concat [ tmp, "purescript-console" ]
       pursJson =
         """
         {
@@ -81,9 +81,14 @@ main = launchAff_ $ do
             ]
         }
 
-    liftAff $ FS.writeTextFile UTF8 (packageSourceDir <> Path.sep <> "purs.json") pursJson
+    liftAff $ FS.writeTextFile UTF8 (Path.concat [ packageSourceDir, "purs.json" ]) pursJson
 
-    publishToPursuit
-      { packageSourceDir
-      , buildPlan
-      }
+    compilePackage { packageSourceDir, buildPlan } >>= case _ of
+      Left err -> throwWithComment err
+      Right _ -> do
+        let dependenciesDir = Path.concat [ packageSourceDir, ".registry" ]
+        files <- liftAff $ FS.readdir packageSourceDir
+        logShow files
+        deps <- liftAff $ FS.readdir dependenciesDir
+        logShow deps
+        publishToPursuit { packageSourceDir, buildPlan, dependenciesDir: Path.concat [ packageSourceDir, ".registry" ] }

--- a/v1/Operation.dhall
+++ b/v1/Operation.dhall
@@ -14,7 +14,7 @@ let Location = ./Location.dhall
 -- The compiler version must be a non-pre-release version with no build
 -- metadata, such as '0.14.0'. Compiler versions are accepted from 0.13.0
 -- onward; earlier compilers are not supported.
-let BuildPlan = { compiler : Text, resolutions : Map Text Text }
+let BuildPlan = { compiler : Text, resolutions : Optional (Map Text Text) }
 
 -- An operation that must be signed with the key listed in the owners field of
 -- the manifest.


### PR DESCRIPTION
This PR makes build plan resolutions optional. In practice, that means that when registering a package you can either:

1. Provide a compiler version and resolved dependencies the registry should use to verify your package and push documentation
2. Provide only the compiler version, and rely on the registry solver to figure out the resolved dependencies

Optional build plans mean that it is feasible to register a package by hand. Since we'd like to move the `new-packages.json` and `bower-packages.json` files into the registry, and disable PRs there, that means people will now need to start registering their packages by hand.

A future improvement we can make is to take the build plan from Spago directly, if it's a Spago package being published. That may make things a little more reliable in the case that folks' dependency ranges are off.