### PR TITLE
Implement 'License' from spec

### DIFF
--- a/app/src/Foreign/SPDX.js
+++ b/app/src/Foreign/SPDX.js
@@ -1,29 +1,14 @@
-import parse from "spdx-expression-parse";
 import Fuse from "fuse.js";
-import { createRequire } from "module";
 
 // The spdx-license-ids project is just a set of JSON files, which can't be
 // imported directly into ESM without import assertions to guide TypeScript.
+import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 const identifiers = require("spdx-license-ids");
 const deprecatedIdentifiers = require("spdx-license-ids/deprecated");
 
 const allIdentifiers = identifiers.concat(deprecatedIdentifiers);
-
 const fuse = new Fuse(allIdentifiers);
 
-export const parseSPDXLicenseIdImpl = (onError, onSuccess, identifier) => {
-  try {
-    parse(identifier);
-    return onSuccess(identifier);
-  } catch (_) {
-    const results = fuse.search(identifier);
-    if (results.length < 1) {
-      return onError(`Invalid SPDX identifier: ${identifier}`);
-    } else {
-      return onError(
-        `Invalid SPDX identifier: ${identifier}\nDid you mean ${results[0].item}?`
-      );
-    }
-  }
-};
+export const matchLicenseImpl = (identifier) =>
+  fuse.search(identifier).map(({ item }) => item);

--- a/app/src/Foreign/SPDX.purs
+++ b/app/src/Foreign/SPDX.purs
@@ -1,48 +1,24 @@
-module Foreign.SPDX
-  ( License
-  , parse
-  , print
-  , SPDXConjunction(..)
-  , joinWith
-  ) where
+module Foreign.SPDX (fuzzyMatchLicense) where
 
 import Registry.Prelude
 
-import Data.Function.Uncurried (Fn3, runFn3)
-import Data.String as String
-import Registry.Json as Json
-import Safe.Coerce (coerce)
+import Data.Array as Array
+import Data.Array.NonEmpty as NonEmptyArray
+import Data.Either as Either
+import Data.Function.Uncurried (Fn1)
+import Data.Function.Uncurried as Uncurried
+import Registry.License (License)
+import Registry.License as License
 
--- | An SPDX license identifier such as 'MIT' or 'Apache-2.0'.
-newtype License = License String
+foreign import matchLicenseImpl :: Fn1 String (Array String)
 
-derive newtype instance Eq License
-
-instance RegistryJson License where
-  encode = Json.encode <<< print
-  decode = parse <=< Json.decode
-
--- | Print an SPDX license identifier.
-print :: License -> String
-print (License license) = license
-
--- | Parse a string as a SPDX license identifier.
--- |
--- | ```purs
--- | > parse 'BSD-3-Clause'
--- | Right (SPDXLicense ...)
--- |
--- | > parse 'MITT'
--- | Left "Invalid SPDX identifier: MITT. Did you mean MIT?"
--- | ```
-parse :: String -> Either String License
-parse = runFn3 parseSPDXLicenseIdImpl Left (Right <<< License)
-
-data SPDXConjunction = And | Or
-
-joinWith :: SPDXConjunction -> Array License -> License
-joinWith = case _ of
-  And -> coerce <<< String.joinWith " AND " <<< coerce
-  Or -> coerce <<< String.joinWith " OR " <<< coerce
-
-foreign import parseSPDXLicenseIdImpl :: forall r. Fn3 (String -> r) (String -> r) String r
+-- | Attempt to fuzzy-match an SPDX identifier. Returns an array of potential
+-- | SPDX identifiers that match the input string, or an empty array if none are
+-- | similar enough.
+fuzzyMatchLicense :: String -> Maybe (NonEmptyArray License)
+fuzzyMatchLicense input = case Uncurried.runFn1 matchLicenseImpl input of
+  [] -> Nothing
+  matches ->
+    map (Either.hush <<< License.parse) matches
+      # Array.catMaybes
+      # NonEmptyArray.fromArray

--- a/app/src/Registry/Json.purs
+++ b/app/src/Registry/Json.purs
@@ -73,6 +73,7 @@ import Node.Path (FilePath)
 import Prim.Row as Row
 import Prim.RowList as RL
 import Record as Record
+import Registry.License as License
 import Registry.PackageName as PackageName
 import Registry.Sha256 as Sha256
 import Type.Proxy (Proxy(..))
@@ -239,6 +240,10 @@ instance RegistryJson Sha256.Sha256 where
 instance RegistryJson PackageName.PackageName where
   encode = CA.encode PackageName.codec
   decode = lmap CA.printJsonDecodeError <<< CA.decode PackageName.codec
+
+instance RegistryJson License.License where
+  encode = CA.encode License.codec
+  decode = lmap CA.printJsonDecodeError <<< CA.decode License.codec
 
 ---------
 

