### PR TITLE
Tighten up the dependency list: remove unused and include undeclared transitive packages

### DIFF
--- a/app/spago.yaml
+++ b/app/spago.yaml
@@ -59,7 +59,6 @@ package:
     - registry-lib
     - run
     - safe-coerce
-    - spec
     - strings
     - sunde
     - these

--- a/app/spago.yaml
+++ b/app/spago.yaml
@@ -7,32 +7,31 @@ package:
     license: BSD-3-Clause
   dependencies:
     - aff
-    - aff-promise
     - affjax
     - affjax-node
+    - ansi
     - argonaut-core
     - arrays
     - b64
     - bifunctors
+    - codec-argonaut
     - console
+    - const
     - control
-    - convertable-options
     - datetime
     - dodo-printer
     - dotenv
     - effect
     - either
     - exceptions
+    - exists
     - filterable
     - foldable-traversable
     - foreign-object
     - formatters
-    - functions
-    - graphs
     - http-methods
     - identity
     - integers
-    - interpolate
     - js-date
     - js-uri
     - lists
@@ -47,23 +46,29 @@ package:
     - node-process
     - now
     - nullable
+    - numbers
     - ordered-collections
+    - orders
     - parallel
     - parsing
     - partial
-    - precise-datetime
     - prelude
-    - record
+    - profunctor
     - refs
-    - registry-lib
     - registry-foreign
+    - registry-lib
+    - run
     - safe-coerce
+    - spec
     - strings
     - sunde
     - these
     - transformers
     - tuples
-    - uncurried-transformers
+    - typelevel-prelude
+    - unicode
+    - unsafe-coerce
+    - variant
   test:
     main: Test.Registry.Main
     dependencies:

--- a/foreign/spago.yaml
+++ b/foreign/spago.yaml
@@ -3,14 +3,43 @@ package:
   publish:
     license: BSD-3-Clause
   dependencies:
+    - aff
     - aff-promise
+    - argonaut-core
+    - arrays
     - b64
+    - bifunctors
+    - codec-argonaut
     - convertable-options
+    - datetime
+    - effect
+    - either
     - filterable
+    - foldable-traversable
+    - foreign-object
+    - functions
     - http-methods
+    - integers
+    - js-date
+    - maybe
+    - newtype
+    - node-buffer
+    - node-fs
+    - node-fs-aff
+    - node-path
     - node-process
+    - nullable
+    - ordered-collections
+    - prelude
+    - profunctor
     - registry-lib
+    - spec
+    - strings
+    - tuples
+    - unsafe-coerce
+    - variant
   test:
     main: Test.Foreign
     dependencies:
       - spec
+

--- a/foreign/spago.yaml
+++ b/foreign/spago.yaml
@@ -24,16 +24,12 @@ package:
     - maybe
     - newtype
     - node-buffer
-    - node-fs
-    - node-fs-aff
     - node-path
-    - node-process
     - nullable
     - ordered-collections
     - prelude
     - profunctor
     - registry-lib
-    - spec
     - strings
     - tuples
     - unsafe-coerce
@@ -41,5 +37,7 @@ package:
   test:
     main: Test.Foreign
     dependencies:
+      - node-fs
+      - node-fs-aff
+      - node-process
       - spec
-

--- a/lib/spago.yaml
+++ b/lib/spago.yaml
@@ -12,7 +12,6 @@ package:
     - datetime
     - effect
     - either
-    - exceptions
     - foldable-traversable
     - foreign-object
     - formatters
@@ -24,7 +23,6 @@ package:
     - maybe
     - newtype
     - node-buffer
-    - node-child-process
     - node-fs
     - node-fs-aff
     - node-path
@@ -34,15 +32,15 @@ package:
     - prelude
     - profunctor
     - safe-coerce
-    - spec
     - strings
-    - sunde
     - transformers
     - tuples
-    - unsafe-coerce
   test:
     main: Test.Registry
     dependencies:
       - argonaut-core
+      - exceptions
+      - node-child-process
       - spec
       - sunde
+      - unsafe-coerce

--- a/lib/spago.yaml
+++ b/lib/spago.yaml
@@ -3,17 +3,43 @@ package:
   publish:
     license: BSD-3-Clause
   dependencies:
+    - aff
+    - argonaut-core
+    - arrays
+    - bifunctors
     - codec-argonaut
+    - control
+    - datetime
     - effect
+    - either
+    - exceptions
+    - foldable-traversable
+    - foreign-object
     - formatters
+    - functions
+    - functors
     - graphs
+    - integers
+    - lists
+    - maybe
+    - newtype
     - node-buffer
+    - node-child-process
+    - node-fs
     - node-fs-aff
     - node-path
+    - ordered-collections
     - parsing
+    - partial
     - prelude
+    - profunctor
+    - safe-coerce
+    - spec
     - strings
-    - uncurried-transformers
+    - sunde
+    - transformers
+    - tuples
+    - unsafe-coerce
   test:
     main: Test.Registry
     dependencies:

--- a/scripts/spago.yaml
+++ b/scripts/spago.yaml
@@ -3,6 +3,36 @@ package:
   publish:
     license: BSD-3-Clause
   dependencies:
+    - aff
+    - argonaut-core
     - argparse-basic
+    - arrays
+    - codec-argonaut
+    - console
+    - control
+    - datetime
+    - either
+    - exceptions
+    - exists
+    - filterable
+    - foldable-traversable
+    - formatters
+    - lists
+    - newtype
+    - node-path
+    - node-process
+    - now
+    - numbers
+    - ordered-collections
+    - parsing
+    - prelude
+    - profunctor
+    - refs
     - registry-app
+    - registry-foreign
     - registry-lib
+    - run
+    - strings
+    - tuples
+    - variant
+


### PR DESCRIPTION
Spago Next now has an improved version of what used to be the "unused and transitive dependencies check", that allows for tightening up the dependencies declared in the build files.

It can be run with the `--pedantic-packages` flag, sample output before this PR:
<img width="1200" alt="image" src="https://user-images.githubusercontent.com/5480361/213917092-d704a500-2f3d-4fa6-bf45-696a0f124916.png">
