### PR TITLE
More lenient parsing in GitHub issues

### DIFF
--- a/src/Registry/API.purs
+++ b/src/Registry/API.purs
@@ -136,11 +136,22 @@ readOperation eventPath = do
     Right event ->
       pure event
 
-  pure $ case Argonaut.Parser.jsonParser body of
+  pure $ case Argonaut.Parser.jsonParser (firstObject body) of
     Left _err -> NotJson
     Right json -> case Json.decode json of
       Left err -> MalformedJson issueNumber err
       Right operation -> DecodedOperation issueNumber username operation
+
+-- | Users may submit issues with contents wrapped in code fences, perhaps with
+-- | a language specifier, trailing lines, and other issues. This rudimentary
+-- | cleanup pass retrieves all contents within an opening { and closing }
+-- | delimiter.
+firstObject :: String -> String
+firstObject input = fromMaybe input do
+  before <- String.indexOf (String.Pattern "{") input
+  let start = String.drop before input
+  after <- String.lastIndexOf (String.Pattern "}") start
+  pure (String.take (after + 1) start)
 
 -- TODO: test all the points where the pipeline could throw, to show that we are implementing
 -- all the necessary checks

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -393,6 +393,22 @@ decodeEventsToOps = do
     res <- API.readOperation "test/fixtures/package-set-update_issue_created.json"
     res `Assert.shouldEqual` API.DecodedOperation issueNumber username operation
 
+  Spec.it "decodes lenient JSON" do
+    let
+      operation = Addition
+        { packageName: mkUnsafePackage "prelude"
+        , newRef: "v5.0.0"
+        , newPackageLocation: GitHub { subdir: Nothing, owner: "purescript", repo: "purescript-prelude" }
+        , buildPlan: BuildPlan
+            { compiler: mkUnsafeVersion "0.15.0"
+            , resolutions: Map.empty
+            }
+        }
+
+      rawOperation = preludeAdditionString
+
+    Json.parseJson (API.firstObject rawOperation) `Assert.shouldEqual` (Right operation)
+
 goodBowerfiles :: Spec.Spec Unit
 goodBowerfiles = do
   let
@@ -575,3 +591,23 @@ compilerVersions = do
       case result of
         Left MissingCompiler -> pure unit
         _ -> Assert.fail "Should have failed with MissingCompiler"
+
+preludeAdditionString :: String
+preludeAdditionString =
+  """
+  Here's my new package!
+
+  ```json
+  {
+    "packageName": "prelude",
+    "newRef": "v5.0.0",
+    "newPackageLocation": {
+      "githubOwner": "purescript",
+      "githubRepo": "purescript-prelude"
+    },
+    "buildPlan": { "compiler": "0.15.0", "resolutions": {} }
+  }
+  ```
+
+  Thanks!
+  """

--- a/test/fixtures/update_issue_comment.json
+++ b/test/fixtures/update_issue_comment.json
@@ -2,7 +2,7 @@
   "action": "created",
   "comment": {
     "author_association": "MEMBER",
-    "body": "{\"packageName\":\"something\",\"updateRef\":\"v1.2.3\", \"buildPlan\": { \"compiler\": \"0.15.0\", \"resolutions\": { \"prelude\": \"1.0.0\" } } }",
+    "body": "```{\"packageName\":\"something\",\"updateRef\":\"v1.2.3\", \"buildPlan\": { \"compiler\": \"0.15.0\", \"resolutions\": { \"prelude\": \"1.0.0\" } } }```",
     "created_at": "2021-03-09T02:03:56Z",
     "html_url": "https://github.com/purescript/registry/issues/43#issuecomment-793265839",
     "id": 793265839,

--- a/test/fixtures/update_issue_comment.json
+++ b/test/fixtures/update_issue_comment.json
@@ -2,7 +2,7 @@
   "action": "created",
   "comment": {
     "author_association": "MEMBER",
-    "body": "```{\"packageName\":\"something\",\"updateRef\":\"v1.2.3\", \"buildPlan\": { \"compiler\": \"0.15.0\", \"resolutions\": { \"prelude\": \"1.0.0\" } } }```",
+    "body": "```json\n{\"packageName\":\"something\",\"updateRef\":\"v1.2.3\", \"buildPlan\": { \"compiler\": \"0.15.0\", \"resolutions\": { \"prelude\": \"1.0.0\" } } }```",
     "created_at": "2021-03-09T02:03:56Z",
     "html_url": "https://github.com/purescript/registry/issues/43#issuecomment-793265839",
     "id": 793265839,


### PR DESCRIPTION
When we decode operations submitted to the API via GitHub Actions we attempt to parse their contents as JSON. However, this means the entire issue body must be valid JSON, ie. something like this will work:

{ "newPackageName": "prelude" }

...but something like this will not:

```json
{ "newPackageName": "prelude" }
```

This PR adds a minimal cleanup pass to the body we receive as input, trimming the input to a matching `{ }` pair. Then we defer to our JSON parser for the rest of the work.