--- a/app/src/Registry/Legacy/Manifest.purs
+++ b/app/src/Registry/Legacy/Manifest.purs
@@ -17,8 +17,6 @@ import Data.These as These
 import Foreign.GitHub as GitHub
 import Foreign.JsonRepair as JsonRepair
 import Foreign.Licensee as Licensee
-import Foreign.SPDX (License)
-import Foreign.SPDX as SPDX
 import Foreign.Tmp as Tmp
 import Node.ChildProcess as NodeProcess
 import Node.FS.Aff as FSA
@@ -30,6 +28,8 @@ import Registry.Json ((.:), (.:?))
 import Registry.Json as Json
 import Registry.Legacy.PackageSet (LegacyPackageSet(..), LegacyPackageSetEntry, PscTag(..))
 import Registry.Legacy.PackageSet as Legacy.PackageSet
+import Registry.License (License)
+import Registry.License as License
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.RegistryM (RegistryM, throwWithComment)
@@ -200,13 +200,13 @@ validateLicense licenses = do
       other -> other
 
     parsedLicenses =
-      map (SPDX.parse <<< rewrite)
+      map (License.parse <<< rewrite)
         $ Array.filter (_ /= "LICENSE")
         $ map NonEmptyString.toString licenses
 
   case partitionEithers parsedLicenses of
     { fail: [], success: [] } -> Left { error: MissingLicense, reason: "No licenses found." }
-    { fail: [], success } -> Right $ SPDX.joinWith SPDX.And success
+    { fail: [], success } -> Right $ License.joinWith License.And success
     { fail } -> Left { error: InvalidLicense fail, reason: "Licenses found, but not valid SPDX identifiers." }
 
 validateDependencies :: Map RawPackageName RawVersionRange -> Either LegacyManifestValidationError (Map PackageName Range)

--- a/app/src/Registry/Schema.purs
+++ b/app/src/Registry/Schema.purs
@@ -8,9 +8,9 @@ import Data.Formatter.DateTime as Formatter.DateTime
 import Data.List as List
 import Data.Map as Map
 import Data.RFC3339String (RFC3339String)
-import Foreign.SPDX (License)
 import Registry.Json ((.:), (.:?), (:=))
 import Registry.Json as Json
+import Registry.License (License)
 import Registry.PackageName (PackageName)
 import Registry.Sha256 (Sha256)
 import Registry.Version (Range, Version)

--- a/app/test/Fixture/Manifest.purs
+++ b/app/test/Fixture/Manifest.purs
@@ -9,9 +9,9 @@ import Data.Monoid (power)
 import Data.Monoid.Multiplicative (Multiplicative(..))
 import Data.Newtype (unwrap)
 import Data.String as String
-import Foreign.SPDX (License)
-import Foreign.SPDX as SPDX
 import Parsing as Parsing
+import Registry.License (License)
+import Registry.License as License
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Schema (Location(..), Manifest(..), Owner(..))
@@ -31,7 +31,7 @@ instance Fixture Version where
   fixture = unsafeFromRight $ Version.parseVersion Version.Lenient "1.0.0"
 
 instance Fixture License where
-  fixture = unsafeFromRight $ SPDX.parse "MIT"
+  fixture = unsafeFromRight $ License.parse "MIT"
 
 instance Fixture Owner where
   fixture = Owner

--- a/app/test/Foreign/SPDX.purs
+++ b/app/test/Foreign/SPDX.purs
@@ -1,0 +1,45 @@
+module Test.Foreign.SPDX (spec) where
+
+import Registry.Prelude
+
+import Data.Array as Array
+import Data.Array.NonEmpty as NonEmptyArray
+import Data.String as String
+import Foreign.SPDX as SPDX
+import Registry.License as License
+import Test.Assert as Assert
+import Test.Spec as Spec
+
+spec :: Spec.Spec Unit
+spec = do
+  Spec.it "Suggests replacements for fixable malformed licenses" do
+    for_ fixable \(input /\ output) ->
+      case SPDX.fuzzyMatchLicense input of
+        Nothing ->
+          Assert.fail $ Array.fold [ input, " had no matches, but should have matched ", output ]
+        Just matches -> do
+          let firstMatch = License.print $ NonEmptyArray.head matches
+          unless (firstMatch == output) do
+            Assert.fail $ Array.fold [ input, " matched with ", firstMatch, " but should have matched ", output ]
+
+  Spec.it "Does not suggest replacements for unfixable malformed licenses" do
+    for_ unfixable \input ->
+      for_ (SPDX.fuzzyMatchLicense input) \matches ->
+        Assert.fail $ Array.fold
+          [ input
+          , " should have no matches, but matched: "
+          , String.joinWith ", " (NonEmptyArray.toArray (map License.print matches))
+          ]
+
+fixable :: Array (Tuple String String)
+fixable =
+  [ "Apache" /\ "Apache-1.0"
+  , "Apache-2" /\ "Apache-2.0"
+  , "Apache 2" /\ "Apache-2.0"
+  , "BSD-3" /\ "BSD-3-Clause"
+  ]
+
+unfixable :: Array String
+unfixable =
+  [ "MIT AND BSD-3"
+  ]

