### PR TITLE
Verify manifest against request and metadata

### DIFF
--- a/spago.yaml
+++ b/spago.yaml
@@ -1,3 +1,3 @@
 workspace:
   set:
-    registry: 1.0.0
+    registry: 2.2.0


### PR DESCRIPTION
This PR adds two verification checks we've long planned but never implemented:

1. Make sure the manifest matches the package name submitted via the API (we try not to trust the API-provided information)
2. Make sure the manifest matches the registry metadata for everything _except_ the owners field. Transfers should happen via a Transfer operation, not by changing the manifest. This ensures transfers happen correctly as discussed in https://github.com/purescript/registry-dev/issues/331.
