### PR TITLE
Migrate PackageName to registry library

### DIFF
--- a/app/src/Registry/API.purs
+++ b/app/src/Registry/API.purs
@@ -52,7 +52,6 @@ import Node.FS.Stats as FS.Stats
 import Node.FS.Sync as FS.Sync
 import Node.Path as Path
 import Node.Process as Node.Process
-import Parsing as Parsing
 import Registry.Cache (Cache)
 import Registry.Cache as Cache
 import Registry.Constants as Constants
@@ -1015,7 +1014,7 @@ fillMetadataRef = do
         Right p -> pure p
         Left err -> do
           log $ "Encountered error while parsing package name! It was: " <> rawPackageName
-          Aff.throwError $ Aff.error $ Parsing.parseErrorMessage err
+          Aff.throwError $ Aff.error err
       let metadataPath = metadataFile registryDir packageName
       metadata <- Json.readJsonFile metadataPath >>= case _ of
         Left err -> Aff.throwError $ Aff.error $ "Error parsing metadata file located at " <> metadataPath <> ": " <> err

--- a/app/src/Registry/Json.purs
+++ b/app/src/Registry/Json.purs
@@ -73,7 +73,7 @@ import Node.Path (FilePath)
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record as Record
-import Registry.Sha256 (Sha256)
+import Registry.PackageName as PackageName
 import Registry.Sha256 as Sha256
 import Type.Proxy (Proxy(..))
 
@@ -139,6 +139,10 @@ class StringEncodable a where
 instance StringEncodable String where
   toEncodableString = identity
   fromEncodableString = Right
+
+instance StringEncodable PackageName.PackageName where
+  toEncodableString = PackageName.print
+  fromEncodableString = PackageName.parse
 
 -- | A class for encoding and decoding JSON
 class RegistryJson a where
@@ -228,9 +232,13 @@ instance (EncodeRecord row list, DecodeRecord row list, RL.RowToList row list) =
     Nothing -> Left "Expected Object"
     Just object -> decodeRecord object (Proxy :: Proxy list)
 
-instance RegistryJson Sha256 where
+instance RegistryJson Sha256.Sha256 where
   encode = CA.encode Sha256.codec
   decode = lmap CA.printJsonDecodeError <<< CA.decode Sha256.codec
+
+instance RegistryJson PackageName.PackageName where
+  encode = CA.encode PackageName.codec
+  decode = lmap CA.printJsonDecodeError <<< CA.decode PackageName.codec
 
 ---------
 

--- a/app/src/Registry/Legacy/Manifest.purs
+++ b/app/src/Registry/Legacy/Manifest.purs
@@ -212,7 +212,7 @@ validateLicense licenses = do
 validateDependencies :: Map RawPackageName RawVersionRange -> Either LegacyManifestValidationError (Map PackageName Range)
 validateDependencies dependencies = do
   let
-    parsePackageName = lmap Parsing.parseErrorMessage <<< PackageName.parse <<< stripPureScriptPrefix
+    parsePackageName = PackageName.parse <<< stripPureScriptPrefix
     parseVersionRange = lmap Parsing.parseErrorMessage <<< Version.parseRange Version.Lenient
 
     foldFn (RawPackageName name) acc (RawVersionRange range) = do

--- a/app/test/Main.purs
+++ b/app/test/Main.purs
@@ -19,7 +19,6 @@ import Node.FS as FS
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
 import Node.Process as Process
-import Parsing as Parsing
 import Registry.API (copyPackageSourceFiles)
 import Registry.API as API
 import Registry.Json as Json
@@ -275,7 +274,7 @@ badPackageName = do
     failParse str err = Spec.it str do
       case PackageName.print <$> PackageName.parse str of
         Left parseError ->
-          Assert.shouldEqual err (Parsing.parseErrorMessage parseError)
+          Assert.shouldEqual err parseError
         Right _ ->
           Assert.fail $ str <> " should have failed with error: " <> err
 

--- a/app/test/Main.purs
+++ b/app/test/Main.purs
@@ -61,8 +61,6 @@ main = launchAff_ do
   runSpec' (defaultConfig { timeout = Just $ Milliseconds 10_000.0 }) [ consoleReporter ] do
     Spec.describe "API" do
       Spec.describe "Checks" do
