### PR TITLE
Move bower installer into test scripts

### DIFF
--- a/lib/test/Integration.purs
+++ b/lib/test/Integration.purs
@@ -20,10 +20,10 @@ import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Schema (Location(..), Manifest(..))
-import Registry.Scripts.BowerInstaller (BowerSolved)
 import Registry.Solver as Solver
 import Registry.Version (Range, Version)
 import Registry.Version as Version
+import Test.Scripts.BowerInstaller (BowerSolved)
 import Test.Spec as Spec
 import Test.Spec.Assertions as Assert
 import Test.Spec.Reporter (consoleReporter)

--- a/lib/test/scripts/BowerInstaller.purs
+++ b/lib/test/scripts/BowerInstaller.purs
@@ -2,7 +2,7 @@
 -- | Bower, recording which packages have a successful run and which packages
 -- | fail to install. This is used to generate the list of Bower packages that
 -- | succeed in the integration tests for the registry solver.
-module Registry.Scripts.BowerInstaller where
+module Test.Scripts.BowerInstaller where
 
 import Registry.Prelude
 

--- a/lib/test/scripts/PublishPursuit.purs
+++ b/lib/test/scripts/PublishPursuit.purs
@@ -1,5 +1,5 @@
 -- | A test script that exercises publishing to Pursuit only.
-module PublishPursuit where
+module Test.Scripts.PublishPursuit where
 
 import Registry.Prelude
 


### PR DESCRIPTION
In the monorepo migration it looks like the `BowerInstaller` script got put into the `lib` directory, but this is really just a test script used to produce the integration test. I've moved it into the test directory with this in mind.