--- a/app/test/Registry/Index.purs
+++ b/app/test/Registry/Index.purs
@@ -11,12 +11,12 @@ import Effect.Ref as Ref
 import Foreign.FastGlob (Include(..))
 import Foreign.FastGlob as FastGlob
 import Foreign.Node.FS as FSE
-import Foreign.SPDX as License
 import Foreign.Tmp as Tmp
 import Node.FS.Aff as FSA
 import Node.Path as Path
 import Registry.Index (RegistryIndex)
 import Registry.Index as Index
+import Registry.License as License
 import Registry.PackageGraph as PackageGraph
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,5 +2,7 @@
   "name": "registry-lib",
   "private": true,
   "license": "BSD-3-Clause",
-  "dependencies": {}
+  "dependencies": {
+    "spdx-expression-parse": "^3.0.0"
+  }
 }

--- a/lib/src/Registry/License.js
+++ b/lib/src/Registry/License.js
@@ -1,0 +1,10 @@
+import parse from "spdx-expression-parse";
+
+export const parseSPDXLicenseIdImpl = (onError, onSuccess, identifier) => {
+  try {
+    parse(identifier);
+    return onSuccess(identifier);
+  } catch (_) {
+    return onError(`Invalid SPDX identifier ${identifier}`);
+  }
+};

--- a/lib/src/Registry/License.purs
+++ b/lib/src/Registry/License.purs
@@ -1,0 +1,58 @@
+-- | Implementation of the `License` data type from the registry spec.
+-- | https://github.com/purescript/registry-dev/blob/master/SPEC.md#license
+-- |
+-- | WARNING:
+-- | This module relies on the 'spdx-expression-parse' NPM library, which you
+-- | must install if you are using parsing code from this module. Please see the
+-- | package.json file for exact versions.
+module Registry.License
+  ( License
+  , SPDXConjunction(..)
+  , codec
+  , joinWith
+  , parse
+  , print
+  ) where
+
+import Prelude
+
+import Data.Codec.Argonaut (JsonCodec)
+import Data.Codec.Argonaut as CA
+import Data.Either (Either(..))
+import Data.Either as Either
+import Data.Function.Uncurried (Fn3, runFn3)
+import Data.String as String
+import Safe.Coerce (coerce)
+
+-- | An SPDX license identifier such as 'MIT' or 'Apache-2.0'.
+newtype License = License String
+
+derive newtype instance Eq License
+
+-- | A codec for encoding and decoding a `License` as JSON
+codec :: JsonCodec License
+codec = CA.prismaticCodec "License" (Either.hush <<< parse) print CA.string
+
+-- | Print an SPDX license identifier as a string.
+print :: License -> String
+print (License license) = license
+
+foreign import parseSPDXLicenseIdImpl :: forall r. Fn3 (String -> r) (String -> r) String r
+
+-- | Parse a string as a SPDX license identifier.
+parse :: String -> Either String License
+parse = runFn3 parseSPDXLicenseIdImpl Left (Right <<< License)
+
+-- | A valid conjunction for SPDX license identifiers. AND means that both
+-- | licenses must be satisfied; OR means that at least one license must be
+-- | satisfied.
+data SPDXConjunction = And | Or
+
+derive instance Eq SPDXConjunction
+
+-- | Join multiple license identifiers together with the given SPDX conjunction
+-- | to create a new valid SPDX license identifier.
+joinWith :: SPDXConjunction -> Array License -> License
+joinWith = case _ of
+  And -> coerce <<< String.joinWith " AND " <<< coerce
+  Or -> coerce <<< String.joinWith " OR " <<< coerce

