### PR TITLE
No longer reuse directory names in the package set updater

### DIFF
--- a/app/src/Registry/API.purs
+++ b/app/src/Registry/API.purs
@@ -321,7 +321,8 @@ runOperation source operation = case operation of
     if Map.isEmpty candidates.accepted then do
       throwWithComment "No packages in the suggested batch can be processed; all failed validation checks."
     else do
-      PackageSet.processBatchAtomic registryIndex latestPackageSet compiler candidates.accepted >>= case _ of
+      workDir <- liftEffect Tmp.mkTmpDir
+      PackageSet.processBatchAtomic workDir registryIndex latestPackageSet compiler candidates.accepted >>= case _ of
         Just { fail, packageSet, success } | Map.isEmpty fail -> do
           newPath <- PackageSet.getPackageSetPath (un PackageSet packageSet).version
           liftAff $ Json.writeJsonFile newPath packageSet

--- a/app/src/Registry/PackageSet.purs
+++ b/app/src/Registry/PackageSet.purs
@@ -15,25 +15,28 @@ import Registry.Prelude
 
 import Affjax as Http
 import Control.Alternative (guard)
-import Control.Monad.Reader (asks)
+import Control.Monad.Reader (ReaderT, asks)
+import Control.Monad.Reader as ReaderT
 import Data.Array as Array
 import Data.Bitraversable (ltraverse)
 import Data.Filterable (partitionMap)
-import Data.Foldable (foldl, traverse_)
+import Data.Foldable (foldl)
+import Data.FoldableWithIndex (traverseWithIndex_)
 import Data.Map as Map
 import Data.Monoid as Monoid
 import Data.Set as Set
 import Data.String as String
+import Data.Tuple (uncurry)
 import Effect.Aff as Aff
 import Effect.Now as Now
 import Effect.Ref as Ref
-import Foreign.Node.FS as FSE
+import Foreign.Node.FS as FS.Extra
 import Foreign.Purs (CompilerFailure(..))
 import Foreign.Purs as Purs
 import Foreign.Tar as Tar
 import Foreign.Wget as Wget
 import Node.FS.Aff as FS.Aff
-import Node.FS.Aff as FSA
+import Node.FS.Sync as FS.Sync
 import Node.Path as Path
 import Registry.Constants as Constants
 import Registry.Index (RegistryIndex)
@@ -76,6 +79,21 @@ readLatestPackageSet = do
         Left err -> throwWithComment $ "Could not decode latest package set: " <> err
         Right set -> pure set
 
+type Paths =
+  { workDirectory :: FilePath
+  , packagesDirectory :: FilePath
+  , outputDirectory :: FilePath
+  , outputBackupDirectory :: FilePath
+  }
+
+runWithPaths :: forall m a. MonadAff m => FilePath -> ReaderT Paths Aff a -> m a
+runWithPaths workDir k = liftAff $ ReaderT.runReaderT k do
+  { workDirectory: workDir
+  , packagesDirectory: Path.concat [ workDir, "packages" ]
+  , outputDirectory: Path.concat [ workDir, "output" ]
+  , outputBackupDirectory: Path.concat [ workDir, "output-backup" ]
+  }
+
 -- TODO: It would be ideal to report _why_ a package failed, similar to the
 -- batch validation.
 type PackageSetBatchResult =
@@ -87,17 +105,28 @@ type PackageSetBatchResult =
 -- | Attempt to produce a new package set from the given package set by adding
 -- | or removing the provided packages. Fails if the batch is not usable as a
 -- | whole. To fall back to sequential processing, use `processBatchSequential`.