-        Spec.describe "Good package names" goodPackageName
-        Spec.describe "Bad package names" badPackageName
         Spec.describe "Good SPDX licenses" goodSPDXLicense
         Spec.describe "Bad SPDX licenses" badSPDXLicense
         Spec.describe "Decode GitHub event to Operation" decodeEventsToOps
@@ -256,42 +254,6 @@ copySourceFiles = RegistrySpec.toSpec $ Spec.before runBefore do
       writeFiles = liftAff <<< traverse_ (\path -> FS.Aff.writeTextFile UTF8 (inTmp path) "<test>")
 
     pure { source: tmp, destination: destTmp, writeDirectories, writeFiles }
-
-goodPackageName :: Spec.Spec Unit
-goodPackageName = do
-  let
-    parseName str res = Spec.it str do
-      (PackageName.print <$> PackageName.parse str) `Assert.shouldEqual` (Right res)
-
-  parseName "a" "a"
-  parseName "some-dash" "some-dash"
-  -- A blessed prefixed package
-  parseName "purescript-compiler-backend-utilities" "purescript-compiler-backend-utilities"
-
-badPackageName :: Spec.Spec Unit
-badPackageName = do
-  let
-    failParse str err = Spec.it str do
-      case PackageName.print <$> PackageName.parse str of
-        Left parseError ->
-          Assert.shouldEqual err parseError
-        Right _ ->
-          Assert.fail $ str <> " should have failed with error: " <> err
-
-  let startErr = "Package name should start with a lower case char or a digit"
-  let midErr = "Package name can contain lower case chars, digits and non-consecutive dashes"
-  let prefixErr = "Package names should not begin with 'purescript-'"
-  let endErr = "Package name should end with a lower case char or digit"
-  let manyDashes = "Package names cannot contain consecutive dashes"
-
-  failParse "-a" startErr
-  failParse "double--dash" manyDashes
-  failParse "BIGLETTERS" startErr
-  failParse "some space" midErr
-  failParse "a-" endErr
-  failParse "" startErr
-  failParse "🍝" startErr
-  failParse "purescript-aff" prefixErr
 
 goodSPDXLicense :: Spec.Spec Unit
 goodSPDXLicense = do

--- a/app/test/scripts/BowerInstaller.purs
+++ b/app/test/scripts/BowerInstaller.purs
@@ -106,7 +106,7 @@ main = launchAff_ do
       log $ "Reading " <> show (Array.length files) <> " input files..."
       result <- for files \file -> do
         package <- case PackageName.parse file of
-          Left err -> throwError $ Exception.error $ Parsing.parseErrorMessage err
+          Left err -> throwError $ Exception.error err
           Right res -> pure res
         versions <- Json.readJsonFile (Path.concat [ resultsPath, file <> ".json" ]) >>= case _ of
           Left err -> throwError $ Exception.error err
@@ -160,7 +160,7 @@ runBowerSolver index metadata previousResults =
           dependencies <- case Json.parseJson originalBowerfile of
             Left err -> Except.throwError err
             Right ({ dependencies } :: { dependencies :: Map String String }) -> either Except.throwError pure do
-              parsedNames <- traverseKeys (lmap Parsing.parseErrorMessage <<< PackageName.parse <<< stripPureScriptPrefix) dependencies
+              parsedNames <- traverseKeys (PackageName.parse <<< stripPureScriptPrefix) dependencies
               parsedRanges <- traverse (lmap Parsing.parseErrorMessage <<< Version.parseRange Version.Lenient) parsedNames
               pure parsedRanges
 
@@ -235,7 +235,7 @@ readResolutions tmp = do
       Right val -> pure val
 
     package <- case PackageName.parse (stripPureScriptPrefix dir) of
-      Left err -> throwError $ Exception.error $ Parsing.parseErrorMessage err
+      Left err -> throwError $ Exception.error err
       Right res -> pure res
 
     version <- case Version.parseVersion Version.Lenient rawVersion of

--- a/lib/src/Registry/Sha256.purs
+++ b/lib/src/Registry/Sha256.purs
@@ -41,6 +41,7 @@ newtype Sha256 = Sha256 { sri :: String, hash :: String }
 
 derive instance Eq Sha256
 
+-- | A codec for encoding and decoding a `Sha256` as a JSON string
 codec :: JsonCodec Sha256
 codec = CA.prismaticCodec "Sha256" (Either.hush <<< parse) print CA.string
 