--- a/lib/test/Registry/License.purs
+++ b/lib/test/Registry/License.purs
@@ -1,0 +1,57 @@
+module Test.Registry.License (spec) where
+
+import Prelude
+
+import Data.Array as Array
+import Data.String as String
+import Registry.License as License
+import Test.Assert as Assert
+import Test.Spec as Spec
+import Test.Utils as Utils
+
+spec :: Spec.Spec Unit
+spec = do
+  Spec.it "Parses well-formed licenses" do
+    let { fail } = Utils.partitionEithers $ map License.parse valid
+    unless (Array.null fail) do
+      Assert.fail $ String.joinWith "\n"
+        [ "Some well-formed licenses names were not parsed correctly:"
+        , Array.foldMap (append "\n  - ") fail
+        ]
+
+  Spec.it "Fails to parse malformed licenses" do
+    let { success } = Utils.partitionEithers $ map License.parse invalid
+    unless (Array.null success) do
+      Assert.fail $ String.joinWith "\n"
+        [ "Some malformed package names were not parsed correctly:"
+        , Array.foldMap (append "\n  - " <<< License.print) success
+        ]
+
+valid :: Array String
+valid =
+  [ "MIT"
+  , "BSD-3-Clause"
+  , "CC-BY-1.0"
+  , "APACHE-2.0"
+
+  -- deprecated licenses are acceptable
+  , "GPL-3.0"
+  , "AGPL-1.0"
+
+  -- conjunctions are understood
+  , "LGPL-2.1 OR BSD-3-CLAUSE AND MIT"
+  , "MIT AND (LGPL-2.1+ AND BSD-3-CLAUSE)"
+
+  -- exceptions are understood
+  , "GPS-3.0 WITH GPL-3.0-linking-exception"
+  ]
+
+invalid :: Array String
+invalid =
+  [ "Apache"
+  , "Apache-2"
+  , "Apache 2"
+  , "BSD-3"
+  , "MIT AND BSD-3"
+  , "MIT AN BSD-3-Clause"
+  ]

--- a/lib/test/Registry/PackageName.purs
+++ b/lib/test/Registry/PackageName.purs
@@ -23,12 +23,12 @@ spec = do
 
       formatError (Tuple name error) = name <> ": " <> error
 
-      { fail } = Utils.partitionEithers $ map parse goodPackageNames
+      { fail } = Utils.partitionEithers $ map parse valid
 
     unless (Array.null fail) do
       Assert.fail $ String.joinWith "\n"
         [ "Some well-formed package names were not parsed correctly:"
-        , String.joinWith "\n  - " $ map formatError fail
+        , Array.foldMap (append "\n  - " <<< formatError) fail
         ]
 
   Spec.it "Fails to parse malformed package names" do
@@ -42,16 +42,16 @@ spec = do
         Nothing -> [ name, "...should have failed with '" <> expectedError <> "'", "...but succeeded instead." ]
         Just error -> [ name, "...should have failed with '" <> expectedError <> "'", "...but failed with '" <> error <> "' instead." ]
 
-      { fail } = Utils.partitionEithers $ map parse badPackageNames
+      { fail } = Utils.partitionEithers $ map parse invalid
 
     unless (Array.null fail) do
       Assert.fail $ String.joinWith "\n"
         [ "Some malformed package names were not parsed correctly:"
-        , String.joinWith "\n  - " $ map formatError fail
+        , Array.foldMap (append "\n  - " <<< formatError) fail
         ]
 
-goodPackageNames :: Array String
-goodPackageNames =
+valid :: Array String
+valid =
   -- standard package names
   [ "a"
   , "ab"
@@ -63,8 +63,8 @@ goodPackageNames =
   , "purescript-compiler-backend-utilities"
   ]
 
-badPackageNames :: Array (Tuple String String)
-badPackageNames = do
+invalid :: Array (Tuple String String)
+invalid = do
   let startErr = "Package name should start with a lower case char or a digit"
   let midErr = "Package name can contain lower case chars, digits and non-consecutive dashes"
   let prefixErr = "Package names should not begin with 'purescript-'"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,10 @@
     },
     "lib": {
       "name": "registry-lib",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.1"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2270,7 +2273,10 @@
       }
     },
     "registry-lib": {
-      "version": "file:lib"
+      "version": "file:lib",
+      "requires": {
+        "spdx-expression-parse": "*"
+      }
     },
     "reusify": {
       "version": "1.0.4",


### PR DESCRIPTION
This PR implements the registry `License` type from the spec (#533). Notably, as with the version & range changes in #541, I have added a small amount of separation between the way the application may choose to deal with malformed licenses and how the stricter registry library does.

Specifically, the `License` parsing no longer tries to bulk up its error message by fuzzy-matching on license identifiers with the Fuse library and simply fails with an 'invalid SPDX license' error message. However, since being able to fuzzy-match and report a suggestion is useful, I've preserved this behavior in the library proper.

You can use `License.parse` for standard license parsing, and you can use `fuzzyMatchLicense` to try and match with valid licenses that the user could have meant. The registry API can look for JSON parsing failures arising from the `license` field and elaborate on the error message if it wants to, and Spago can use this function to suggest alternatives if a config is incorrect.

There is no reason that consumers of the registry library should have to bring in the several libraries necessary to make the fuzzy matcher work when it is only used to add a suggestion to the error message; the fuzzy matching is really best suited for the registry application.