-processBatchAtomic :: RegistryIndex -> PackageSet -> Maybe Version -> Map PackageName (Maybe Version) -> RegistryM (Maybe PackageSetBatchResult)
-processBatchAtomic index prevSet@(PackageSet { compiler: prevCompiler, packages }) newCompiler batch = do
-  let compilerVersion = fromMaybe prevCompiler newCompiler
+processBatchAtomic :: FilePath -> RegistryIndex -> PackageSet -> Maybe Version -> Map PackageName (Maybe Version) -> RegistryM (Maybe PackageSetBatchResult)
+processBatchAtomic workDir index prevSet@(PackageSet { compiler: prevCompiler, packages }) newCompiler batch = do
+  let
+    compilerVersion = fromMaybe prevCompiler newCompiler
+    buildInitialSet = runWithPaths workDir do
+      paths <- ReaderT.ask
+      liftAff do
+        -- It's possible to run batches in a persistent directory, especially for
+        -- testing purposes, so we always clean out the working directories we use.
+        FS.Extra.remove paths.packagesDirectory
+        FS.Extra.remove paths.outputDirectory
+        FS.Extra.remove paths.outputBackupDirectory
+      installPackages packages
+      compileInstalledPackages compilerVersion
 
-  liftAff (installPackages packages *> compileInstalledPackages compilerVersion) >>= case _ of
+  buildInitialSet >>= case _ of
     Left compilerError -> do
       handleCompilerError compilerVersion compilerError
       throwWithComment "Starting package set must compile in order to process a batch."
     Right _ -> pure unit
 
-  liftAff (tryBatch compilerVersion prevSet batch) >>= case _ of
+  runWithPaths workDir (tryBatch compilerVersion prevSet batch) >>= case _ of
     Right newSet -> do
       packageSet <- liftEffect $ updatePackageSetMetadata { previous: prevSet, pending: newSet } batch
       validatePackageSet index packageSet