--- a/lib/test/Registry.purs
+++ b/lib/test/Registry.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Aff as Aff
+import Test.Registry.PackageName as Test.PackageName
 import Test.Registry.Sha256 as Test.Sha256
 import Test.Spec as Spec
 import Test.Spec.Reporter as Spec.Reporter
@@ -12,3 +13,4 @@ import Test.Spec.Runner as Spec.Runner
 main :: Effect Unit
 main = Aff.launchAff_ $ Spec.Runner.runSpec [ Spec.Reporter.consoleReporter ] do
   Spec.describe "Sha256" Test.Sha256.spec
+  Spec.describe "PackageName" Test.PackageName.spec

--- a/lib/test/Registry/PackageName.purs
+++ b/lib/test/Registry/PackageName.purs
@@ -1,0 +1,84 @@
+module Test.Registry.PackageName (spec) where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Data.String as String
+import Data.Tuple (Tuple(..))
+import Data.Tuple.Nested ((/\))
+import Registry.PackageName as PackageName
+import Test.Assert as Assert
+import Test.Spec as Spec
+import Test.Utils as Utils
+
+spec :: Spec.Spec Unit
+spec = do
+  Spec.it "Parses well-formed package names" do
+    let
+      parse name = case PackageName.parse name of
+        Left error -> Left (name /\ error)
+        Right value -> Right (PackageName.print value)
+
+      formatError (Tuple name error) = name <> ": " <> error
+
+      { fail } = Utils.partitionEithers $ map parse goodPackageNames
+
+    unless (Array.null fail) do
+      Assert.fail $ String.joinWith "\n"
+        [ "Some well-formed package names were not parsed correctly:"
+        , String.joinWith "\n  - " $ map formatError fail
+        ]
+
+  Spec.it "Fails to parse malformed package names" do
+    let
+      parse (Tuple name expectedError) = case PackageName.parse name of
+        Left error | error == expectedError -> Right name
+        Left error -> Left { name, expectedError, actualError: Just error }
+        Right _ -> Left { name, expectedError, actualError: Nothing }
+
+      formatError { name, expectedError, actualError } = Array.foldMap (append "\n  ") $ case actualError of
+        Nothing -> [ name, "...should have failed with '" <> expectedError <> "'", "...but succeeded instead." ]
+        Just error -> [ name, "...should have failed with '" <> expectedError <> "'", "...but failed with '" <> error <> "' instead." ]
+
+      { fail } = Utils.partitionEithers $ map parse badPackageNames
+
+    unless (Array.null fail) do
+      Assert.fail $ String.joinWith "\n"
+        [ "Some malformed package names were not parsed correctly:"
+        , String.joinWith "\n  - " $ map formatError fail
+        ]
+
+goodPackageNames :: Array String
+goodPackageNames =
+  -- standard package names
+  [ "a"
+  , "ab"
+  , "abc"
+  , "prelude"
+  , "codec-argonaut"
+
+  -- blessed purescript-prefixed packages
+  , "purescript-compiler-backend-utilities"
+  ]
+
+badPackageNames :: Array (Tuple String String)
+badPackageNames = do
+  let startErr = "Package name should start with a lower case char or a digit"
+  let midErr = "Package name can contain lower case chars, digits and non-consecutive dashes"
+  let prefixErr = "Package names should not begin with 'purescript-'"
+  let endErr = "Package name should end with a lower case char or digit"
+  let manyDashesErr = "Package names cannot contain consecutive dashes"
+  let expectedEOF = "Expected EOF"
+
+  [ "-a" /\ startErr
+  , "double--dash" /\ manyDashesErr
+  , "BIGLETTERS" /\ startErr
+  , "some space" /\ midErr
+  , "a-" /\ endErr
+  , "" /\ startErr
+  , "🍝" /\ startErr
+  , "abc-🍝-abc" /\ expectedEOF
+  , "purescript-aff" /\ prefixErr
+  ]

--- a/lib/test/Registry/Sha256.purs
+++ b/lib/test/Registry/Sha256.purs
@@ -19,31 +19,29 @@ import Test.Utils as Utils
 
 spec :: Spec.Spec Unit
 spec = do
-  Spec.describe "Creates a valid sha256 SRI hash" do
-    Spec.it "Hashes a spago.dhall file the same as openssl" do
-      hash <- Sha256.hashFile hooksSpago
-      hash `Assert.shouldEqual` hooksSpagoHash
+  Spec.it "Hashes a spago.dhall file the same as openssl" do
+    hash <- Sha256.hashFile hooksSpago
+    hash `Assert.shouldEqual` hooksSpagoHash
 
