### PR TITLE
Remove Show instances from registry types

### DIFF
--- a/app/src/Foreign/GitHub.purs
+++ b/app/src/Foreign/GitHub.purs
@@ -395,7 +395,6 @@ newtype IssueNumber = IssueNumber Int
 
 instance Newtype IssueNumber Int
 derive newtype instance Eq IssueNumber
-derive newtype instance Show IssueNumber
 derive newtype instance RegistryJson IssueNumber
 
 newtype PackageURL = PackageURL String

--- a/app/src/Foreign/SPDX.purs
+++ b/app/src/Foreign/SPDX.purs
@@ -22,9 +22,6 @@ instance RegistryJson License where
   encode = Json.encode <<< print
   decode = parse <=< Json.decode
 
-instance Show License where
-  show = print
-
 -- | Print an SPDX license identifier.
 print :: License -> String
 print (License license) = license

--- a/app/src/Registry/Legacy/Manifest.purs
+++ b/app/src/Registry/Legacy/Manifest.purs
@@ -287,7 +287,6 @@ newtype Bowerfile = Bowerfile
   }
 
 derive newtype instance Eq Bowerfile
-derive newtype instance Show Bowerfile
 
 instance RegistryJson Bowerfile where
   encode (Bowerfile fields) = Json.encode fields