@@ -109,9 +138,9 @@ processBatchAtomic index prevSet@(PackageSet { compiler: prevCompiler, packages 
 -- | Attempt to produce a new package set from the given package set by adding
 -- | or removing the provided packages. Attempts the entire batch first, and
 -- | then falls sequential processing if that fails.
-processBatchSequential :: RegistryIndex -> PackageSet -> Maybe Version -> Map PackageName (Maybe Version) -> RegistryM (Maybe PackageSetBatchResult)
-processBatchSequential registryIndex prevSet@(PackageSet { compiler: prevCompiler, packages }) newCompiler batch = do
-  processBatchAtomic registryIndex prevSet newCompiler batch >>= case _ of
+processBatchSequential :: FilePath -> RegistryIndex -> PackageSet -> Maybe Version -> Map PackageName (Maybe Version) -> RegistryM (Maybe PackageSetBatchResult)
+processBatchSequential workDir registryIndex prevSet@(PackageSet { compiler: prevCompiler, packages }) newCompiler batch = do
+  processBatchAtomic workDir registryIndex prevSet newCompiler batch >>= case _ of
     Just batchResult ->
       pure (Just batchResult)
     Nothing -> do
@@ -137,14 +166,10 @@ processBatchSequential registryIndex prevSet@(PackageSet { compiler: prevCompile
       successRef <- liftEffect $ Ref.new Map.empty
       packageSetRef <- liftEffect $ Ref.new prevSet
 
-      let
-        formatName name version =
-          PackageName.print name <> "@" <> Version.printVersion version
-
       -- Then we attempt to add them one-by-one.
       for_ sortedBatch \(Tuple name maybeVersion) -> do
         currentSet <- liftEffect $ Ref.read packageSetRef
-        result <- liftAff (tryPackage currentSet name maybeVersion)
+        result <- runWithPaths workDir $ tryPackage currentSet name maybeVersion
         case result of
           -- If the package could not be processed, then the state of the
           -- filesystem is rolled back. We just need to insert the package into
@@ -153,7 +178,7 @@ processBatchSequential registryIndex prevSet@(PackageSet { compiler: prevCompile
             liftEffect $ Ref.modify_ (Map.insert name maybeVersion) failRef
             log $ case maybeVersion of
               Nothing -> "Could not remove " <> PackageName.print name
-              Just version -> "Could not add or update " <> formatName name version
+              Just version -> "Could not add or update " <> formatPackage name version
             handleCompilerError compilerVersion packageCompilerError
           -- If the package could be processed, then the state of the filesystem
           -- is stepped and we need to record the success of this package and
@@ -164,7 +189,7 @@ processBatchSequential registryIndex prevSet@(PackageSet { compiler: prevCompile
             liftEffect $ Ref.write newSet packageSetRef
             log $ case maybeVersion of
               Nothing -> "Removed " <> PackageName.print name
-              Just version -> "Added or updated " <> formatName name version
+              Just version -> "Added or updated " <> formatPackage name version
 
       fail <- liftEffect $ Ref.read failRef
       success <- liftEffect $ Ref.read successRef
@@ -194,23 +219,28 @@ handleCompilerError compilerVersion = case _ of
 -- | set. This will be rolled back if the operation fails.
 -- |
 -- | NOTE: You must have previously built a package set.
-tryBatch :: Version -> PackageSet -> Map PackageName (Maybe Version) -> Aff (Either CompilerFailure PackageSet)
+tryBatch :: Version -> PackageSet -> Map PackageName (Maybe Version) -> ReaderT Paths Aff (Either CompilerFailure PackageSet)
 tryBatch compilerVersion (PackageSet set) batch = do
-  let backupDir = "output-backup"
-  let outputDir = "output"
-  FSE.copy { from: outputDir, to: backupDir, preserveTimestamps: true }
-  removePackages (Map.keys batch)
-  installPackages (Map.catMaybes batch)
+  paths <- ReaderT.ask
+  liftAff $ FS.Extra.copy { from: paths.outputDirectory, to: paths.outputBackupDirectory, preserveTimestamps: true }
+  let
+    batchAdditions = Map.catMaybes batch
+    oldVersions = Map.fromFoldable do
+      Tuple name _ <- Map.toUnfoldable batch
+      case Map.lookup name set.packages of
+        Nothing -> []
+        Just version -> [ Tuple name version ]
+  removePackages oldVersions
+  installPackages batchAdditions
   compileInstalledPackages compilerVersion >>= case _ of
     Left err -> do
-      FSE.remove outputDir
-      FSE.copy { from: backupDir, to: outputDir, preserveTimestamps: true }
-      for_ (Map.keys batch) \packageName -> do
-        removePackage packageName
-        for_ (Map.lookup packageName set.packages) (installPackage packageName)
+      liftAff $ FS.Extra.remove paths.outputDirectory
+      liftAff $ FS.Extra.copy { from: paths.outputBackupDirectory, to: paths.outputDirectory, preserveTimestamps: true }
+      removePackages batchAdditions
+      installPackages oldVersions
       pure $ Left err
     Right _ -> do
-      FSE.remove backupDir
+      liftAff $ FS.Extra.remove paths.outputBackupDirectory
       let
         foldFn name existingSet = case _ of
           Nothing -> Map.delete name existingSet
@@ -222,83 +252,83 @@ tryBatch compilerVersion (PackageSet set) batch = do
 -- | operation will be rolled back if the addition fails.
 -- |
 -- | NOTE: You must have previously built a package set.
-tryPackage :: PackageSet -> PackageName -> Maybe Version -> Aff (Either CompilerFailure PackageSet)
-tryPackage (PackageSet set) package maybeVersion = do
-  let backupDir = "output-backup"
-  let outputDir = "output"
-  FSE.copy { from: outputDir, to: backupDir, preserveTimestamps: true }
-  removePackage package
-  for_ maybeVersion (installPackage package)
+tryPackage :: PackageSet -> PackageName -> Maybe Version -> ReaderT Paths Aff (Either CompilerFailure PackageSet)
+tryPackage (PackageSet set) package maybeNewVersion = do
+  paths <- ReaderT.ask
+  liftAff $ FS.Extra.copy { from: paths.outputDirectory, to: paths.outputBackupDirectory, preserveTimestamps: true }
+  let maybeOldVersion = Map.lookup package set.packages
+  for_ maybeOldVersion (removePackage package)
+  for_ maybeNewVersion (installPackage package)
   compileInstalledPackages set.compiler >>= case _ of
     Left err -> do
-      log $ case maybeVersion of
+      log $ case maybeNewVersion of
         Nothing -> "Failed to build set without " <> PackageName.print package
-        Just version -> "Failed to build set with " <> PackageName.print package <> "@" <> Version.printVersion version
-      FSE.remove outputDir
-      FSE.copy { from: backupDir, to: outputDir, preserveTimestamps: true }
-      for_ maybeVersion \_ -> removePackage package
-      for_ (Map.lookup package set.packages) (installPackage package)
+        Just version -> "Failed to build set with " <> formatPackage package version
+      liftAff do
+        FS.Extra.remove paths.outputDirectory
+        FS.Extra.copy { from: paths.outputBackupDirectory, to: paths.outputDirectory, preserveTimestamps: true }
+      for_ maybeNewVersion (removePackage package)
+      for_ maybeOldVersion (installPackage package)
       pure $ Left err
     Right _ -> do
-      FSE.remove backupDir
-      pure $ Right $ PackageSet $ case maybeVersion of
+      liftAff $ FS.Extra.remove paths.outputBackupDirectory
+      pure $ Right $ PackageSet $ case maybeNewVersion of
         Nothing -> set { packages = Map.delete package set.packages }
         Just version -> set { packages = Map.insert package version set.packages }
 
 -- | Compile all PureScript files in the given directory. Expects all packages
 -- | to be installed in a subdirectory "packages".
-compileInstalledPackages :: Version -> Aff (Either CompilerFailure String)
+compileInstalledPackages :: Version -> ReaderT Paths Aff (Either CompilerFailure String)
 compileInstalledPackages compilerVersion = do
+  paths <- ReaderT.ask
   log "Compiling installed packages..."
-  let command = Purs.Compile { globs: [ "packages/**/*.purs" ] }
+  let command = Purs.Compile { globs: [ Path.concat [ Path.basename paths.packagesDirectory, "**/*.purs" ] ] }
   let version = Version.printVersion compilerVersion
-  Purs.callCompiler { command, version, cwd: Nothing }
+  liftAff $ Purs.callCompiler { command, version, cwd: Just paths.workDirectory }
 
 -- | Delete package source directories in the given installation directory.
-removePackages :: Set PackageName -> Aff Unit
-removePackages = traverse_ removePackage
+removePackages :: Map PackageName Version -> ReaderT Paths Aff Unit
+removePackages = traverseWithIndex_ removePackage
 
 -- | Delete a package source directory in the given installation directory.
-removePackage :: PackageName -> Aff Unit
-removePackage name = FSE.remove (Path.concat [ "packages", PackageName.print name ])
+removePackage :: PackageName -> Version -> ReaderT Paths Aff Unit
+removePackage name version = do
+  paths <- ReaderT.ask
+  let formattedPackage = formatPackage name version
+  log $ "Uninstalling " <> formattedPackage
+  liftAff $ FS.Extra.remove $ Path.concat [ paths.packagesDirectory, formattedPackage ]
 
 -- | Install all packages in a package set into a temporary directory, returning
 -- | the reference to the installation directory. Installed packages have the
 -- | form: "package-name-major.minor.patch" and are stored in the "packages"
 -- | directory.
-installPackages :: Map PackageName Version -> Aff Unit
+installPackages :: Map PackageName Version -> ReaderT Paths Aff Unit
 installPackages packages = do
+  paths <- ReaderT.ask
   log "Installing packages..."
-  FSE.ensureDirectory "packages"
+  liftAff $ FS.Extra.ensureDirectory paths.packagesDirectory
   forWithIndex_ packages installPackage
 
 -- | Install a package into the given installation directory, replacing an
 -- | existing installation if there is on. Package sources are stored in the
 -- | "packages" subdirectory of the given directory using their package name
 -- | ie. 'aff'.
-installPackage :: PackageName -> Version -> Aff Unit
+installPackage :: PackageName -> Version -> ReaderT Paths Aff Unit
 installPackage name version = do
-  log $ "installing " <> PackageName.print name <> "@" <> Version.printVersion version
-  _ <- Wget.wget registryUrl tarballPath >>= ltraverse (Aff.error >>> throwError)
-  liftEffect $ Tar.extract { cwd: packagesDir, archive: extractedName <> ".tar.gz" }
-  FSE.remove tarballPath
-  FSA.rename extractedPath installPath
+  paths <- ReaderT.ask
+  let
+    formattedPackage = formatPackage name version
+    extractedName = PackageName.print name <> "-" <> Version.printVersion version
+    tarballPath = Path.concat [ paths.packagesDirectory, extractedName <> ".tar.gz" ]
+    extractedPath = Path.concat [ paths.packagesDirectory, extractedName ]
+    installPath = Path.concat [ paths.packagesDirectory, formattedPackage ]
+  unlessM (liftEffect (FS.Sync.exists installPath)) $ liftAff do
+    log $ "Installing " <> formattedPackage
+    _ <- Wget.wget registryUrl tarballPath >>= ltraverse (Aff.error >>> throwError)
+    liftEffect $ Tar.extract { cwd: paths.packagesDirectory, archive: extractedName <> ".tar.gz" }
+    FS.Extra.remove tarballPath
+    FS.Aff.rename extractedPath installPath
   where
-  packagesDir :: FilePath
-  packagesDir = "packages"
-
-  installPath :: FilePath
-  installPath = Path.concat [ packagesDir, PackageName.print name ]
-
-  extractedPath :: FilePath
-  extractedPath = Path.concat [ packagesDir, extractedName ]
-
-  tarballPath :: FilePath
-  tarballPath = extractedPath <> ".tar.gz"
-
-  extractedName :: String
-  extractedName = PackageName.print name <> "-" <> Version.printVersion version
-
   registryUrl :: Http.URL
   registryUrl = Array.fold
     [ Constants.registryPackagesUrl
@@ -327,7 +357,7 @@ commitMessage (PackageSet set) accepted newVersion = String.joinWith "\n" $ fold
 
   addedLines = "New packages:\n" <> String.joinWith "\n" do
     Tuple packageName version <- added
-    pure $ Array.fold [ "  - ", PackageName.print packageName, "@", Version.printVersion version ]
+    pure $ Array.fold [ "  - ", formatPackage packageName version ]
 
   updated = do
     Tuple packageName maybeVersion <- Map.toUnfoldable accepted
@@ -337,7 +367,7 @@ commitMessage (PackageSet set) accepted newVersion = String.joinWith "\n" $ fold
 
   updatedLines = "Updated packages:\n" <> String.joinWith "\n" do
     Tuple packageName { version, previousVersion } <- updated
-    pure $ Array.fold [ "  - ", PackageName.print packageName, "@", Version.printVersion previousVersion, " -> ", Version.printVersion version ]
+    pure $ Array.fold [ "  - ", formatPackage packageName previousVersion, " -> ", Version.printVersion version ]
 
   removed = do
     Tuple packageName maybeVersion <- Map.toUnfoldable accepted
@@ -347,7 +377,7 @@ commitMessage (PackageSet set) accepted newVersion = String.joinWith "\n" $ fold
 
   removedLines = "Removed packages:\n" <> String.joinWith "\n" do
     Tuple packageName version <- removed
-    pure $ Array.fold [ "  - ", PackageName.print packageName, "@", Version.printVersion version ]
+    pure $ Array.fold [ "  - ", formatPackage packageName version ]
 
 -- | Computes new package set version from old package set and version information of successfully added/updated packages.
 -- | Note: this must be called with the old `PackageSet` that has not had updates applied.
@@ -462,7 +492,9 @@ validatePackageSetCandidates index (PackageSet { packages: previousPackages }) c
 
     case Array.filter (not <<< dependencyExists) dependencies of
       [] -> pure unit
-      missing -> Left $ "Missing dependencies (" <> String.joinWith ", " (map PackageName.print missing) <> ")"
+      missing -> do
+        let formatMissing = String.joinWith ", " <<< map PackageName.print
+        Left $ "Missing dependencies (" <> formatMissing missing <> ")"
 
   validateRemovals :: Map PackageName Version -> Set PackageName -> ValidatedCandidates
   validateRemovals updates removals = do
@@ -485,8 +517,8 @@ validatePackageSetCandidates index (PackageSet { packages: previousPackages }) c
         -- A package can be removed if the only packages that depend on it are also being removed.
         [] -> pure unit
         missing -> do
-          let printPackage (Tuple packageName version) = String.joinWith "@" [ PackageName.print packageName, Version.printVersion version ]
-          Left $ "Has dependents that aren't also being removed (" <> String.joinWith ", " (map printPackage missing) <> ")"
+          let formatMissing = String.joinWith ", " <<< map (uncurry formatPackage)
+          Left $ "Has dependents that aren't also being removed (" <> formatMissing missing <> ")"
 
   dependsOn :: PackageName -> Tuple PackageName Version -> Boolean
   dependsOn removal (Tuple package version) = fromMaybe false do
@@ -509,7 +541,10 @@ printRejections rejections = do
     ]
   where
   printUpdate name { version, reason } =
-    Array.fold [ PackageName.print name, "@", Version.printVersion version, ": ", reason ]
+    formatPackage name version <> ": " <> reason
 
   printRemoval name reason =
-    Array.fold [ PackageName.print name, ": ", reason ]
+    PackageName.print name <> ": " <> reason
+
+formatPackage :: PackageName -> Version -> FilePath
+formatPackage name version = PackageName.print name <> "@" <> Version.printVersion version

--- a/scripts/src/PackageSetUpdater.purs
+++ b/scripts/src/PackageSetUpdater.purs
@@ -112,7 +112,8 @@ main = Aff.launchAff_ do
 
       log "Found the following package versions eligible for inclusion in package set:"
       forWithIndex_ candidates.accepted logPackage
-      PackageSet.processBatchSequential registryIndex prevPackageSet Nothing candidates.accepted >>= case _ of
+      let workDir = Path.concat [ API.scratchDir, "package-set-build" ]
+      PackageSet.processBatchSequential workDir registryIndex prevPackageSet Nothing candidates.accepted >>= case _ of
         Nothing -> do
           log "\n----------\nNo packages could be added to the set. All packages failed:"
           forWithIndex_ candidates.accepted logPackage


### PR DESCRIPTION
The current package set updater is failing to add some packages (such as `jelly@0.7.0`), because it is relying on stale modules when installing a new version and compiling the package set. It is also incorrectly marking some packages as successful (such as `codec-argonaut@10.0.0`) for the same reason.

The root of the issue is that we are reusing the same directory name for all versions of a package. For example, `codec-argonaut@9.2.0` is installed in the directory `codec-argonaut`. Then we compile everything, and go to install `codec-argonaut@10.0.0`. To do this, we delete the `codec-argonaut` directory, then reinstall the new version into a new directory of the same name. This is causing some confusion with the compiler, which in this case won't recompile the package at all and just reports a successful result.

While `jelly` and `codec-argonaut` are failing for different reasons and with different results, both are fixed by always installing packages into a directory containing their version (ie. `codec-argonaut@10.0.0` instead of `codec-argonaut`). I've tested this out by running the package set updater locally for both of the affected packages, and I now see the expected success for `jelly` and expected failure for `codec-argonaut`.

You can test this locally yourself by running:

```
registry-package-set-updater generate
```

...adjusting the `PackageSetUpdater` module lookback from 24 hours to as far as you need to get some packages to upload, or manually changing the `candidates.accepted` field to include the packages you want to test