-    Spec.it "Hashes a LICENSE file the same as openssl" do
-      hash <- Sha256.hashFile hooksLicense
-      hash `Assert.shouldEqual` hooksLicenseHash
+  Spec.it "Hashes a LICENSE file the same as openssl" do
+    hash <- Sha256.hashFile hooksLicense
+    hash `Assert.shouldEqual` hooksLicenseHash
 
-    Spec.it "spago.dhall hash matches the nix hash" do
-      hash <- Sha256.hashFile hooksSpago
-      nix <- Except.runExceptT $ sha256Nix hooksSpago
-      hash `Assert.shouldEqualRight` nix
+  Spec.it "spago.dhall hash matches the nix hash" do
+    hash <- Sha256.hashFile hooksSpago
+    nix <- Except.runExceptT $ sha256Nix hooksSpago
+    hash `Assert.shouldEqualRight` nix
 
-    Spec.it "LICENSE hash matches the nix hash" do
-      hash <- Sha256.hashFile hooksLicense
-      nix <- Except.runExceptT $ sha256Nix hooksLicense
-      hash `Assert.shouldEqualRight` nix
+  Spec.it "LICENSE hash matches the nix hash" do
+    hash <- Sha256.hashFile hooksLicense
+    nix <- Except.runExceptT $ sha256Nix hooksLicense
+    hash `Assert.shouldEqualRight` nix
 
-  Spec.describe "Encodes and decodes from string" do
-    Spec.it "Round-trips spago.dhall file" do
-      hooksSpagoHash `Assert.shouldEqualRight` Sha256.parse (Sha256.print hooksSpagoHash)
+  Spec.it "Round-trips spago.dhall file" do
+    hooksSpagoHash `Assert.shouldEqualRight` Sha256.parse (Sha256.print hooksSpagoHash)
 
-    Spec.it "Round-trips LICENSE file" do
-      hooksLicenseHash `Assert.shouldEqualRight` Sha256.parse (Sha256.print hooksLicenseHash)
+  Spec.it "Round-trips LICENSE file" do
+    hooksLicenseHash `Assert.shouldEqualRight` Sha256.parse (Sha256.print hooksLicenseHash)
 
 -- Test hash produced by `openssl`:
 -- openssl dgst -sha256 -binary < test/_fixtures/halogen-hooks/spago.dhall | openssl base64 -A

--- a/lib/test/Utils.purs
+++ b/lib/test/Utils.purs
@@ -1,13 +1,23 @@
 module Test.Utils where
 
 import Data.Argonaut.Core as Argonaut
-import Data.Either (Either)
+import Data.Array as Array
+import Data.Either (Either(..))
 import Data.Either as Either
 import Partial.Unsafe as Partial
 import Unsafe.Coerce (unsafeCoerce)
 
+-- | Unsafely unpack the `Right` of an `Either`, given a message to crash with
+-- | if the value is a `Left`.
 fromRight :: forall a b. String -> Either a b -> b
 fromRight msg = Either.fromRight' (\_ -> Partial.unsafeCrashWith msg)
 
+-- | Unsafely stringify a value by coercing it to `Json` and stringifying it.
 unsafeStringify :: forall a. a -> String
 unsafeStringify a = Argonaut.stringify (unsafeCoerce a :: Argonaut.Json)
+
+-- | Partition an array of `Either` values into failure and success  values
+partitionEithers :: forall e a. Array (Either e a) -> { fail :: Array e, success :: Array a }
+partitionEithers = Array.foldMap case _ of
+  Left err -> { fail: [ err ], success: [] }
+  Right res -> { fail: [], success: [ res ] }

--- a/scripts/src/LegacyImporter.purs
+++ b/scripts/src/LegacyImporter.purs
@@ -498,7 +498,7 @@ validatePackageName :: RawPackageName -> Either PackageValidationError PackageNa
 validatePackageName (RawPackageName name) =
   PackageName.parse name # lmap \parserError ->
     { error: InvalidPackageName
-    , reason: Parsing.parseErrorMessage parserError
+    , reason: parserError
     }
 
 type JsonValidationError =


### PR DESCRIPTION
This implements the `PackageName` from the registry spec (see #533).