### PR TITLE
Fix subdir reference in fetchRepo

### DIFF
--- a/app/src/Registry/App/PackageSets.purs
+++ b/app/src/Registry/App/PackageSets.purs
@@ -332,7 +332,7 @@ installPackage name version = do
   where
   registryUrl :: Http.URL
   registryUrl = Array.fold
-    [ Constants.packageStorage
+    [ Constants.packageStorageUrl
     , "/"
     , PackageName.print name
     , "/"

--- a/lib/src/Registry/Constants.purs
+++ b/lib/src/Registry/Constants.purs
@@ -1,37 +1,29 @@
 module Registry.Constants where
 
-import Data.Maybe (Maybe(..))
 import Node.Path (FilePath)
-import Registry.Location (GitHubData)
+
+type GitHubRepo = { owner :: String, repo :: String }
 
 -- | The location of the registry GitHub repository
-registry :: GitHubData
-registry = { owner: "purescript", repo: "registry", subdir: Nothing }
-
--- | The location of the package sets within the registry GitHub repository
-packageSets :: GitHubData
-packageSets = registry { subdir = Just packageSetsDirectory }
+registry :: GitHubRepo
+registry = { owner: "purescript", repo: "registry" }
 
 -- | The file path to the package sets within the registry GitHub repository
 packageSetsDirectory :: FilePath
 packageSetsDirectory = "package-sets"
-
--- | The location of the package metadata within the registry GitHub repository
-packageMetadata :: GitHubData
-packageMetadata = registry { subdir = Just packageMetadataDirectory }
 
 -- | The file path to the package metadata within the registry GitHub repository
 packageMetadataDirectory :: FilePath
 packageMetadataDirectory = "metadata"
 
 -- | The location of the package index GitHub repository
-packageIndex :: GitHubData
-packageIndex = { owner: "purescript", repo: "registry-index", subdir: Nothing }
+packageIndex :: GitHubRepo
+packageIndex = { owner: "purescript", repo: "registry-index" }
 
 -- | The URL of the package storage backend
-packageStorage :: String
-packageStorage = "https://packages.registry.purescript.org"
+packageStorageUrl :: String
+packageStorageUrl = "https://packages.registry.purescript.org"
 
 -- | The URL of the package operation API
-packageApi :: String
-packageApi = "https://registry.purescript.org/api"
+packageApiUrl :: String
+packageApiUrl = "https://registry.purescript.org/api"


### PR DESCRIPTION
Calls to `fetchRepo` are failing when they include a `subdir` key. The intent was to prevent us from mistakenly calling this and cloning into a subdirectory before there is support for that, or expecting that we _will_ go into a subdirectory when we won't, but alas it's very easy to accidentally crash by supplying a subdir.

Instead, we just don't accept one at all.