### PR TITLE
Fix bounds derived from legacy package sets, bugfixes

### DIFF
--- a/app/src/App/Effect/Registry.purs
+++ b/app/src/App/Effect/Registry.purs
@@ -179,9 +179,10 @@ handle ref = Cache.interpret _registryCache (Cache.handleMemory ref) <<< case _ 
             Right _ -> pure $ Just $ "Update manifest for " <> formatted
         case result of
           Left error -> Except.throw $ "Failed to write and commit manifest: " <> error
-          Right Git.NoChange -> Log.info "Did not commit manifest because it did not change."
-          Right Git.Changed -> do
-            Log.info "Wrote and committed manifest."
+          Right r -> do
+            case r of
+              Git.NoChange -> Log.info "Did not commit manifest because it did not change."
+              Git.Changed -> Log.info "Wrote and committed manifest."
             Cache.put _registryCache AllManifests updated
 
   DeleteManifest name version reply -> map (map reply) Except.runExcept do
@@ -201,9 +202,12 @@ handle ref = Cache.interpret _registryCache (Cache.handleMemory ref) <<< case _ 
             Right _ -> pure $ Just $ "Remove manifest entry for " <> formatted
         case commitResult of
           Left error -> Except.throw $ "Failed to delete and commit manifest: " <> error
-          Right Git.NoChange -> Log.info "Did not commit manifest because it already didn't exist."
-          Right Git.Changed -> do
-            Log.info "Wrote and committed manifest."
+          Right r -> do
+            case r of
+              Git.NoChange ->
+                Log.info "Did not commit manifest because it already didn't exist."
+              Git.Changed ->
+                Log.info "Wrote and committed manifest."
             Cache.put _registryCache AllManifests updated
 
   ReadAllManifests reply -> map (map reply) Except.runExcept do
@@ -311,9 +315,12 @@ handle ref = Cache.interpret _registryCache (Cache.handleMemory ref) <<< case _ 
         Right _ -> pure $ Just $ "Update metadata for " <> printedName
     case commitResult of
       Left error -> Except.throw $ "Failed to write and commit metadata: " <> error
-      Right Git.NoChange -> Log.info "Did not commit metadata because it was unchanged."
-      Right Git.Changed -> do
-        Log.info "Wrote and committed metadata."
+      Right r -> do
+        case r of
+          Git.NoChange ->
+            Log.info "Did not commit metadata because it was unchanged."
+          Git.Changed ->
+            Log.info "Wrote and committed metadata."
         cache <- Cache.get _registryCache AllMetadata
         for_ cache \cached ->
           Cache.put _registryCache AllMetadata (Map.insert name metadata cached)

--- a/app/src/App/Effect/Storage.purs
+++ b/app/src/App/Effect/Storage.purs
@@ -94,9 +94,8 @@ parsePackagePath input = do
         <$> PackageName.parse namePart
         <*> Version.parse versionPart
     parts -> Left
-      if Array.length parts > 2
-        then "Too many parts in path: " <> input
-        else "Too few parts in path: " <> input
+      if Array.length parts > 2 then "Too many parts in path: " <> input
+      else "Too few parts in path: " <> input
 
 formatPackageUrl :: PackageName -> Version -> Affjax.Node.URL
 formatPackageUrl name version = Constants.storageUrl <> "/" <> formatPackagePath name version
@@ -132,8 +131,9 @@ handleS3 env = Cache.interpret _storageCache (Cache.handleFs env.cache) <<< case
         Except.throw $ "Could not upload package " <> PackageName.print name <> " due to an error connecting to the storage backend."
       Just objects ->
         pure $ map _.key objects
-    pure $ Set.fromFoldable $
-      resources >>= \resource -> do
+    pure $ Set.fromFoldable
+      $ resources
+      >>= \resource -> do
         { name: parsedName, version } <- Array.fromFoldable $ parsePackagePath resource
         version <$ guardA (name == parsedName)
 

--- a/app/src/App/Effect/Storage.purs
+++ b/app/src/App/Effect/Storage.purs
@@ -181,7 +181,7 @@ handleS3 env = Cache.interpret _storageCache (Cache.handleFs env.cache) <<< case
       Except.throw $ "Could not delete " <> package <> " because it does not exist in the storage backend."
 
 -- | A storage effect that reads from the registry but does not write to it.
-handleReadOnly :: forall r a. FilePath -> Storage a -> Run (LOG + EXCEPT String + AFF + EFFECT + r) a
+handleReadOnly :: forall r a. FilePath -> Storage a -> Run (LOG + AFF + EFFECT + r) a
 handleReadOnly cache = Cache.interpret _storageCache (Cache.handleFs cache) <<< case _ of
   Upload name version _ reply -> do
     Log.warn $ "Requested upload of " <> formatPackageVersion name version <> " to url " <> formatPackageUrl name version <> " but this interpreter is read-only."

--- a/app/src/App/Effect/Storage.purs
+++ b/app/src/App/Effect/Storage.purs
@@ -23,6 +23,7 @@ import Affjax.StatusCode (StatusCode(..))
 import Data.Array as Array
 import Data.Exists as Exists
 import Data.HTTP.Method (Method(..))
+import Data.Set as Set
 import Data.String as String
 import Effect.Aff as Aff
 import Node.Buffer as Buffer
@@ -46,7 +47,7 @@ data Storage a
   = Upload PackageName Version FilePath (Either String Unit -> a)
   | Download PackageName Version FilePath (Either String Unit -> a)
   | Delete PackageName Version (Either String Unit -> a)
-  | Query PackageName (Either String (Array String) -> a)
+  | Query PackageName (Either String (Set Version) -> a)
 
 derive instance Functor Storage
 
@@ -72,7 +73,7 @@ interpret :: forall r a. (Storage ~> Run r) -> Run (STORAGE + r) a -> Run r a
 interpret handler = Run.interpret (Run.on _storage handler Run.send)
 
 -- | Query what tarballs exist for a package in the storage backend
-query :: forall r. PackageName -> Run (STORAGE + EXCEPT String + r) (Array String)
+query :: forall r. PackageName -> Run (STORAGE + EXCEPT String + r) (Set Version)
 query name = Except.rethrow =<< Run.lift _storage (Query name identity)
 
 formatPackagePath :: PackageName -> Version -> String
@@ -82,6 +83,20 @@ formatPackagePath name version = Array.fold
   , Version.print version
   , ".tar.gz"
   ]
