### PR TITLE
Update Nix dependencies

### DIFF
--- a/app/spago.yaml
+++ b/app/spago.yaml
@@ -1,5 +1,7 @@
 package:
   name: registry-app
+  run:
+    main: Registry.API
   publish:
     version: 0.0.1
     license: BSD-3-Clause

--- a/app/spago.yaml
+++ b/app/spago.yaml
@@ -57,10 +57,13 @@ package:
     - refs
     - registry-lib
     - safe-coerce
-    - spec
     - strings
     - sunde
     - these
     - transformers
     - tuples
     - uncurried-transformers
+  test:
+    main: Test.Main
+    dependencies:
+      - spec

--- a/app/src/Registry/API.purs
+++ b/app/src/Registry/API.purs
@@ -485,7 +485,7 @@ jsonToDhallManifest :: String -> Aff (Either String String)
 jsonToDhallManifest jsonStr = do
   let cmd = "json-to-dhall"
   let stdin = Just jsonStr
-  let args = [ "--records-loose", "--unions-strict", Path.concat [ rootDir, "v1", "Manifest.dhall" ] ]
+  let args = [ "--records-loose", "--unions-strict", Path.concat [ "v1", "Manifest.dhall" ] ]
   result <- Process.spawn { cmd, stdin, args } NodeProcess.defaultSpawnOptions
   pure $ case result.exit of
     NodeProcess.Normally 0 -> Right jsonStr
@@ -1413,21 +1413,16 @@ packagingTeam = { org: "purescript", team: "packaging" }
 pacchettiBottiKeyType :: String
 pacchettiBottiKeyType = "ssh-ed25519"
 
--- | Path to the root of the registry-dev repository from the directory where
--- | Spago executes the API script
-rootDir :: FilePath
-rootDir = Path.concat [ ".." ]
-
 -- | An ignored directory suitable for storing results when running the API or
 -- | scripts.
 scratchDir :: FilePath
-scratchDir = Path.concat [ rootDir, "scratch" ]
+scratchDir = "scratch"
 
 cacheDir :: FilePath
-cacheDir = Path.concat [ rootDir, ".cache" ]
+cacheDir = ".cache"
 
 envFilePath :: FilePath
-envFilePath = Path.concat [ rootDir, ".env" ]
+envFilePath = ".env"
 
 -- | Loads the `.env` file into the environment.
 loadEnv :: Aff Dotenv.Settings

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "easy-purescript-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1666271405,
-        "narHash": "sha256-rBUF78MxVrZm4ZB2u6Ag/iRBD6Agg1a8IYgFRafdVds=",
+        "lastModified": 1667495045,
+        "narHash": "sha256-vA7jY8weUFqv1Rncxcr8JcdHNixs79W1Uwjx6UY3JtY=",
         "owner": "f-f",
         "repo": "easy-purescript-nix",
-        "rev": "eaae09072cf170503a3f9d0603957d63dfbed0af",
+        "rev": "dede6d5c5f4c99c8dc63252678c7d7a76415743f",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666610816,
-        "narHash": "sha256-q4F2VNe5bpxXOvp16DyLwE1SgNZMbNO29ZQJPIomedg=",
+        "lastModified": 1667491161,
+        "narHash": "sha256-VnfuHS2PQDunGX9vxnyF4+BoaQauNK5aXo6icJEoJPs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6107f97012a0c134c5848125b5aa1b149b76d2c9",
+        "rev": "5d3976195b04db1d33adf7528f7a3c8a66b9f818",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
             cd $(git rev-parse --show-toplevel)
             npm ci
             spago test -p registry-app
-            spago test -p registry-lib -m Test.Registry
+            spago test -p registry-lib
           '';
 
           registry-check-format = ''

--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,7 @@
 
           registry-api = ''
             cd $(git rev-parse --show-toplevel)
-            spago run -p registry-app -m Registry.API
+            spago run -p registry-app
           '';
 
           registry-importer = ''

--- a/lib/spago.yaml
+++ b/lib/spago.yaml
@@ -15,4 +15,3 @@ package:
     - argonaut-core
     - spec
     - sunde
-

--- a/lib/spago.yaml
+++ b/lib/spago.yaml
@@ -11,7 +11,9 @@ package:
     - parsing
     - prelude
     - strings
-  test_dependencies:
-    - argonaut-core
-    - spec
-    - sunde
+  test:
+    main: Test.Registry
+    dependencies:
+      - argonaut-core
+      - spec
+      - sunde


### PR DESCRIPTION
This updates to the latest Spago version and adds PureScript 0.15.6 to the available compilers list. The new Spago version executes from the root directory when you use `spago run`, so I've removed the "rootDir" workaround introduced in #536.