### PR TITLE
Disable correct endpoints-express version

### DIFF
--- a/scripts/src/LegacyImporter.purs
+++ b/scripts/src/LegacyImporter.purs
@@ -115,8 +115,8 @@ main = launchAff_ do
         , commitPackageSetFile: \_ _ _ -> do
             log "Skipping committing to registry package sets..."
             pure (Right unit)
-        , uploadPackage: Upload.upload
-        , deletePackage: Upload.delete
+        , uploadPackage: mempty -- Upload.upload
+        , deletePackage: mempty -- Upload.delete
         , octokit
         , cache
         , username: ""
@@ -425,7 +425,7 @@ validateVersionDisabled package version =
     [ Tuple (disabled "concur-core" "v0.3.9") noSrcDirectory
     , Tuple (disabled "concur-react" "v0.3.9") noSrcDirectory
     , Tuple (disabled "pux-devtool" "v5.0.0") noSrcDirectory
-    , Tuple (disabled "endpoints-express" "v0.0.1") noSrcDirectory
+    , Tuple (disabled "endpoints-express" "0.0.1") noSrcDirectory
     ]
     where
     noSrcDirectory = "Does not contain a 'src' directory."

--- a/scripts/src/LegacyImporter.purs
+++ b/scripts/src/LegacyImporter.purs
@@ -115,8 +115,8 @@ main = launchAff_ do
         , commitPackageSetFile: \_ _ _ -> do
             log "Skipping committing to registry package sets..."
             pure (Right unit)
-        , uploadPackage: mempty -- Upload.upload
-        , deletePackage: mempty -- Upload.delete
+        , uploadPackage: Upload.upload
+        , deletePackage: Upload.delete
         , octokit
         , cache
         , username: ""


### PR DESCRIPTION
In #541 I incorrectly recorded the ref for `endpoints-express` that we've manually disabled in the importer; I wrote `v1.0.0`, but it was supposed to be `1.0.0`. This isn't going to break anything, but it changes the overall statistics recorded for broken packages, so I've fixed it.