### PR TITLE
Migrate sanitizePath into lib

### DIFF
--- a/lib/spago.yaml
+++ b/lib/spago.yaml
@@ -13,6 +13,7 @@ package:
     - parsing
     - prelude
     - strings
+    - filterable
   test:
     main: Test.Registry
     dependencies:

--- a/lib/spago.yaml
+++ b/lib/spago.yaml
@@ -13,7 +13,6 @@ package:
     - parsing
     - prelude
     - strings
-    - filterable
   test:
     main: Test.Registry
     dependencies:

--- a/lib/src/Registry/Internal/Path.purs
+++ b/lib/src/Registry/Internal/Path.purs
@@ -1,31 +1,21 @@
-module Registry.Internal.Path
-  ( sanitizePaths
-  , SanitizedPaths
-  ) where
+module Registry.Internal.Path where
 
 import Prelude
 
 import Control.Monad.Except (ExceptT(..), runExceptT)
 import Data.Bifunctor (lmap)
-import Data.Compactable (separate)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.String as String
-import Data.Traversable (traverse)
 import Effect.Aff (Aff)
 import Effect.Aff as Aff
 import Node.FS.Aff as FS
 import Node.Path (FilePath)
 import Node.Path as Path
 
-type SanitizedPaths = { succeeded :: Array FilePath, failed :: Array FilePath }
-
-sanitizePaths :: FilePath -> Array FilePath -> Aff SanitizedPaths
-sanitizePaths baseDirectory paths = do
-  sanitized <- traverse (sanitizePath baseDirectory) paths
-  let { right, left } = separate sanitized
-  pure { succeeded: right, failed: left }
-
+-- | Given a directory, validate a file path relative to that root to ensure
+-- | that file path does not traverse out of the directory. 
+-- | Paths are expanded using `FS.realpath` to follow symlinks.
 sanitizePath :: FilePath -> FilePath -> Aff (Either String FilePath)
 sanitizePath baseDirectory path = runExceptT do
   absoluteRoot <- ExceptT $ map (lmap (\_ -> "sanitizePath provided with a base directory that does not exist: " <> baseDirectory)) (Aff.attempt (FS.realpath baseDirectory))

--- a/lib/src/Registry/Internal/Path.purs
+++ b/lib/src/Registry/Internal/Path.purs
@@ -1,0 +1,41 @@
+module Registry.Internal.Path
+  ( sanitizePaths
+  , SanitizedPaths
+  ) where
+
+import Prelude
+
+import Data.Compactable (separate)
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Data.String as String
+import Data.Traversable (traverse)
+import Effect.Aff (Aff)
+import Effect.Aff as Aff
+import Node.FS.Aff as FS
+import Node.Path (FilePath)
+import Node.Path as Path
+import Partial.Unsafe (unsafeCrashWith)
+
+type SanitizedPaths = { succeeded :: Array FilePath, failed :: Array FilePath }
+
+sanitizePaths :: FilePath -> Array FilePath -> Aff SanitizedPaths
+sanitizePaths baseDirectory paths = do
+  sanitized <- traverse (sanitizePath baseDirectory) paths
+  let { right, left } = separate sanitized
+  pure { succeeded: right, failed: left }
+
+sanitizePath :: FilePath -> FilePath -> Aff (Either String FilePath)
+sanitizePath baseDirectory path = do
+  absoluteRoot <- Aff.attempt (FS.realpath baseDirectory) >>= case _ of
+    Left _ -> unsafeCrashWith $ "sanitizePath provided with a base directory that does not exist: " <> baseDirectory
+    Right canonical -> pure canonical
+
+  absolutePath <- Aff.attempt (FS.realpath $ Path.concat [ absoluteRoot, path ]) >>= case _ of
+    Left _ -> unsafeCrashWith $ "sanitizePath provided with a path that does not exist: " <> path
+    Right canonical -> pure canonical
+
+  -- Protect against directory traversals
+  pure $ case String.indexOf (String.Pattern absoluteRoot) absolutePath of
+    Just 0 -> Right path
+    _ -> Left path


### PR DESCRIPTION
I need to use `sanitizePath` in my work for operations validations for #523 - it is pure code that was located in the `Foreign.FastGlob` module previously, so I pulled it out into a new lib module `Registry.Internal.Path` for use within the lib directory itself.

@thomashoneyman has said he'll take a look at migrating tests over once this merges. Right now, there are tests exercising the whole `FastGlob.match` but none for this specific utility itself.