--- a/app/src/Registry/Legacy/PackageSet.purs
+++ b/app/src/Registry/Legacy/PackageSet.purs
@@ -56,7 +56,6 @@ newtype LegacyPackageSet = LegacyPackageSet (Map PackageName LegacyPackageSetEnt
 
 derive instance Newtype LegacyPackageSet _
 derive newtype instance Eq LegacyPackageSet
-derive newtype instance Show LegacyPackageSet
 
 instance RegistryJson LegacyPackageSet where
   encode (LegacyPackageSet plan) = Json.encode plan

--- a/app/src/Registry/Operation.purs
+++ b/app/src/Registry/Operation.purs
@@ -16,16 +16,6 @@ data Operation
 
 derive instance Eq Operation
 
-instance Show Operation where
-  show = case _ of
-    Publish inner -> "Publish (" <> show (showWithPackage inner) <> ")"
-    PackageSetUpdate inner -> "PackageSetUpdate (" <> show inner <> ")"
-    Authenticated inner -> "Authenticated (" <> show inner <> ")"
-    where
-    showWithPackage :: forall r. { name :: PackageName | r } -> { name :: String | r }
-    showWithPackage inner =
-      inner { name = "PackageName (" <> PackageName.print inner.name <> ")" }
-
 instance RegistryJson Operation where
   encode = case _ of
     Publish fields -> Json.encode fields
@@ -56,15 +46,6 @@ instance RegistryJson AuthenticatedOperation where
     let parseTransfer = Transfer <$> Json.decode json
     parseUnpublish <|> parseTransfer
 
-instance Show AuthenticatedOperation where
-  show = case _ of
-    Unpublish inner -> "Unpublish (" <> show (showWithPackage inner) <> ")"
-    Transfer inner -> "Transfer (" <> show (showWithPackage inner) <> ")"
-    where
-    showWithPackage :: forall r. { name :: PackageName | r } -> { name :: String | r }
-    showWithPackage inner =
-      inner { name = "PackageName (" <> PackageName.print inner.name <> ")" }
-
 newtype AuthenticatedData = AuthenticatedData
   { payload :: AuthenticatedOperation
   -- We include the unparsed payload for use in verification so as to preserve
@@ -76,7 +57,6 @@ newtype AuthenticatedData = AuthenticatedData
 
 derive instance Newtype AuthenticatedData _
 derive newtype instance Eq AuthenticatedData
-derive newtype instance Show AuthenticatedData
 
 instance RegistryJson AuthenticatedData where
   encode (AuthenticatedData fields) = Json.encode fields

--- a/app/src/Registry/PackageGraph.purs
+++ b/app/src/Registry/PackageGraph.purs
@@ -20,8 +20,10 @@ import Data.Monoid (guard)
 import Data.Set as Set
 import Registry.Index (RegistryIndex)
 import Registry.PackageName (PackageName)
+import Registry.PackageName as PackageName
 import Registry.Schema (Manifest(..))
 import Registry.Version (Range, Version)
+import Registry.Version as Version
 
 type PackageWithVersion = { package :: PackageName, version :: Version }
 
@@ -41,7 +43,7 @@ checkPackages index packages = do
     constraints = Array.sortWith (_.dependencies >>> Array.length) do
       Tuple package version <- Map.toUnfoldable packages
       case Map.lookup package index >>= Map.lookup version of
-        Nothing -> unsafeCrashWith ("Unregistered package version: " <> show { package, version })
+        Nothing -> unsafeCrashWith ("Unregistered package version: " <> show { package: PackageName.print package, version: Version.printVersion version })
         Just (Manifest manifest) -> do
           let dependencies = Set.toUnfoldable (Map.keys manifest.dependencies)
           [ { package: { package, version }, dependencies } ]

--- a/app/src/Registry/PackageName.purs
+++ b/app/src/Registry/PackageName.purs
@@ -24,9 +24,6 @@ newtype PackageName = PackageName String
 derive newtype instance Eq PackageName
 derive newtype instance Ord PackageName
 
-instance Show PackageName where
-  show = print
-
 instance StringEncodable PackageName where
   toEncodableString = print
   fromEncodableString = lmap (append "Expected PackageName: " <<< Parsing.parseErrorMessage) <<< parse

--- a/app/src/Registry/Prelude.purs
+++ b/app/src/Registry/Prelude.purs
@@ -43,7 +43,6 @@ import Data.Maybe (Maybe(..), fromJust, fromMaybe, isJust, isNothing, maybe) as 
 import Data.Newtype (class Newtype, un) as Extra
 import Data.Nullable (Nullable, toMaybe, toNullable) as Extra
 import Data.Set (Set) as Extra
-import Data.Show.Generic (genericShow) as Extra
 import Data.String as String
 import Data.String.NonEmpty (NonEmptyString) as Extra
 import Data.Traversable (for, for_, sequence, traverse) as Extra

--- a/app/src/Registry/Schema.purs
+++ b/app/src/Registry/Schema.purs
@@ -5,7 +5,6 @@ import Registry.Prelude
 import Data.DateTime (DateTime)
 import Data.Formatter.DateTime (Formatter, FormatterCommand(..))
 import Data.Formatter.DateTime as Formatter.DateTime
-import Data.Generic.Rep as Generic
 import Data.List as List
 import Data.Map as Map
 import Data.RFC3339String (RFC3339String)
@@ -59,7 +58,6 @@ newtype Owner = Owner
 
 derive instance Newtype Owner _
 derive newtype instance Eq Owner
-derive newtype instance Show Owner
 derive newtype instance RegistryJson Owner
 
 dateFormatter :: Formatter
@@ -80,7 +78,6 @@ newtype PackageSet = PackageSet
 
 derive instance Newtype PackageSet _
 derive newtype instance Eq PackageSet
-derive newtype instance Show PackageSet
 
 instance RegistryJson PackageSet where
   -- This instance is manually encoded so we can control the order of fields.
@@ -103,7 +100,6 @@ newtype BuildPlan = BuildPlan
 
 derive instance Newtype BuildPlan _
 derive newtype instance Eq BuildPlan
-derive newtype instance Show BuildPlan
 
 instance RegistryJson BuildPlan where
   encode (BuildPlan plan) = Json.encode plan
@@ -126,11 +122,6 @@ data Location
   | GitHub GitHubData
 
 derive instance Eq Location
-
-derive instance Generic.Generic Location _
-
-instance Show Location where
-  show = genericShow
 
 -- | We encode it this way so that json-to-dhall can read it
 instance RegistryJson Location where

--- a/app/src/Registry/Solver.purs
+++ b/app/src/Registry/Solver.purs
@@ -11,7 +11,6 @@ import Data.Array.NonEmpty (foldMap1)
 import Data.Array.NonEmpty as NEA
 import Data.Foldable (foldMap)
 import Data.FoldableWithIndex (foldMapWithIndex, traverseWithIndex_)
-import Data.Generic.Rep as Generic
 import Data.Map as Map
 import Data.Newtype (alaF)
 import Data.Semigroup.First (First(..))
@@ -33,10 +32,6 @@ data SolverPosition
 
 derive instance Eq SolverPosition
 derive instance Ord SolverPosition
-derive instance Generic.Generic SolverPosition _
-
-instance Show SolverPosition where
-  show a = genericShow a
 
 printSolverPosition :: SolverPosition -> String
 printSolverPosition = case _ of
@@ -88,10 +83,6 @@ data SolverError
   | DisjointRanges PackageName Range SolverPosition Range SolverPosition
 
 derive instance Eq SolverError
-derive instance Generic.Generic SolverError _
-
-instance Show SolverError where
-  show a = genericShow a
 
 -- Minimize the positions on the errors and group/deduplicate them
 minimizeErrors :: Dependencies -> Map PackageName Range -> NonEmptyArray SolverError -> NonEmptyArray SolverError

--- a/app/src/Registry/Types.purs
+++ b/app/src/Registry/Types.purs
@@ -11,7 +11,6 @@ newtype RawPackageName = RawPackageName String
 derive instance Newtype RawPackageName _
 derive newtype instance Eq RawPackageName
 derive newtype instance Ord RawPackageName
-derive newtype instance Show RawPackageName
 derive newtype instance StringEncodable RawPackageName
 derive newtype instance RegistryJson RawPackageName
 
@@ -21,7 +20,6 @@ newtype RawVersion = RawVersion String
 derive instance Newtype RawVersion _
 derive newtype instance Eq RawVersion
 derive newtype instance Ord RawVersion
-derive newtype instance Show RawVersion
 derive newtype instance StringEncodable RawVersion
 derive newtype instance RegistryJson RawVersion
 
@@ -31,6 +29,5 @@ newtype RawVersionRange = RawVersionRange String
 derive instance Newtype RawVersionRange _
 derive newtype instance Eq RawVersionRange
 derive newtype instance Ord RawVersionRange
-derive newtype instance Show RawVersionRange
 derive newtype instance StringEncodable RawVersionRange
 derive newtype instance RegistryJson RawVersionRange

--- a/app/src/Registry/Version.purs
+++ b/app/src/Registry/Version.purs
@@ -60,9 +60,6 @@ instance Eq Version where
 instance Ord Version where
   compare = compare `on` (\(Version v) -> [ v.major, v.minor, v.patch ])
 
-instance Show Version where
-  show = printVersion
-
 instance StringEncodable Version where
   toEncodableString = printVersion
   fromEncodableString = lmap Parsing.parseErrorMessage <<< parseVersion Strict
@@ -149,9 +146,6 @@ instance RegistryJson Range where
   decode json = do
     string <- Json.decode json
     lmap Parsing.parseErrorMessage $ parseRange Strict string
-
-instance Show Range where
-  show = printRange
 
 greaterThanOrEq :: Range -> Version
 greaterThanOrEq (Range range) = range.lhs

--- a/app/test/Foreign/JsonRepair.purs
+++ b/app/test/Foreign/JsonRepair.purs
@@ -5,8 +5,8 @@ import Registry.Prelude
 import Data.Either as Either
 import Foreign.JsonRepair as JsonRepair
 import Registry.Json as Json
+import Test.Assert as Assert
 import Test.Spec as Spec
-import Test.Spec.Assertions as Assert
 
 type Spec = Spec.SpecT Aff Unit Identity Unit
 

--- a/app/test/Foreign/Licensee.purs
+++ b/app/test/Foreign/Licensee.purs
@@ -4,8 +4,8 @@ import Registry.Prelude
 
 import Foreign.Licensee as Licensee
 import Node.Path as Path
+import Test.Assert as Assert
 import Test.Spec as Spec
-import Test.Spec.Assertions as Assert
 import Test.Support.ManifestFiles as ManifestFiles
 
 licensee :: Spec.Spec Unit

--- a/app/test/Foreign/Tar.purs
+++ b/app/test/Foreign/Tar.purs
@@ -11,9 +11,8 @@ import Node.FS.Aff as FSA
 import Node.FS.Stats as FS.Stats
 import Node.Path as Path
 import Registry.Sha256 as Sha256
+import Test.Assert as Assert
 import Test.Spec as Spec
-import Test.Spec.Assertions (AnyShow(..))
-import Test.Spec.Assertions as Assert
 
 tar :: Spec.Spec Unit
 tar = do
@@ -26,7 +25,7 @@ tar = do
       tarball1 <- createTarball
       Aff.delay (Aff.Milliseconds 1010.0)
       tarball2 <- createTarball
-      AnyShow tarball1 `Assert.shouldEqual` AnyShow tarball2
+      tarball1 `Assert.shouldEqual` tarball2
   where
   createTarball = do
     packageTmp <- liftEffect Tmp.mkTmpDir

--- a/app/test/Integration.purs
+++ b/app/test/Integration.purs
@@ -23,9 +23,9 @@ import Registry.Schema (Location(..), Manifest(..))
 import Registry.Solver as Solver
 import Registry.Version (Range, Version)
 import Registry.Version as Version
+import Test.Assert as Assert
 import Test.Scripts.BowerInstaller (BowerSolved)
 import Test.Spec as Spec
-import Test.Spec.Assertions as Assert
 import Test.Spec.Reporter (consoleReporter)
 import Test.Spec.Runner (defaultConfig, runSpec')
 

--- a/app/test/Main.purs
+++ b/app/test/Main.purs
@@ -31,6 +31,7 @@ import Registry.Schema (BuildPlan(..), Location(..), Manifest(..))
 import Registry.Version (Version)
 import Registry.Version as Version
 import Safe.Coerce (coerce)
+import Test.Assert as Assert
 import Test.Fixture.Manifest as Fixture
 import Test.Foreign.JsonRepair as Foreign.JsonRepair
 import Test.Foreign.Licensee (licensee)
@@ -42,7 +43,6 @@ import Test.Registry.Solver as TestSolver
 import Test.Registry.Version as TestVersion
 import Test.RegistrySpec as RegistrySpec
 import Test.Spec as Spec
-import Test.Spec.Assertions as Assert
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.Runner (defaultConfig, runSpec')
 

--- a/app/test/Registry/Index.purs
+++ b/app/test/Registry/Index.purs
@@ -22,9 +22,9 @@ import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Schema (Location(..), Manifest(..))
 import Registry.Version as Version
+import Test.Assert as Assert
 import Test.Fixture.Manifest as Fixture
 import Test.Spec as Spec
-import Test.Spec.Assertions as Assert
 
 type TestIndexEnv =
   { tmp :: FilePath
@@ -104,7 +104,7 @@ testRegistryIndex = Spec.before runBefore do
     pure { tmp, index, writeMemory }
 
   insertAndCheck manifest@(Manifest { name: packageName, version }) = do
-    let specName = "Inserts " <> PackageName.print packageName <> " version " <> show version
+    let specName = "Inserts " <> PackageName.print packageName <> " version " <> Version.printVersion version
 
     Spec.it specName \{ tmp, index, writeMemory } -> do
       -- First, we insert the manifest to disk and then read back the result.

--- a/app/test/Registry/PackageSet.purs
+++ b/app/test/Registry/PackageSet.purs
@@ -20,9 +20,9 @@ import Registry.Schema as Schema
 import Registry.Sha256 as Sha256
 import Registry.Version (Version)
 import Registry.Version as Version
+import Test.Assert as Assert
 import Test.Fixture.Manifest (fixture, setDependencies, setName, setVersion)
 import Test.Spec as Spec
-import Test.Spec.Assertions as Assert
 
 spec :: Spec.Spec Unit
 spec = do

--- a/app/test/Registry/SSH.purs
+++ b/app/test/Registry/SSH.purs
@@ -12,8 +12,8 @@ import Registry.SSH as SSH
 import Registry.Schema (Owner(..))
 import Registry.Version (Version)
 import Registry.Version as Version
+import Test.Assert as Assert
 import Test.Spec as Spec
-import Test.Spec.Assertions as Assert
 
 spec :: Spec.Spec Unit
 spec = do

--- a/app/test/Registry/Solver.purs
+++ b/app/test/Registry/Solver.purs
@@ -9,13 +9,14 @@ import Data.Array.NonEmpty as NonEmptyArray
 import Data.Map as Map
 import Data.Set as Set
 import Data.Set.NonEmpty as NES
+import Registry.Json as Json
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Solver (SolverError(..), SolverPosition(..), printSolverError, solve, solveAndValidate)
 import Registry.Version (ParseMode(..), Range, Version)
 import Registry.Version as Version
+import Test.Assert as Assert
 import Test.Spec as Spec
-import Test.Spec.Assertions as Assert
 
 spec :: Spec.Spec Unit
 spec = do
@@ -39,7 +40,7 @@ spec = do
           received.message `Assert.shouldEqual` expected.message
 
       Right value ->
-        Assert.fail $ "Expected failure, but received: " <> show value
+        Assert.fail $ "Expected failure, but received: " <> Json.stringifyJson value
 
   Spec.describe "Valid dependency ranges" do
     Spec.it "Solves simple range" do

--- a/app/test/Registry/Version.purs
+++ b/app/test/Registry/Version.purs
@@ -8,8 +8,8 @@ import Registry.Prelude
 import Data.Either as Either
 import Registry.Version (ParseMode(..))
 import Registry.Version as Version
+import Test.Assert as Assert
 import Test.Spec as Spec
-import Test.Spec.Assertions as Assert
 
 testVersion :: Spec.Spec Unit
 testVersion = do

--- a/lib/test/Assert.purs
+++ b/lib/test/Assert.purs
@@ -3,17 +3,41 @@ module Test.Assert where
 import Prelude
 
 import Control.Monad.Error.Class (class MonadThrow)
-import Data.Argonaut.Core as Argonaut
 import Data.Either (Either(..))
+import Data.Foldable (class Foldable)
+import Data.Foldable as Foldable
 import Effect.Exception (Error)
 import Test.Spec.Assertions (AnyShow(..))
 import Test.Spec.Assertions as Assertions
-import Unsafe.Coerce (unsafeCoerce)
+import Test.Utils as Utils
+
+fail :: forall m. MonadThrow Error m => String -> m Unit
+fail = Assertions.fail
 
 shouldEqual :: forall m a. MonadThrow Error m => Eq a => a -> a -> m Unit
 shouldEqual a b = Assertions.shouldEqual (AnyShow a) (AnyShow b)
 
 shouldEqualRight :: forall m e a. MonadThrow Error m => Eq a => a -> Either e a -> m Unit
 shouldEqualRight a = case _ of
-  Left e -> Assertions.fail (Argonaut.stringify (unsafeCoerce e :: Argonaut.Json))
-  Right b -> Assertions.shouldEqual (AnyShow a) (AnyShow b)
+  Left e -> fail ("Expected Right, but received Left with value: " <> Utils.unsafeStringify e)
+  Right b -> shouldEqual a b
+
+shouldContain :: forall m f a. MonadThrow Error m => Eq a => Foldable f => f a -> a -> m Unit
+shouldContain container elem =
+  when (elem `Foldable.notElem` container) do
+    fail (Utils.unsafeStringify elem <> "\n\nshould be a member of\n\n" <> Utils.unsafeStringify container)
+
+shouldNotContain :: forall m f a. MonadThrow Error m => Eq a => Foldable f => f a -> a -> m Unit
+shouldNotContain container elem =
+  when (elem `Foldable.elem` container) do
+    fail (Utils.unsafeStringify elem <> "\n\nshould not be a member of\n\n" <> Utils.unsafeStringify container)
+
+shouldSatisfy :: forall m a. MonadThrow Error m => a -> (a -> Boolean) -> m Unit
+shouldSatisfy a predicate =
+  unless (predicate a) do
+    fail (Utils.unsafeStringify a <> " doesn't satisfy predicate.")
+
+shouldNotSatisfy :: forall m a. MonadThrow Error m => a -> (a -> Boolean) -> m Unit
+shouldNotSatisfy a predicate =
+  when (predicate a) do
+    fail (Utils.unsafeStringify a <> " satisfies predicate, but should not.")

--- a/lib/test/Utils.purs
+++ b/lib/test/Utils.purs
@@ -1,8 +1,13 @@
 module Test.Utils where
 
+import Data.Argonaut.Core as Argonaut
 import Data.Either (Either)
 import Data.Either as Either
 import Partial.Unsafe as Partial
+import Unsafe.Coerce (unsafeCoerce)
 
 fromRight :: forall a b. String -> Either a b -> b
 fromRight msg = Either.fromRight' (\_ -> Partial.unsafeCrashWith msg)
+
+unsafeStringify :: forall a. a -> String
+unsafeStringify a = Argonaut.stringify (unsafeCoerce a :: Argonaut.Json)

--- a/scripts/src/LegacyImporter.purs
+++ b/scripts/src/LegacyImporter.purs
@@ -208,7 +208,7 @@ main = launchAff_ do
           log "\n----------"
           log "UPLOADING"
           log $ PackageName.print manifest.name <> "@" <> Version.printVersion manifest.version
-          log $ show manifest.location
+          log $ Json.stringifyJson manifest.location
           log "----------"
           API.runOperation source (mkOperation manifest)
 
@@ -355,12 +355,12 @@ buildLegacyPackageManifests existingRegistry legacyPackageSets rawPackage rawUrl
       case Map.lookup package.name existingRegistry >>= Map.lookup version of
         Just manifest -> pure manifest
         _ -> do
-          let key = "manifest__" <> show package.name <> "--" <> tag.name
+          let key = "manifest__" <> PackageName.print package.name <> "--" <> tag.name
           liftEffect (Cache.readJsonEntry key cache) >>= case _ of
             -- We can't just write the version directly, as we need to preserve the _raw_ version.
             -- So we update the manifest fields before reading/writing the cache.
             Left _ -> ExceptT do
-              log $ "CACHE MISS: Building manifest for " <> show package.name <> "@" <> tag.name
+              log $ "CACHE MISS: Building manifest for " <> PackageName.print package.name <> "@" <> tag.name
               manifest <- Except.runExceptT buildManifest
               liftEffect $ Cache.writeJsonEntry key (map (_ { version = Version.rawVersion version } <<< un Manifest) manifest) cache
               pure manifest

--- a/scripts/src/PackageTransferrer.purs
+++ b/scripts/src/PackageTransferrer.purs
@@ -68,7 +68,7 @@ main = launchAff_ do
 
 processLegacyRegistry :: LegacyRegistryFile -> RegistryM Unit
 processLegacyRegistry legacyFile = do
-  log $ Array.fold [ "Reading legacy registry file (", show legacyFile, ")" ]
+  log $ Array.fold [ "Reading legacy registry file (", API.legacyRegistryFilePath legacyFile, ")" ]
   packages <- LegacyImporter.readLegacyRegistryFile legacyFile
   log "Reading latest locations..."
   locations <- latestLocations packages


### PR DESCRIPTION
We should only be using `Show` for our tests, and since `spec` no longer requires a `Show` instance we no longer need to use these in our code. It's quite easy to slip up and use `show` for convenience, such as in an error message, only to inadvertently leak the internal structure of the type instead of pretty-printing, or the opposite: to make the show instance pretty-print, when it is supposed to show the structure of the type for debugging. As a last argument against Show, all these instances and their associated `Generic` instances add to quite a bit of code bloat in the generated code.

As part of the general registry cleanup, this PR removes our use of `Show` throughout the codebase and updates the tests to accommodate the change.