### PR TITLE
Allow trustees to authorize operations on packages without owners

### DIFF
--- a/app/src/App/Auth.purs
+++ b/app/src/App/Auth.purs
@@ -6,7 +6,7 @@ module Registry.App.Auth
 
 import Registry.App.Prelude
 
-import Data.Array.NonEmpty as NonEmptyArray
+import Data.Array as Array
 import Data.String as String
 import Node.ChildProcess as Node.ChildProcess
 import Node.FS.Aff as FS.Aff
@@ -32,11 +32,11 @@ sshKeyPath = "id_ed25519"
 -- sign authenticated transfers. This is not sufficient to blanket authorize
 -- things, as someone still needs to use the pacchettibotti credentials to
 -- actually sign the payload.
-verifyPayload :: Owner -> NonEmptyArray Owner -> AuthenticatedData -> Aff (Either String String)
+verifyPayload :: Owner -> Array Owner -> AuthenticatedData -> Aff (Either String String)
 verifyPayload pacchettiBotti owners { email, signature, rawPayload } = do
   tmp <- Tmp.mkTmpDir
   let joinWithNewlines = String.joinWith "\n"
-  let signers = joinWithNewlines $ NonEmptyArray.toArray $ map formatOwner (NonEmptyArray.cons pacchettiBotti owners)
+  let signers = joinWithNewlines $ map formatOwner (Array.cons pacchettiBotti owners)
   FS.Aff.writeTextFile UTF8 (Path.concat [ tmp, allowedSignersPath ]) signers
   FS.Aff.writeTextFile UTF8 (Path.concat [ tmp, payloadSignaturePath ]) (joinWithNewlines signature)
   -- The 'ssh-keygen' command will only exit normally if the signature verifies,

--- a/app/test/App/Auth.purs
+++ b/app/test/App/Auth.purs
@@ -2,7 +2,6 @@ module Test.Registry.App.Auth (spec) where
 
 import Registry.App.Prelude
 
-import Data.Array.NonEmpty as NonEmptyArray
 import Data.Newtype (over)
 import Data.String as String
 import Registry.App.Auth as Auth
@@ -15,13 +14,13 @@ import Test.Spec as Spec
 spec :: Spec.Spec Unit
 spec = do
   Spec.it "Verifies correct payloads" do
-    Auth.verifyPayload pacchettibotti (NonEmptyArray.singleton validOwner) validPayload >>= case _ of
+    Auth.verifyPayload pacchettibotti [ validOwner ] validPayload >>= case _ of
       Left err -> Assert.fail err
       Right _ -> mempty
 
   Spec.it "Fails to verify when public key is incorrect" do
     let badPublicKey = over Owner (_ { public = "" }) validOwner
-    Auth.verifyPayload pacchettibotti (NonEmptyArray.singleton badPublicKey) validPayload >>= case _ of
+    Auth.verifyPayload pacchettibotti [ badPublicKey ] validPayload >>= case _ of
       Left err -> verifyError err "allowed_signers:2: invalid key"
       Right _ -> Assert.fail "Verified an invalid public key."
 
@@ -38,25 +37,25 @@ spec = do
 
       badSignatureData = validPayload { signature = badSignature }
 
-    Auth.verifyPayload pacchettibotti (NonEmptyArray.singleton validOwner) badSignatureData >>= case _ of
+    Auth.verifyPayload pacchettibotti [ validOwner ] badSignatureData >>= case _ of
       Left err -> verifyError err "Signature verification failed: incorrect signature"
       Right _ -> Assert.fail "Verified an incorrect SSH signature for the payload."
 
   Spec.it "Fails to verify when email is incorrect in authenticated data" do
     let badEmailData = validPayload { email = "test@bar" }
-    Auth.verifyPayload pacchettibotti (NonEmptyArray.singleton validOwner) badEmailData >>= case _ of
+    Auth.verifyPayload pacchettibotti [ validOwner ] badEmailData >>= case _ of
       Left err -> verifyError err ""
       Right _ -> Assert.fail "Verified with an incorrect email address."
 
   Spec.it "Fails to verify when email is incorrect in owner field" do
     let badEmailOwner = over Owner (_ { email = "test@bar" }) validOwner
-    Auth.verifyPayload pacchettibotti (NonEmptyArray.singleton badEmailOwner) validPayload >>= case _ of
+    Auth.verifyPayload pacchettibotti [ badEmailOwner ] validPayload >>= case _ of
       Left err -> verifyError err ""
       Right _ -> Assert.fail "Verified with an incorrect email address."
 
   Spec.it "Fails to verify when payload is incorrect" do
     let badRawPayload = validPayload { rawPayload = "{}" }
-    Auth.verifyPayload pacchettibotti (NonEmptyArray.singleton validOwner) badRawPayload >>= case _ of
+    Auth.verifyPayload pacchettibotti [ validOwner ] badRawPayload >>= case _ of
       Left err -> verifyError err "Signature verification failed: incorrect signature"
       Right _ -> Assert.fail "Verified with a modified payload."
 


### PR DESCRIPTION
Check owners only if authentication fails