### PR TITLE
Add self-contained check to package set generation

### DIFF
--- a/src/Registry/PackageSet.purs
+++ b/src/Registry/PackageSet.purs
@@ -421,6 +421,7 @@ validatePackageSetCandidates index (PackageSet { packages: previousPackages }) c
     case Map.lookup name previousPackages of
       Nothing -> Right unit
       Just v | v < version -> Right unit
+      Just v | v == version -> Left "This version already exists in the package set."
       Just v -> Left $ "A higher version already exists in the package set: " <> Version.printVersion v
 
     -- A package can only be added to the package set if all its dependencies

--- a/src/Registry/Scripts/LegacyImporter.purs
+++ b/src/Registry/Scripts/LegacyImporter.purs
@@ -278,7 +278,7 @@ importLegacyRegistry existingRegistry legacyRegistry = do
 
     -- A 'checked' index is one where we have verified that all dependencies
     -- are self-contained within the registry.
-    checkedIndex :: Graph.CheckResult
+    checkedIndex :: Graph.CheckedRegistryIndex
     checkedIndex = Graph.checkRegistryIndex rawLegacyIndex
 
     -- The list of all packages that were present in the legacy registry files,

--- a/src/Registry/Scripts/PackageSetUpdater.purs
+++ b/src/Registry/Scripts/PackageSetUpdater.purs
@@ -91,8 +91,8 @@ main = Aff.launchAff_ do
 
     registryIndexPath <- asks _.registryIndex
     registryIndex <- liftAff $ Index.readRegistryIndex registryIndexPath
-
     prevPackageSet <- PackageSet.readLatestPackageSet
+    PackageSet.validatePackageSet registryIndex prevPackageSet
 
     metadata <- readPackagesMetadata
     recentUploads <- findRecentUploads metadata (Hours 24.0)


### PR DESCRIPTION
The 0.0.1 package set we converted from the legacy package sets and released has an issue: all packages work using the dependencies listed in the legacy sets, but since the new package sets use the registry manifest files, two packages are not actually self-contained (ie. they don't have all dependencies in the set).

We already have self-containment checks for any packages being added or removed to the sets, but we assumed that the prior package set was blessed and all packages proven to work. Alas, this was not the case.

This PR adds a self-containment check on the previous package set before we go to produce a new one. It also adds the check on the result of the new package set we produce, just to be extra sure. When I run the package set updater, I now see this error:

```
[COMMENT] Package set 0.1.0 is invalid! Some packages have dependencies not in the set:

  - quotient (proxy)
  - refined (generics-rep)
```

This error means that `quotient` has a list of dependencies, and they are all in the package set _except_ for the `proxy` dependency. To be usable in the set this dependency must be dropped.