### PR TITLE
Run `nix flake update`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "easy-purescript-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1671225494,
-        "narHash": "sha256-pJJrH9S0lUmb5PZcDCzZdTGTK3FGW1HZliK/fZUH+bg=",
+        "lastModified": 1671226981,
+        "narHash": "sha256-Nli22oZzP3bJYKyMCphjiJy12pug9iyqMF8cWhPpkzI=",
         "owner": "f-f",
         "repo": "easy-purescript-nix",
-        "rev": "96aa4a4c4e58a09ca5ae1483722c95502377b8b5",
+        "rev": "df0818700ed1f358abd21adbcfb1b9849d77d4a3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "easy-purescript-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1667495045,
-        "narHash": "sha256-vA7jY8weUFqv1Rncxcr8JcdHNixs79W1Uwjx6UY3JtY=",
+        "lastModified": 1671225494,
+        "narHash": "sha256-pJJrH9S0lUmb5PZcDCzZdTGTK3FGW1HZliK/fZUH+bg=",
         "owner": "f-f",
         "repo": "easy-purescript-nix",
-        "rev": "dede6d5c5f4c99c8dc63252678c7d7a76415743f",
+        "rev": "96aa4a4c4e58a09ca5ae1483722c95502377b8b5",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671053426,
-        "narHash": "sha256-wBUQPX2G0ZSbXrOZPNa3EiEcL86tDw5NHWtT53MCTFc=",
+        "lastModified": 1671104304,
+        "narHash": "sha256-XT0Kyw/W8DWd1Qb1fWUjkK647hwFCuzcx8WrQCIG8Ec=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9264e62367d4893af624b2cbd163e843e7271bf1",
+        "rev": "0461a5124276c6a314f63d5ec1f6b653a53289b3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667491161,
-        "narHash": "sha256-VnfuHS2PQDunGX9vxnyF4+BoaQauNK5aXo6icJEoJPs=",
+        "lastModified": 1671053426,
+        "narHash": "sha256-wBUQPX2G0ZSbXrOZPNa3EiEcL86tDw5NHWtT53MCTFc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5d3976195b04db1d33adf7528f7a3c8a66b9f818",
+        "rev": "9264e62367d4893af624b2cbd163e843e7271bf1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
See https://github.com/purescript/registry/issues/121#issuecomment-1352404601

```sh
$ nix flake update --extra-experimental-features nix-command --extra-experimental-features flakes
warning: updating lock file './registry-dev/flake.lock':
• Updated input 'flake-compat':
    'github:edolstra/flake-compat/b4a34015c698c7793d592d66adbab377907a2be8' (2022-04-19)
  → 'github:edolstra/flake-compat/009399224d5e398d03b22badca40a37ac85412a1' (2022-11-17)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5d3976195b04db1d33adf7528f7a3c8a66b9f818' (2022-11-03)
  → 'github:nixos/nixpkgs/9264e62367d4893af624b2cbd163e843e7271bf1' (2022-12-14)
warning: Git tree '/home/jordan/programming/registry-dev' is dirty