+
+parsePackagePath :: String -> Either String { name :: PackageName, version :: Version }
+parsePackagePath input = do
+  filePath <- String.stripSuffix (String.Pattern ".tar.gz") input
+    # note ("Missing .tar.gz suffix: " <> input)
+  case String.split (String.Pattern "/") filePath of
+    [ namePart, versionPart ] ->
+      { name: _, version: _ }
+        <$> PackageName.parse namePart
+        <*> Version.parse versionPart
+    parts -> Left
+      if Array.length parts > 2
+        then "Too many parts in path: " <> input
+        else "Too few parts in path: " <> input
 
 formatPackageUrl :: PackageName -> Version -> Affjax.Node.URL
 formatPackageUrl name version = Constants.storageUrl <> "/" <> formatPackagePath name version
@@ -111,12 +126,16 @@ handleS3 :: forall r a. S3Env -> Storage a -> Run (LOG + AFF + EFFECT + r) a
 handleS3 env = Cache.interpret _storageCache (Cache.handleFs env.cache) <<< case _ of
   Query name reply -> map (map reply) Except.runExcept do
     s3 <- connectS3 env.s3
-    Run.liftAff (withBackoff' (S3.listObjects s3 { prefix: PackageName.print name <> "/" })) >>= case _ of
+    resources <- Run.liftAff (withBackoff' (S3.listObjects s3 { prefix: PackageName.print name <> "/" })) >>= case _ of
       Nothing -> do
         Log.error $ "Failed to list S3 objects for " <> PackageName.print name <> " because the process timed out."
         Except.throw $ "Could not upload package " <> PackageName.print name <> " due to an error connecting to the storage backend."
       Just objects ->
         pure $ map _.key objects
+    pure $ Set.fromFoldable $
+      resources >>= \resource -> do
+        { name: parsedName, version } <- Array.fromFoldable $ parsePackagePath resource
+        version <$ guardA (name == parsedName)
 
   Download name version path reply -> map (map reply) Except.runExcept do
     let package = formatPackageVersion name version
@@ -198,6 +217,7 @@ handleS3 env = Cache.interpret _storageCache (Cache.handleFs env.cache) <<< case
 -- | A storage effect that reads from the registry but does not write to it.
 handleReadOnly :: forall r a. FilePath -> Storage a -> Run (LOG + AFF + EFFECT + r) a
 handleReadOnly cache = Cache.interpret _storageCache (Cache.handleFs cache) <<< case _ of
+  -- TODO: is there a way to do this without S3 credentials?
   Query _ reply -> do
     pure $ reply $ Left "Cannot query in read-only mode."
 

--- a/app/src/App/Legacy/Manifest.purs
+++ b/app/src/App/Legacy/Manifest.purs
@@ -415,8 +415,10 @@ fetchLegacyPackageSets = Run.Except.runExceptAt _legacyPackageSetsError do
         -- Package sets are only valid if all packages in the set have dependencies that are also in
         -- the set, so this (should) be safe.
         resolveDependencyVersion dep =
-          let v = unsafeFromJust (_.version <$> Map.lookup dep entries)
-          in { min: Min v, max: Max v }
+          let
+            v = unsafeFromJust (_.version <$> Map.lookup dep entries)
+          in
+            { min: Min v, max: Max v }
         resolveDependencyVersions =
           Array.foldl (\m name -> Map.insert name (resolveDependencyVersion name) m) Map.empty
       SemigroupMap $ Map.singleton version $ SemigroupMap $ resolveDependencyVersions dependencies

--- a/app/src/App/Legacy/Manifest.purs
+++ b/app/src/App/Legacy/Manifest.purs
@@ -10,7 +10,10 @@ import Data.Codec.Argonaut.Variant as CA.Variant
 import Data.Either as Either
 import Data.Exists as Exists
 import Data.FunctorWithIndex (mapWithIndex)
+import Data.Map (SemigroupMap(..))
 import Data.Map as Map
+import Data.Ord.Max (Max(..))
+import Data.Ord.Min (Min(..))
 import Data.Profunctor as Profunctor
 import Data.String as String
 import Data.String.NonEmpty as NonEmptyString
@@ -45,6 +48,7 @@ import Run as Run
 import Run.Except (EXCEPT)
 import Run.Except as Except
 import Run.Except as Run.Except
+import Safe.Coerce (coerce)
 import Sunde as Process
 import Type.Proxy (Proxy(..))
 
@@ -92,11 +96,16 @@ fetchLegacyManifest name address ref = Run.Except.runExceptAt _legacyManifestErr
         let printRange version = Array.fold [ ">=", fixed, " <", bump version ]
         RawVersionRange $ Either.either (const fixed) (printRange <<< LenientVersion.version) parsedVersion
 
+      minMaxToRange { min: smallest, max: highest } =
+        { min: fixedToRange smallest, max: fixedToRange highest }
+
       maybePackageSetDeps :: Maybe (Map PackageName Range)
       maybePackageSetDeps =
         Map.lookup name legacyPackageSets >>= Map.lookup ref >>= \deps -> do
-          let converted = mapKeys (RawPackageName <<< PackageName.print) $ map fixedToRange deps
-          hush $ validateDependencies converted
+          let converted = mapKeys (RawPackageName <<< PackageName.print) $ map minMaxToRange deps
+          let smallerBounds = validateDependencies (converted <#> _.min)
+          let higherBounds = validateDependencies (converted <#> _.max)
+          hush $ Map.unionWith Range.union <$> smallerBounds <*> higherBounds
 
       validateSpagoDeps :: SpagoDhallJson -> Either LegacyManifestValidationError (Map PackageName Range)
       validateSpagoDeps (SpagoDhallJson { dependencies, packages }) = do
@@ -397,19 +406,20 @@ fetchLegacyPackageSets = Run.Except.runExceptAt _legacyPackageSetsError do
     tags :: Array String
     tags = Legacy.PackageSet.filterLegacyPackageSets allTags
 
-    convertPackageSet :: LegacyPackageSet -> LegacyPackageSetUnion
-    convertPackageSet (LegacyPackageSet packages) = map (convertEntry packages) packages
+    convertPackageSet :: LegacyPackageSet -> SemigroupMap PackageName (SemigroupMap RawVersion (SemigroupMap PackageName { min :: Min RawVersion, max :: Max RawVersion }))
+    convertPackageSet (LegacyPackageSet packages) = SemigroupMap $ map (convertEntry packages) packages
 
-    convertEntry :: Map PackageName LegacyPackageSetEntry -> LegacyPackageSetEntry -> Map RawVersion (Map PackageName RawVersion)
+    convertEntry :: Map PackageName LegacyPackageSetEntry -> LegacyPackageSetEntry -> SemigroupMap RawVersion (SemigroupMap PackageName { min :: Min RawVersion, max :: Max RawVersion })
     convertEntry entries { dependencies, version } = do
       let
         -- Package sets are only valid if all packages in the set have dependencies that are also in
         -- the set, so this (should) be safe.
         resolveDependencyVersion dep =
-          unsafeFromJust (_.version <$> Map.lookup dep entries)
+          let v = unsafeFromJust (_.version <$> Map.lookup dep entries)
+          in { min: Min v, max: Max v }
         resolveDependencyVersions =
           Array.foldl (\m name -> Map.insert name (resolveDependencyVersion name) m) Map.empty
-      Map.singleton version (resolveDependencyVersions dependencies)
+      SemigroupMap $ Map.singleton version $ SemigroupMap $ resolveDependencyVersions dependencies
 
   Log.debug "Merging legacy package sets into a union."
   tagsHash <- Sha256.hashString (String.joinWith " " tags)
@@ -438,13 +448,11 @@ fetchLegacyPackageSets = Run.Except.runExceptAt _legacyPackageSetsError do
         Log.warn $ "Failed to retrieve package sets for some tags: " <> String.joinWith ", " (map (fst >>> un RawVersion) results.fail)
 
       let
-        convertedSets :: Array LegacyPackageSetUnion
+        convertedSets :: Array (SemigroupMap PackageName (SemigroupMap RawVersion (SemigroupMap PackageName { min :: Min RawVersion, max :: Max RawVersion })))
         convertedSets = map convertPackageSet results.success
 
-        -- TODO: As we've discovered, this union is backwards and needs to be fixed. But that's for
-        -- another PR to take care of.
         merged :: LegacyPackageSetUnion
-        merged = Array.foldl (\m set -> Map.unionWith Map.union set m) Map.empty convertedSets
+        merged = coerce $ fold convertedSets
 
       Cache.put _legacyCache (LegacyUnion tagsHash) merged
       pure merged

--- a/app/src/App/Legacy/Manifest.purs
+++ b/app/src/App/Legacy/Manifest.purs
@@ -373,11 +373,11 @@ bowerfileCodec :: JsonCodec Bowerfile
 bowerfileCodec = Profunctor.dimap toRep fromRep $ CA.Record.object "Bowerfile"
   { description: CA.Record.optional CA.string
   , dependencies: CA.Record.optional dependenciesCodec
-  , license: licenseCodec
+  , license: CA.Record.optional licenseCodec
   }
   where
-  toRep (Bowerfile fields) = fields { dependencies = Just fields.dependencies }
-  fromRep fields = Bowerfile $ fields { dependencies = fromMaybe Map.empty fields.dependencies }
+  toRep (Bowerfile fields) = fields { dependencies = Just fields.dependencies, license = Just fields.license }
+  fromRep fields = Bowerfile $ fields { dependencies = fromMaybe Map.empty fields.dependencies, license = fromMaybe [] fields.license }
 
   dependenciesCodec :: JsonCodec (Map RawPackageName RawVersionRange)
   dependenciesCodec = rawPackageNameMapCodec rawVersionRangeCodec

--- a/app/src/App/Legacy/Types.purs
+++ b/app/src/App/Legacy/Types.purs
@@ -21,10 +21,14 @@ legacyPackageSetCodec =
 
 -- | The union of all legacy package sets, with packages represented at all
 -- | versions they have in the package sets.
-type LegacyPackageSetUnion = Map PackageName (Map RawVersion (Map PackageName RawVersion))
+type LegacyPackageSetUnion = Map PackageName (Map RawVersion (Map PackageName { min :: RawVersion, max :: RawVersion }))
 
 legacyPackageSetUnionCodec :: JsonCodec LegacyPackageSetUnion
-legacyPackageSetUnionCodec = Internal.Codec.packageMap $ rawVersionMapCodec $ Internal.Codec.packageMap rawVersionCodec
+legacyPackageSetUnionCodec = Internal.Codec.packageMap $ rawVersionMapCodec $ Internal.Codec.packageMap $
+  CA.Record.object "LenientBounds"
+    { min: rawVersionCodec
+    , max: rawVersionCodec
+    }
 
 -- | The format of a legacy packages.json package set entry for an individual
 -- | package.

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,11 @@
               spago run -p registry-scripts -m Registry.Scripts.PackageDeleter -- $@
             '';
 
+            registry-solver = ''
+              cd $(git rev-parse --show-toplevel)
+              spago run -p registry-scripts -m Registry.Scripts.Solver -- $@
+            '';
+
             # This script verifies that
             # - all the dhall we have in the repo actually compiles
             # - all the example manifests actually typecheck as Manifests

--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,11 @@
               spago run -p registry-scripts -m Registry.Scripts.Solver -- $@
             '';
 
+            registry-verify = ''
+              cd $(git rev-parse --show-toplevel)
+              spago run -p registry-scripts -m Registry.Scripts.VerifyIntegrity -- $@
+            '';
+
             # This script verifies that
             # - all the dhall we have in the repo actually compiles
             # - all the example manifests actually typecheck as Manifests

--- a/lib/src/Range.purs
+++ b/lib/src/Range.purs
@@ -12,6 +12,7 @@ module Registry.Range
   , parser
   , print
   , union
+  , mk
   ) where
 
 import Prelude
@@ -128,3 +129,7 @@ intersect (Range r1) (Range r2)
       { lhs: max r1.lhs r2.lhs
       , rhs: min r1.rhs r2.rhs
       }
+
+mk :: Version -> Version -> Maybe Range
+mk lhs rhs | lhs < rhs = Just (Range { lhs, rhs })
+mk _ _ = Nothing

--- a/scripts/src/LegacyImporter.purs
+++ b/scripts/src/LegacyImporter.purs
@@ -274,7 +274,7 @@ runLegacyImport mode logs = do
 
       let
         source = case mode of
-          DryRun -> Current
+          DryRun -> Legacy
           GenerateRegistry -> Legacy
           UpdateRegistry -> Current
 
@@ -519,6 +519,8 @@ validateVersionDisabled package version =
     , Tuple (disabled "concur-react" "v0.3.9") noSrcDirectory
     , Tuple (disabled "pux-devtool" "v5.0.0") noSrcDirectory
     , Tuple (disabled "endpoints-express" "0.0.1") noSrcDirectory
+    , Tuple (disabled "argonaut-aeson-generic" "0.4.0") "Does not compile."
+    , Tuple (disabled "batteries-core" "0.3.0") "Does not solve."
     ]
     where
     noSrcDirectory = "Does not contain a 'src' directory."

--- a/scripts/src/PackageDeleter.purs
+++ b/scripts/src/PackageDeleter.purs
@@ -171,12 +171,12 @@ main = launchAff_ do
     forWithIndex_ deletions \name versions ->
       for_ versions \version -> do
         result <- Except.runExcept $ deleteVersion arguments name version
-        let printed = Version.print version
+        let formatted = formatPackageVersion name version
         case result of
           Left err -> do
-            Log.error $ "Failed to delete " <> printed <> ": " <> err
+            Log.error $ "Failed to delete " <> formatted <> ": " <> err
           Right _ ->
-            Log.info $ "Successfully removed " <> printed
+            Log.info $ "Successfully removed " <> formatted
 
   -- --commit
   when arguments.commit do

--- a/scripts/src/PackageDeleter.purs
+++ b/scripts/src/PackageDeleter.purs
@@ -12,20 +12,23 @@ import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Map as Map
 import Data.String as String
 import Data.Tuple (uncurry)
+import Effect.Class.Console (log)
 import Effect.Class.Console as Console
 import Node.Path as Path
 import Node.Process as Process
+import Registry.App.API as API
 import Registry.App.Effect.Cache as Cache
 import Registry.App.Effect.Env as Env
 import Registry.App.Effect.Git (GitEnv, PullMode(..), WriteMode(..))
 import Registry.App.Effect.Git as Git
 import Registry.App.Effect.GitHub as GitHub
-import Registry.App.Effect.Log (LOG, LogVerbosity(..))
+import Registry.App.Effect.Log (LogVerbosity(..))
 import Registry.App.Effect.Log as Log
-import Registry.App.Effect.Registry (REGISTRY)
+import Registry.App.Effect.Notify as Notify
+import Registry.App.Effect.Pursuit as Pursuit
 import Registry.App.Effect.Registry as Registry
-import Registry.App.Effect.Storage (STORAGE)
 import Registry.App.Effect.Storage as Storage
+import Registry.App.Legacy.Manifest (_legacyCache)
 import Registry.Foreign.FSExtra as FS.Extra
 import Registry.Foreign.Octokit as Octokit
 import Registry.Internal.Codec as Internal.Codec
@@ -34,29 +37,51 @@ import Registry.PackageName as PackageName
 import Registry.Version as Version
 import Run (Run)
 import Run as Run
-import Run.Except (EXCEPT)
 import Run.Except as Except
 
-data DeleteMode = File FilePath | Package PackageName Version
+type Arguments =
+  { inputMode :: InputMode
+  , reimport :: Boolean
+  , commit :: Boolean
+  , upload :: Boolean
+  , pullMode :: PullMode
+  }
 
-derive instance Eq DeleteMode
+data InputMode = File FilePath | Package PackageName Version
+
+derive instance Eq InputMode
 
 type DeletePackages = Map PackageName (Array Version)
 
 deletePackagesCodec :: JsonCodec DeletePackages
 deletePackagesCodec = Internal.Codec.packageMap (CA.array Version.codec)
 
-parser :: ArgParser DeleteMode
-parser = Arg.choose "command"
-  [ Arg.argument [ "--file" ]
-      """Delete package versions from a JSON file like: { "prelude": [ "1.0.0", "1.1.1" ] }"""
-      # Arg.unformat "FILE_PATH" pure
-      # map File
-  , Arg.argument [ "--package" ]
-      "Delete the indicated package at the given version, separated by '@'"
-      # Arg.unformat "NAME@VERSION" parsePackage
-      # map (uncurry Package)
-  ]
+parser :: ArgParser Arguments
+parser = Arg.fromRecord
+  { reimport:
+      Arg.flag [ "--reimport" ] "Reimport packages immediately after deleting" # Arg.boolean
+  , inputMode: Arg.choose "input (--file or --package)"
+      [ Arg.argument [ "--file" ]
+          """Delete package versions from a JSON file like: { "prelude": [ "1.0.0", "1.1.1" ] }"""
+          # Arg.unformat "FILE_PATH" pure
+          # map File
+      , Arg.argument [ "--package" ]
+          "Delete the indicated package at the given version, separated by '@'"
+          # Arg.unformat "NAME@VERSION" parsePackage
+          # map (uncurry Package)
+      ]
+  , commit: Arg.choose "commit-mode (--commit or --no-commit)"
+      [ Arg.flag [ "--commit" ] "Commit changes to ./scratch/registry/metadata and ./scratch/registry-index" $> true
+      , Arg.flag [ "--no-commit" ] "Do not commit changes" $> false
+      ]
+  , upload: Arg.choose "upload-mode (--upload or --no-upload)"
+      [ Arg.flag [ "--upload" ] "Upload changes to S3 storage" $> true
+      , Arg.flag [ "--no-upload" ] "Do not upload changes to S3 storage" $> false
+      ]
+  , pullMode:
+    Arg.flag [ "--autostash" ] "Autostash when pulling, instead of requiring a clean checkout" $> Autostash
+    # Arg.default OnlyClean
+  }
   where
   parsePackage :: String -> Either String (Tuple PackageName Version)
   parsePackage input = do
@@ -75,7 +100,7 @@ main :: Effect Unit
 main = launchAff_ do
   args <- Array.drop 2 <$> liftEffect Process.argv
   let description = "A script for deleting registry packages."
-  mode <- case Arg.parseArgs "package-deleter" description parser args of
+  arguments <- case Arg.parseArgs "package-deleter" description parser args of
     Left err -> Console.log (Arg.printArgError err) *> liftEffect (Process.exit 1)
     Right command -> pure command
 
@@ -90,7 +115,7 @@ main = launchAff_ do
     gitEnv :: WriteMode -> GitEnv
     gitEnv writeMode =
       { write: writeMode
-      , pull: OnlyClean
+      , pull: arguments.pullMode -- --autostash
       , repos: Git.defaultRepos
       , workdir: scratchDir
       , debouncer
@@ -104,6 +129,7 @@ main = launchAff_ do
   FS.Extra.ensureDirectory cache
   githubCacheRef <- Cache.newCacheRef
   registryCacheRef <- Cache.newCacheRef
+  legacyCacheRef <- Cache.newCacheRef
 
   -- Logging
   now <- nowUTC
@@ -111,9 +137,12 @@ main = launchAff_ do
   FS.Extra.ensureDirectory logDir
   let logFile = "package-set-deleter-" <> String.take 19 (Formatter.DateTime.format Internal.Format.iso8601DateTime now) <> ".log"
   let logPath = Path.concat [ logDir, logFile ]
+  log $ "Logs available at " <> logPath
 
-  deletions <- case mode of
+  deletions <- case arguments.inputMode of
+    -- --package name@version
     Package name version -> pure $ Map.singleton name [ version ]
+    -- --file packagesversions.json
     File path -> liftAff (readJsonFile deletePackagesCodec path) >>= case _ of
       Left err -> Console.log err *> liftEffect (Process.exit 1)
       Right values -> pure values
@@ -121,9 +150,12 @@ main = launchAff_ do
   let
     interpret gitMode =
       Registry.interpret (Registry.handle registryCacheRef)
-        >>> Storage.interpret (Storage.handleS3 { s3, cache })
+        >>> Storage.interpret (if arguments.upload then Storage.handleS3 { s3, cache } else Storage.handleReadOnly cache)
         >>> GitHub.interpret (GitHub.handle { octokit, cache, ref: githubCacheRef })
         >>> Git.interpret (Git.handle (gitEnv gitMode))
+        >>> Pursuit.interpret Pursuit.handlePure
+        >>> Cache.interpret _legacyCache (Cache.handleMemoryFs { ref: legacyCacheRef, cache })
+        >>> Notify.interpret Notify.handleLog
         >>> Log.interpret (\log -> Log.handleTerminal Normal log *> Log.handleFs Verbose logPath log)
         >>> Run.runBaseAff'
 
@@ -138,7 +170,7 @@ main = launchAff_ do
 
     forWithIndex_ deletions \name versions ->
       for_ versions \version -> do
-        result <- Except.runExcept $ deleteVersion name version
+        result <- Except.runExcept $ deleteVersion arguments name version
         let printed = Version.print version
         case result of
           Left err -> do
@@ -146,27 +178,54 @@ main = launchAff_ do
           Right _ ->
             Log.info $ "Successfully removed " <> printed
 
+  -- --commit
+  when arguments.commit do
+    -- Then we add our commits with committing enabled.
+    interpret (CommitAs (Git.pacchettibottiCommitter token)) do
+      Git.commit Git.CommitMetadataIndex "Remove some package versions from metadata." >>= case _ of
+        Left error -> Log.error $ "Failed to commit metadata: " <> error
+        Right _ -> pure unit
+
+      Git.commit Git.CommitManifestIndex "Remove some package versions from manifest index." >>= case _ of
+        Left error -> Log.error $ "Failed to commit manifest index: " <> error
+        Right _ -> pure unit
+
+  interpret ReadOnly do
     Log.info "Finished."
 
-  -- Then we add our commits with committing enabled.
-  interpret (CommitAs (Git.pacchettibottiCommitter token)) do
-    Git.commit Git.CommitMetadataIndex "Remove some package versions from metadata." >>= case _ of
-      Left error -> Log.error $ "Failed to commit metadata: " <> error
-      Right _ -> pure unit
-
-    Git.commit Git.CommitManifestIndex "Remove some package versions from manifest index." >>= case _ of
-      Left error -> Log.error $ "Failed to commit manifest index: " <> error
-      Right _ -> pure unit
-
-deleteVersion :: forall r. PackageName -> Version -> Run (REGISTRY + STORAGE + LOG + EXCEPT String + r) Unit
-deleteVersion name version = do
+deleteVersion :: forall r. Arguments -> PackageName -> Version -> Run (API.PublishEffects + r) Unit
+deleteVersion arguments name version = do
   let formatted = formatPackageVersion name version
-  Log.info $ "Deleting " <> formatted
-  Storage.delete name version
+  -- --upload
+  when arguments.upload do
+    Except.catch Log.error do
+      Log.info $ "Deleting " <> formatted <> " from S3 storage"
+      Storage.delete name version
   Log.info $ "Updating metadata for " <> formatted
   Registry.readMetadata name >>= case _ of
     Nothing -> Except.throw $ "Could not update metadata for " <> formatted <> " because no existing metadata was found."
-    Just (Metadata old) -> do
-      let new = Metadata $ old { published = Map.delete version old.published, unpublished = Map.delete version old.unpublished }
-      Registry.writeMetadata name new
+    Just (Metadata oldMetadata) -> do
+      let
+        publishment = case Map.lookup version oldMetadata.published, Map.lookup version oldMetadata.unpublished of
+          Just _, Just _ -> unsafeCrashWith $ "Package version was both published and unpublished: " <> formatted
+          Just published, Nothing -> Just (Right published)
+          Nothing, Just unpublished -> Just (Left unpublished)
+          Nothing, Nothing -> Nothing
+      let
+        newMetadata = Metadata $ oldMetadata { published = Map.delete version oldMetadata.published, unpublished = Map.delete version oldMetadata.unpublished }
+      Registry.writeMetadata name newMetadata
       Registry.deleteManifest name version
+      -- --reimport
+      when arguments.reimport do
+        case publishment of
+          Nothing -> Log.error "Cannot reimport a version that was not published"
+          Just (Left _) -> Log.error "Cannot reimport a version that was specifically unpublished"
+          Just (Right specificPackageMetadata) -> do
+            -- Obtains `newMetadata` via cache
+            API.publish API.Legacy
+              { location: Just oldMetadata.location
+              , name: name
+              , ref: specificPackageMetadata.ref
+              , compiler: unsafeFromRight $ Version.parse "0.15.4"
+              , resolutions: Nothing
+              }

--- a/scripts/src/PackageDeleter.purs
+++ b/scripts/src/PackageDeleter.purs
@@ -79,8 +79,8 @@ parser = Arg.fromRecord
       , Arg.flag [ "--no-upload" ] "Do not upload changes to S3 storage" $> false
       ]
   , pullMode:
-    Arg.flag [ "--autostash" ] "Autostash when pulling, instead of requiring a clean checkout" $> Autostash
-    # Arg.default OnlyClean
+      Arg.flag [ "--autostash" ] "Autostash when pulling, instead of requiring a clean checkout" $> Autostash
+        # Arg.default OnlyClean
   }
   where
   parsePackage :: String -> Either String (Tuple PackageName Version)

--- a/scripts/src/PackageDeleter.purs
+++ b/scripts/src/PackageDeleter.purs
@@ -205,12 +205,12 @@ deleteVersion arguments name version = do
   Registry.readMetadata name >>= case _ of
     Nothing -> Except.throw $ "Could not update metadata for " <> formatted <> " because no existing metadata was found."
     Just (Metadata oldMetadata) -> do
-      let
-        publishment = case Map.lookup version oldMetadata.published, Map.lookup version oldMetadata.unpublished of
-          Just _, Just _ -> unsafeCrashWith $ "Package version was both published and unpublished: " <> formatted
-          Just published, Nothing -> Just (Right published)
-          Nothing, Just unpublished -> Just (Left unpublished)
-          Nothing, Nothing -> Nothing
+      publishment <-
+        case Map.lookup version oldMetadata.published, Map.lookup version oldMetadata.unpublished of
+          Just _, Just _ -> Except.throw $ "Package version was both published and unpublished: " <> formatted
+          Just published, Nothing -> pure (Just (Right published))
+          Nothing, Just unpublished -> pure (Just (Left unpublished))
+          Nothing, Nothing -> pure Nothing
       let
         newMetadata = Metadata $ oldMetadata { published = Map.delete version oldMetadata.published, unpublished = Map.delete version oldMetadata.unpublished }
       Registry.writeMetadata name newMetadata

--- a/scripts/src/Solver.purs
+++ b/scripts/src/Solver.purs
@@ -1,0 +1,212 @@
+module Registry.Scripts.Solver where
+
+import Registry.App.Prelude
+
+import Data.Argonaut.Core as Json
+import Data.Array as Array
+import Data.Codec.Argonaut as J
+import Data.Codec.Argonaut.Compat as JC
+import Data.DateTime.Instant as Instant
+import Data.Foldable (foldMap)
+import Data.Formatter.DateTime as Formatter.DateTime
+import Data.Map as Map
+import Data.Newtype (unwrap)
+import Data.String as String
+import Data.These (These(..), these)
+import Data.Time.Duration (Milliseconds(..))
+import Effect.Class.Console as Aff
+import Effect.Exception (throw)
+import Effect.Now (now)
+import Node.Path as Path
+import Node.Process as Node.Process
+import Node.Process as Process
+import Parsing as Parsing
+import Registry.App.API as API
+import Registry.App.Effect.Cache as Cache
+import Registry.App.Effect.Env as Env
+import Registry.App.Effect.Git (PullMode(..), WriteMode(..))
+import Registry.App.Effect.Git as Git
+import Registry.App.Effect.GitHub as GitHub
+import Registry.App.Effect.Log (LogVerbosity(..), debug, error, info, warn)
+import Registry.App.Effect.Log as Log
+import Registry.App.Effect.Notify as Notify
+import Registry.App.Effect.Pursuit as Pursuit
+import Registry.App.Effect.Registry (readManifestIndexFromDisk)
+import Registry.App.Effect.Registry as Registry
+import Registry.App.Effect.Storage as Storage
+import Registry.App.Legacy.Manifest as Legacy.Manifest
+import Registry.Foreign.FSExtra as FS.Extra
+import Registry.Foreign.Octokit as Octokit
+import Registry.Internal.Codec as Codec
+import Registry.Internal.Format as Internal.Format
+import Registry.ManifestIndex as ManifestIndex
+import Registry.PackageName as PackageName
+import Registry.Range as Range
+import Registry.Scripts.LegacyImporter (IMPORT_CACHE, _importCache)
+import Registry.Scripts.PackageDeleter (deletePackagesCodec)
+import Registry.Solver as Solver
+import Registry.Version as Version
+import Run (Run)
+import Run as Run
+import Run.Except as Except
+
+unionWithMapThese :: forall k a b c. Ord k =>
+  (k -> These a b -> Maybe c) ->
+  Map k a -> Map k b -> Map k c
+unionWithMapThese f ma mb =
+  let
+    combine = case _, _ of
+      This a, That b -> Both a b
+      That b, This a -> Both a b
+      Both a b, _ -> Both a b
+      This a, Both _ b -> Both a b
+      That b, Both a _ -> Both a b
+      That b, That _ -> That b
+      This a, This _ -> This a
+  in Map.mapMaybeWithKey f $ Map.unionWith combine (This <$> ma) (That <$> mb)
+
+diff ::
+  Map PackageName (Map Version (Map PackageName Range)) ->
+  Map PackageName (Map Version (Map PackageName Range)) ->
+  Map PackageName (Map Version (Map PackageName (These Range Range)))
+diff = unionWithMapThese \_ -> filtered <<< these
+  do map (map This)
+  do map (map That)
+  do
+    unionWithMapThese \_ -> filtered <<< these
+      do map This
+      do map That
+      do
+        unionWithMapThese \_ -> these
+          do Just <<< This
+          do Just <<< That
+          \l r ->
+            if l == r then Nothing else Just (Both l r)
+  where
+  filtered :: forall k v. Ord k => Map k v -> Maybe (Map k v)
+  filtered v | Map.isEmpty v = Nothing
+  filtered v = Just v
+
+fromThese :: forall a. These a a -> Array (Maybe a)
+fromThese = these (\l -> [Just l, Nothing]) (\r -> [Nothing, Just r]) (\l r -> [Just l, Just r])
+
+main :: Effect Unit
+main = launchAff_ do
+  args <- liftEffect $ Array.drop 2 <$> Node.Process.argv
+  let
+    getAction :: forall r. Aff (_ -> Run (API.PublishEffects + IMPORT_CACHE + r) Unit)
+    getAction = case args of
+      ["--file", path] -> do
+        packageversions <- liftAff (readJsonFile deletePackagesCodec path) >>= case _ of
+          Left err -> Aff.log err *> liftEffect (Process.exit 1)
+          Right values -> pure values
+        pure \registry -> do
+          forWithIndex_ packageversions \package versionsofpackage -> do
+            for_ versionsofpackage \version -> do
+              let
+                deps =
+                  case Map.lookup package registry of
+                    Nothing -> unsafeCrashWith $ "Missing package: " <> PackageName.print package
+                    Just versions ->
+                      case Map.lookup version versions of
+                        Nothing -> unsafeCrashWith $ "Missing version: " <> PackageName.print package <> "@" <> Version.print version
+                        Just d -> d
+              test registry package version deps
+      ["--manifest", path] -> do
+        let
+          parser =
+            Range.parser <|> (Version.parser <#> \v -> unsafeFromJust (Range.mk v (Version.bumpPatch v)))
+          parsing = hush <<< flip Parsing.runParser parser
+          codec = Codec.packageMap $ J.prismaticCodec "VersionOrRange" parsing Range.print J.string
+          package = unsafeFromRight $ PackageName.parse "manifest"
+          version = unsafeFromRight $ Version.parse "0.0.0"
+        deps <- liftAff (readJsonFile codec path) >>= case _ of
+          Left err -> Aff.log err *> liftEffect (Process.exit 1)
+          Right values -> pure values
+        pure \registry -> test registry package version deps
+      ["--all"] -> pure \registry -> do
+        forWithIndex_ registry \package versions -> do
+          forWithIndex_ versions \version deps -> do
+            test registry package version deps
+      [package_versionS] | [packageS,versionS] <- String.split (String.Pattern "@") package_versionS ->
+        let
+          package = unsafeFromRight $ PackageName.parse packageS
+          version = unsafeFromRight $ Version.parse versionS
+        in pure \registry -> do
+          let versions = unsafeFromJust $ Map.lookup package registry
+          let deps = unsafeFromJust $ Map.lookup version versions
+          test registry package version deps
+      _ -> do
+        Aff.log "Either use --all or package@version"
+        liftEffect $ throw $ "Invalid arguments: " <> show args
+
+  action <- getAction
+
+  Env.loadEnvFile ".env"
+
+  githubCacheRef <- Cache.newCacheRef
+  legacyCacheRef <- Cache.newCacheRef
+  registryCacheRef <- Cache.newCacheRef
+  importCacheRef <- Cache.newCacheRef
+  let cache = Path.concat [ scratchDir, ".cache" ]
+  FS.Extra.ensureDirectory cache
+
+  debouncer <- Git.newDebouncer
+  let gitEnv pull write = { pull, write, repos: Git.defaultRepos { manifestIndex = Git.defaultRepos.manifestIndex { owner = "monoidmusician" }, registry = Git.defaultRepos.registry { owner = "monoidmusician" } }, workdir: scratchDir, debouncer }
+  token <- Env.lookupRequired Env.githubToken
+  octokit <- Octokit.newOctokit token
+  let
+    runAppEffects =
+      Storage.interpret (Storage.handleReadOnly cache)
+        >>> Pursuit.interpret Pursuit.handlePure
+        >>> GitHub.interpret (GitHub.handle { octokit, cache, ref: githubCacheRef })
+        >>> Git.interpret (Git.handle (gitEnv Autostash ReadOnly))
+
+  let
+    doTheThing = do
+      info $ "Reading registry index1 (modified) from " <> Path.concat [ scratchDir, "registry-index" ] <> " ..."
+      index1 <- readManifestIndexFromDisk $ Path.concat [ scratchDir, "registry-index" ]
+
+      info $ "Reading registry index0 (original) from " <> "tmp/registry-index" <> " ..."
+      index0 <- readManifestIndexFromDisk $ "tmp/registry-index"
+
+      let reg i = map (unwrap >>> _.dependencies) <$> ManifestIndex.toMap i
+      let registry = reg $ index1
+
+      liftAff $ writeJsonFile (Codec.packageMap (Codec.versionMap (Codec.packageMap (J.array (JC.maybe Range.codec))))) "tmp/registry_index_diff.json" (map map map fromThese <$> diff (reg index0) (reg index1))
+
+      action registry
+
+  -- Logging setup
+  let logDir = Path.concat [ scratchDir, "logs" ]
+  FS.Extra.ensureDirectory logDir
+  now <- nowUTC
+  let
+    logFile = "solver-" <> String.take 19 (Formatter.DateTime.format Internal.Format.iso8601DateTime now) <> ".log"
+    logPath = Path.concat [ logDir, logFile ]
+
+  doTheThing
+    # Registry.interpret (Registry.handle registryCacheRef)
+    # runAppEffects
+    # Cache.interpret Legacy.Manifest._legacyCache (Cache.handleMemoryFs { cache, ref: legacyCacheRef })
+    # Cache.interpret _importCache (Cache.handleMemoryFs { cache, ref: importCacheRef })
+    # Notify.interpret Notify.handleLog
+    # Except.catch (\msg -> Log.error msg *> Run.liftEffect (Process.exit 1))
+    # Log.interpret (\log -> Log.handleTerminal Normal log *> Log.handleFs Verbose logPath log)
+    # Run.runBaseAff'
+
+  where
+  test :: forall r. _ -> _ -> _ -> _ -> Run (API.PublishEffects + IMPORT_CACHE + r) Unit
+  test registry package version deps = do
+    info $ "%%% Solving " <> PackageName.print package <> "@" <> Version.print version <> " %%%"
+    t0 <- liftEffect now
+    let r = Solver.solve registry deps
+    t1 <- liftEffect now
+    let Milliseconds d = Instant.diff t1 t0
+    debug $ "Took: " <> show d <> "ms"
+    case r of
+      Right vs ->
+        debug $ Json.stringifyWithIndent 2 (J.encode (Codec.packageMap Version.codec) vs)
+      Left es -> do
+        error $ "Failed: " <> PackageName.print package <> "@" <> Version.print version
+        warn $ String.take 5000 $ foldMap Solver.printSolverError es

--- a/scripts/src/VerifyIntegrity.purs
+++ b/scripts/src/VerifyIntegrity.purs
@@ -74,7 +74,7 @@ main = launchAff_ do
     gitEnv =
       { write: ReadOnly
       , pull: Autostash
-      , repos: Git.defaultRepos { manifestIndex = Git.defaultRepos.manifestIndex { owner = "monoidmusician" }, registry = Git.defaultRepos.registry { owner = "monoidmusician" } }
+      , repos: Git.defaultRepos
       , workdir: scratchDir
       , debouncer
       }

--- a/scripts/src/VerifyIntegrity.purs
+++ b/scripts/src/VerifyIntegrity.purs
@@ -1,0 +1,187 @@
+-- | Script for verifying that the registry and registry-index repos match each other and S3
+module Registry.Scripts.VerifyIntegrity where
+
+import Registry.App.Prelude
+
+import ArgParse.Basic (ArgParser)
+import ArgParse.Basic as Arg
+import Control.Apply (lift2)
+import Data.Array as Array
+import Data.Codec.Argonaut as CA
+import Data.Foldable (class Foldable, foldMap, intercalate)
+import Data.Formatter.DateTime as Formatter.DateTime
+import Data.Map as Map
+import Data.Set as Set
+import Data.String as String
+import Effect.Class.Console (log)
+import Effect.Class.Console as Console
+import Node.Path as Path
+import Node.Process as Process
+import Registry.App.Effect.Cache as Cache
+import Registry.App.Effect.Env as Env
+import Registry.App.Effect.Git (GitEnv, PullMode(..), WriteMode(..))
+import Registry.App.Effect.Git as Git
+import Registry.App.Effect.GitHub as GitHub
+import Registry.App.Effect.Log (LOG, LogVerbosity(..))
+import Registry.App.Effect.Log as Log
+import Registry.App.Effect.Registry as Registry
+import Registry.App.Effect.Storage as Storage
+import Registry.Foreign.FSExtra as FS.Extra
+import Registry.Foreign.Octokit as Octokit
+import Registry.Internal.Format as Internal.Format
+import Registry.ManifestIndex as ManifestIndex
+import Registry.PackageName as PackageName
+import Registry.Version as Version
+import Run (Run)
+import Run as Run
+import Run.Except (EXCEPT)
+import Run.Except as Except
+
+data InputMode = File FilePath | Package PackageName | All
+
+derive instance Eq InputMode
+
+parser :: ArgParser InputMode
+parser = Arg.choose "input (--file or --package)"
+  [ Arg.argument [ "--file" ]
+      """Verify packages from a JSON file like: [ "prelude", "console" ]"""
+      # Arg.unformat "FILE_PATH" pure
+      # map File
+  , Arg.argument [ "--package" ]
+      "Verify the indicated package"
+      # Arg.unformat "NAME" PackageName.parse
+      # map Package
+  , Arg.flag [ "--all" ] "Verify all packages" $> All
+  ]
+
+main :: Effect Unit
+main = launchAff_ do
+  args <- Array.drop 2 <$> liftEffect Process.argv
+  let description = "A script for verifying that the registry and registry-index repos match each other and S3."
+  arguments <- case Arg.parseArgs "package-verify" description parser args of
+    Left err -> Console.log (Arg.printArgError err) *> liftEffect (Process.exit 1)
+    Right command -> pure command
+
+  -- Environment
+  _ <- Env.loadEnvFile ".env"
+  token <- Env.lookupRequired Env.pacchettibottiToken
+  s3 <- lift2 { key: _, secret: _ } (Env.lookupRequired Env.spacesKey) (Env.lookupRequired Env.spacesSecret)
+
+  -- Git
+  debouncer <- Git.newDebouncer
+  let
+    gitEnv :: GitEnv
+    gitEnv =
+      { write: ReadOnly
+      , pull: Autostash
+      , repos: Git.defaultRepos { manifestIndex = Git.defaultRepos.manifestIndex { owner = "monoidmusician" }, registry = Git.defaultRepos.registry { owner = "monoidmusician" } }
+      , workdir: scratchDir
+      , debouncer
+      }
+
+  -- GitHub
+  octokit <- Octokit.newOctokit token
+
+  -- Caching
+  let cache = Path.concat [ scratchDir, ".cache" ]
+  FS.Extra.ensureDirectory cache
+  githubCacheRef <- Cache.newCacheRef
+  registryCacheRef <- Cache.newCacheRef
+
+  -- Logging
+  now <- nowUTC
+  let logDir = Path.concat [ scratchDir, "logs" ]
+  FS.Extra.ensureDirectory logDir
+  let logFile = "verify-" <> String.take 19 (Formatter.DateTime.format Internal.Format.iso8601DateTime now) <> ".log"
+  let logPath = Path.concat [ logDir, logFile ]
+  log $ "Logs available at " <> logPath
+
+  selectedPackages <- case arguments of
+    -- --package name@version
+    Package name -> pure (Just [ name ])
+    -- --file packagesversions.json
+    File path -> liftAff (readJsonFile (CA.array PackageName.codec) path) >>= case _ of
+      Left err -> Console.log err *> liftEffect (Process.exit 1)
+      Right values -> pure (Just values)
+    All -> pure Nothing
+
+  let
+    interpret =
+      Registry.interpret (Registry.handle registryCacheRef)
+        >>> Storage.interpret (Storage.handleS3 { s3, cache })
+        >>> Git.interpret (Git.handle gitEnv)
+        >>> GitHub.interpret (GitHub.handle { octokit, cache, ref: githubCacheRef })
+        >>> Log.interpret (\log -> Log.handleTerminal Normal log *> Log.handleFs Verbose logPath log)
+        >>> Run.runBaseAff'
+
+  interpret do
+    let
+      sorry e = Log.error e *> liftEffect (Process.exit 1)
+    allMetadata <- Except.runExcept Registry.readAllMetadata >>= either (map absurd <<< sorry) pure
+    allManifests <- Except.runExcept Registry.readAllManifests >>= either (map absurd <<< sorry) pure
+    let
+      packages = case selectedPackages of
+        Just ps -> ps
+        Nothing -> do
+          Array.fromFoldable
+            $ Map.keys allMetadata
+            <> Map.keys (ManifestIndex.toMap allManifests)
+    Log.info $ Array.fold
+      [ "Verifying package versions:"
+      , do
+          let foldFn name = "\n  - " <> PackageName.print name
+          foldMap foldFn packages
+      ]
+
+    for_ packages \name -> do
+      result <- Except.runExcept do
+        published <- Storage.query name
+        verifyPackage allMetadata allManifests (Set.fromFoldable published) name
+      case result of
+        Left err -> do
+          Log.error $ "Failed to verify " <> PackageName.print name <> ": " <> err
+        Right _ ->
+          Log.info $ "Verified " <> PackageName.print name
+
+    Log.info "Finished."
+
+intercalateMap :: forall f a d. Monoid d => Foldable f => d -> (a -> d) -> f a -> d
+intercalateMap s f = intercalate s <<< map f <<< Array.fromFoldable
+
+setOf :: forall f a. Foldable f => (a -> String) -> f a -> String
+setOf f vs = "{" <> intercalateMap "," f vs <> "}"
+
+dblDiff :: forall k. Ord k => Set k -> Set k -> Maybe { left :: Set k, right :: Set k }
+dblDiff a b | a == b = Nothing
+dblDiff a b = Just { left: Set.difference a b, right: Set.difference b a }
+
+printDblDiff :: forall k. (k -> String) -> { left :: String, right :: String } -> { left :: Set k, right :: Set k } -> String
+printDblDiff f names { left, right } = intercalate ", " $ join
+  [ if Set.isEmpty right then mempty
+    else
+      [ names.left <> " missing " <> setOf f right ]
+  , if Set.isEmpty left then mempty
+    else
+      [ names.right <> " missing " <> setOf f left ]
+  ]
+
+verifyPackage :: forall r. Map PackageName Metadata -> ManifestIndex -> Set String -> PackageName -> Run (EXCEPT String + LOG + r) Unit
+verifyPackage allMetadata allManifests publishedS3 name = do
+  let formatted = PackageName.print name
+  Log.info $ "Checking versions for " <> formatted
+  metadataVersions <- case Map.lookup name allMetadata of
+    Nothing -> Except.throw $ "Missing metadata for " <> formatted
+    Just (Metadata { published }) -> pure $ Map.keys published
+  manifestVersions <- case Map.lookup name $ ManifestIndex.toMap allManifests of
+    Nothing ->
+      if Set.isEmpty metadataVersions then pure Set.empty
+      else Except.throw $ "Missing manifests for " <> formatted
+    Just manifests -> pure $ Map.keys manifests
+
+  for_ (dblDiff metadataVersions manifestVersions) \diff -> do
+    Except.throw $ printDblDiff Version.print { left: "metadata", right: "manifests" } diff
+  let paths = Set.map \version -> PackageName.print name <> "/" <> Version.print version <> ".tar.gz"
+  let versions = Set.intersection metadataVersions manifestVersions
+  for_ (dblDiff publishedS3 (paths versions)) \diff -> do
+    Except.throw $ printDblDiff identity { left: "S3", right: "manifests/metadata" } diff
+  pure unit


### PR DESCRIPTION
Fixes #531. Supersedes #567.

Takes the union of bounds generated from package sets for a particular import. Fixes several bugs we found along the way, some of which were also encountered in the previous PR.

The two PRs generated from this PR (reuploads already went to S3):
- https://github.com/purescript/registry/pull/151
- https://github.com/purescript/registry-index/pull/5