### PR TITLE
Migrate SSH to ssh2 library

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -433,7 +433,7 @@ Being a package "owner" grants the ability to take sensitive actions on behalf o
 The registry relies on SSH to authenticate package owners. An `Owner` is a public SSH key, and this SSH key can be used to sign data using OpenSSH versions 8.0 and above. The registry in turn verifies the signed data using the `Owner` and OpenSSH. To submit an authenticated operation, you are required to take the following steps:
 
 1. Construct the JSON payload for the operation
-2. Sign the JSON payload using an SSH key listed in the package's `owners` metadata field.
+2. Sign the JSON payload using an SSH key listed in the package's `owners` metadata field, where the signature is hex-encoded.
 3. Construct the JSON payload for an authenticated operation using the JSON payload from step (1), the signature from step (2), and the email associated with the SSH key used to create the SSH signature.
 
 For example, here's a stringified JSON payload for an `Unpublish` operation unpublishing `prelude@1.0.1` because credentials were accidentally committed:
@@ -442,29 +442,10 @@ For example, here's a stringified JSON payload for an `Unpublish` operation unpu
 "{ \"name\": \"prelude\", \"version\": \"1.0.1\", \"reason\": \"Accidentally committed credentials\" }"
 ```
 
-We can sign this JSON using `ssh-keygen` as described in the post [It's Now Possible to Sign Arbitrary Data With Your SSH Keys](https://www.agwa.name/blog/post/ssh_signatures):
-
-```sh
-ssh-keygen -Y sign -f [ssh_key] -n file [file_to_sign]
-```
-
-where `[ssh_key]` is the path to your private key (such as `~/.ssh/id_ed25519`) and `[file_to_sign]` is the path to the file to be signed (such as `unpublish.json`). This will write the SSH signature to a new file named `[file_to_sign].sig` (for example, `unpublish.sig`), and it looks like this:
-
-```sig
------BEGIN SSH SIGNATURE-----
-U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAg2rirQQddpzEzOZwbtM0LUMmlLG
-krl2EkDq4CVn/Hw7sAAAAEZmlsZQAAAAAAAAAGc2hhNTEyAAAAUwAAAAtzc2gtZWQyNTUx
-OQAAAEDyjWPjmOdG8HJ8gh1CbM8WDDWoGfm+TTd8Qa8eua9Bt5Cc+43S24i/JqVWmk98qV
-YXoQmOYL4bY8t/q7cSNeMH
------END SSH SIGNATURE-----
-```
-
-You can also specify `-` for the filename, in which case the file to sign is read from stdin and the signature is written to stdout.
-
-You must then assemble this information into a JSON `object` with three fields:
+Then, assemble this information into a JSON `object` with three fields:
 
 - `payload`: The JSON string representing the `Unpublish` or `Transfer` operation
-- `signature`: An array of strings representing each line of the SSH signature
+- `signature`: A hex-encoded SSH signature
 - `email`: The email address associated with the public key used to sign the payload (this should be in the `owners` metadata field).
 
 For example, in JSON:
@@ -472,24 +453,17 @@ For example, in JSON:
 ```json
 {
   "payload": "{ \"name\": \"prelude\", \"version\": \"1.0.1\", \"reason\": \"Accidentally committed credentials\" }",
-  "signature": [
-    "-----BEGIN SSH SIGNATURE-----",
-    "ABCIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAg2rirQQddpzEzOZwbtM0LUMmlLG",
-    "kno3EkDq4CVn/Hw7sAAAAEZmlsZQAAAAAAAAAGc2hhNTEyAAAAUwAAAAtzc2gtZWQyNTUx",
-    "OQAttrDyjWPjmOdG8HJ8gh1CbM8WDDWoGfm+TTd8Qa8eua9Bt5Cc+43S24i/JqVWmk98qV",
-    "YXoQmOYL4bY8t/q7cSNeMH",
-    "-----END SSH SIGNATURE-----"
-  ],
+  "signature": "1f4967eaa5de1076bb2185b818ea4fb7c18cfe83af951ab32c3bcb4a300dfe9b3795daaae1e7a6d5fb9f72c4cec8003f79a452f2dc9da9ec8cfa63b243c80503",
   "email": "trh@example.com"
 }
 ```
 
 **Verifying SSH Signatures**
 
-When the registry receives an authenticated operation, it takes the following steps:
+When the registry receives an authenticated operation it takes the following steps:
 
-1. The registry will create an [`allowed_signers`](https://man.openbsd.org/ssh-keygen#ALLOWED_SIGNERS) file, which will list all package owners from the package's metadata as well as the @pacchettibotti SSH keys.
-2. The registry will use `ssh-keygen` to verify the provided signature, the provided payload, and the provided email address. If the signature is valid, then `ssh-keygen` will exit with a 0 status and a message beginning with "Good 'file' signature for...". Otherwise, the command will exit with an error.
+1. The registry will retrieve all package owners from the package's metadata
+2. The registry will use each key listed in the package owners to attempt to verify the signature on the authenticated operation.
 3. If the signature was valid and the JSON operation payload was well-formed, then the registry will execute the provided operation.
 
 #### 5.3 Unpublish a Package (Authenticated)

--- a/SPEC.md
+++ b/SPEC.md
@@ -143,21 +143,21 @@ Or, using a monorepo:
 **[Source](./lib/src/Registry/Owner.purs)**
 **[Spec](./types/v1/Owner.dhall)**
 
-The registry relies on SSH key pairs to verify package ownership for the purposes of sensitive API operations like unpublishing versions or transferring packages. An `Owner` is made up of the two required components of an SSH public key in text format ([RFC4253](https://www.rfc-editor.org/rfc/rfc4253#section-6.6)). That format looks like this:
+The registry relies on SSH key pairs to verify package ownership for the purposes of sensitive API operations like unpublishing versions or transferring packages. An `Owner` is made up of the three components of an SSH public key in text format ([RFC4253](https://www.rfc-editor.org/rfc/rfc4253#section-6.6)). That format looks like this:
 
 `[keytype] [ssh-public-key] [comment (optional)]`
 
-Note that the comment is optional. A JSON example:
+Note that the comment is optional and is referred to as the "id" in the registry. A JSON example:
 
 ```jsonc
 {
   "keytype": "ssh-ed25519",
   "public": "ABCD3FGzaC1lZDI1NTE5AAAAINq4q0EHXacxMzmcG7TNC1DJpSxpK5dhJA6uAlZ",
-  "comment": "john@abc"
+  "id": "john@abc"
 }
 ```
 
-Alternately, this can be written without a comment:
+Alternately, this can be written without an id:
 
 ```jsonc
 {

--- a/SPEC.md
+++ b/SPEC.md
@@ -157,6 +157,15 @@ Note that the comment is optional. A JSON example:
 }
 ```
 
+Alternately, this can be written without a comment:
+
+```jsonc
+{
+  "keytype": "ssh-ed25519",
+  "public": "ABCD3FGzaC1lZDI1NTE5AAAAINq4q0EHXacxMzmcG7TNC1DJpSxpK5dhJA6uAlZ"
+}
+```
+
 #### License
 
 **[Source](./lib/src/Registry/License.purs)**

--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -1026,7 +1026,7 @@ getPacchettiBotti :: forall r. Run (PACCHETTIBOTTI_ENV + r) Owner
 getPacchettiBotti = do
   { publicKey } <- Env.askPacchettiBotti
   pure $ Owner
-    { email: pacchettibottiEmail
+    { comment: Just pacchettibottiEmail
     , keytype: pacchettibottiKeyType
     , public: publicKey
     }

--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -1026,7 +1026,7 @@ getPacchettiBotti :: forall r. Run (PACCHETTIBOTTI_ENV + r) Owner
 getPacchettiBotti = do
   { publicKey } <- Env.askPacchettiBotti
   pure $ Owner
-    { comment: Just pacchettibottiEmail
+    { id: Just pacchettibottiEmail
     , keytype: pacchettibottiKeyType
     , public: publicKey
     }

--- a/app/src/App/Auth.purs
+++ b/app/src/App/Auth.purs
@@ -24,7 +24,7 @@ verifyPayload pacchettiBotti owners auth = do
       Left "None of the owner keys are suitable to verify the payload."
   where
   formatOwner (Owner owner) =
-    String.joinWith " " [ owner.keytype, owner.public, owner.email ]
+    String.joinWith " " [ owner.keytype, owner.public, fromMaybe "comment" owner.comment ]
 
 type SignAuthenticated =
   { privateKey :: String

--- a/app/src/App/Auth.purs
+++ b/app/src/App/Auth.purs
@@ -24,7 +24,7 @@ verifyPayload pacchettiBotti owners auth = do
       Left "None of the owner keys are suitable to verify the payload."
   where
   formatOwner (Owner owner) =
-    String.joinWith " " [ owner.keytype, owner.public, fromMaybe "comment" owner.comment ]
+    String.joinWith " " [ owner.keytype, owner.public, fromMaybe "id" owner.id ]
 
 type SignAuthenticated =
   { privateKey :: String

--- a/app/src/App/Auth.purs
+++ b/app/src/App/Auth.purs
@@ -8,79 +8,34 @@ import Registry.App.Prelude
 
 import Data.Array as Array
 import Data.String as String
-import Node.ChildProcess as Node.ChildProcess
-import Node.FS.Aff as FS.Aff
-import Node.FS.Perms as Perms
-import Node.Path as Path
-import Registry.Foreign.Tmp as Tmp
+import Node.Buffer as Buffer
 import Registry.Operation (AuthenticatedData)
-import Sunde as Process
+import Registry.SSH as SSH
 
-allowedSignersPath :: FilePath
-allowedSignersPath = "allowed_signers"
-
-payloadSignaturePath :: FilePath
-payloadSignaturePath = "payload_signature.sig"
-
-sshKeyPath :: FilePath
-sshKeyPath = "id_ed25519"
-
--- Payload verification is based on this description:
--- https://www.agwa.name/blog/post/ssh_signatures
---
 -- We take pacchettibotti as an extra owner because pacchettibotti can always
 -- sign authenticated transfers. This is not sufficient to blanket authorize
 -- things, as someone still needs to use the pacchettibotti credentials to
 -- actually sign the payload.
-verifyPayload :: Owner -> Array Owner -> AuthenticatedData -> Aff (Either String String)
-verifyPayload pacchettiBotti owners { email, signature, rawPayload } = do
-  tmp <- Tmp.mkTmpDir
-  let joinWithNewlines = String.joinWith "\n"
-  let signers = joinWithNewlines $ map formatOwner (Array.cons pacchettiBotti owners)
-  FS.Aff.writeTextFile UTF8 (Path.concat [ tmp, allowedSignersPath ]) signers
-  FS.Aff.writeTextFile UTF8 (Path.concat [ tmp, payloadSignaturePath ]) (joinWithNewlines signature)
-  -- The 'ssh-keygen' command will only exit normally if the signature verifies,
-  -- and otherwise will report an error status code.
-  sshKeygenVerify tmp
+verifyPayload :: Owner -> Array Owner -> AuthenticatedData -> Aff (Either String Unit)
+verifyPayload pacchettiBotti owners auth = do
+  let eitherKeys = traverse (SSH.parsePublicKey <<< formatOwner) (Array.cons pacchettiBotti owners)
+  case eitherKeys of
+    Left error -> pure (Left error)
+    Right keys -> do
+      signature <- liftEffect $ Buffer.fromString (String.joinWith "\n" auth.signature) UTF8
+      case Array.any (\key -> SSH.verify key { data: auth.rawPayload, signature }) keys of
+        true -> pure (Right unit)
+        _ -> pure (Left "None of the owner keys are suitable to verify the payload.")
   where
   formatOwner (Owner owner) =
     String.joinWith " " [ owner.email, owner.keytype, owner.public ]
 
-  sshKeygenVerify tmp = do
-    let cmd = "ssh-keygen"
-    let stdin = Just rawPayload
-    let args = [ "-Y", "verify", "-f", allowedSignersPath, "-I", email, "-n", "file", "-s", payloadSignaturePath ]
-    result <- Process.spawn { cmd, stdin, args } (Node.ChildProcess.defaultSpawnOptions { cwd = Just tmp })
-    pure $ bimap String.trim String.trim case result.exit of
-      Node.ChildProcess.Normally 0 -> Right result.stdout
-      _ -> Left result.stderr
-
 type SignAuthenticated =
-  { publicKey :: String
-  , privateKey :: String
+  { privateKey :: String
   , rawPayload :: String
   }
 
-signPayload :: SignAuthenticated -> Aff (Either String (Array String))
-signPayload { publicKey, privateKey, rawPayload } = do
-  tmp <- Tmp.mkTmpDir
-  let publicKeyPath = Path.concat [ tmp, sshKeyPath <> ".pub" ]
-  let privateKeyPath = Path.concat [ tmp, sshKeyPath ]
-  -- Key files must have a single trailing newline.
-  FS.Aff.writeTextFile UTF8 publicKeyPath (String.trim publicKey <> "\n")
-  FS.Aff.writeTextFile UTF8 privateKeyPath (String.trim privateKey <> "\n")
-  for_ (Perms.permsFromString "0600") (FS.Aff.chmod privateKeyPath)
-  sshKeygenSign tmp
-  where
-  sshKeygenSign tmp = do
-    let cmd = "ssh-keygen"
-    let stdin = Just rawPayload
-    -- If you specify - for the filename, the file to sign is read from standard
-    -- in and the signature is written to standard out.
-    let args = [ "-Y", "sign", "-f", sshKeyPath, "-n", "file", "-" ]
-    result <- Process.spawn { cmd, stdin, args } (Node.ChildProcess.defaultSpawnOptions { cwd = Just tmp })
-    pure case result.exit of
-      Node.ChildProcess.Normally 0 ->
-        Right $ String.split (String.Pattern "\n") $ String.trim result.stdout
-      _ ->
-        Left $ String.trim result.stderr
+signPayload :: SignAuthenticated -> Either String Buffer
+signPayload { privateKey, rawPayload } = do
+  private <- SSH.parsePrivateKey privateKey
+  pure (SSH.sign private rawPayload).signature

--- a/app/src/App/Effect/Env.purs
+++ b/app/src/App/Effect/Env.purs
@@ -130,7 +130,7 @@ pacchettibottiED25519Pub = EnvKey
       decoded <- decodeBase64Key input
       let split = String.split (String.Pattern " ") decoded
 
-      keyFields <- note "Key must be of the form 'keytype key email'" do
+      keyFields <- note "Key must be of the form 'keytype key comment'" do
         keyType <- Array.index split 0
         key <- Array.index split 1
         email <- Array.index split 2

--- a/app/src/App/Main.purs
+++ b/app/src/App/Main.purs
@@ -11,7 +11,6 @@ import Effect.Aff as Aff
 import Effect.Class.Console as Console
 import Effect.Ref as Ref
 import Foreign.Object as Object
-import Node.Buffer as Buffer
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
 import Node.Process as Process
@@ -305,8 +304,6 @@ signPacchettiBottiIfTrustee auth = do
 
         signature <- case Auth.signPayload { privateKey, rawPayload: auth.rawPayload } of
           Left _ -> Except.throw "Error signing transfer. cc: @purescript/packaging"
-          Right signature -> do
-            asString <- Run.liftEffect $ Buffer.toString UTF8 signature
-            pure $ String.split (String.Pattern "\n") asString
+          Right signature -> pure signature
 
         pure $ auth { signature = signature }

--- a/app/test/App/Auth.purs
+++ b/app/test/App/Auth.purs
@@ -56,14 +56,14 @@ spec = do
 
 pacchettibotti :: Owner
 pacchettibotti = Owner
-  { email: "pacchettibotti@purescript.org"
+  { comment: Just "pacchettibotti@purescript.org"
   , keytype: "ssh-rsa"
   , public: "AAAAB3NzaC1yc2EAAAADAQABAAACAQDOHWfcD2vlrcaEngneZ2TlHjnjLKoQCuy9R95F1qrfRIE0N6xH7eHMuJGFIvqeuKivSXWLUKQslf2XIA7n0PEX0vmzzM7JZNvOkIFoOinBfCKqAx1dIle7yYPAUZPrzBidyLv+4aCJ+zu819yHA5tfoZB87+N0QAZcEptYw3taWHZGTZdNpgIgcpDGEnUihuQ9eYbdePokWbDsSgBT7AMjpAPTN5Yvg27jNNm6/WdooY7O9tP4Xdheb7GUIabKeNDX4sK0hBWVcS4SVTMVV8ifflKWXboJqIhXvUHcn1Te4o193aC+VgDFyzIAhPiZjfI/Fnha9XVPOXZMotIkJ0xiH7jzFljYshExCiecEDbLnV67Z/CEzVmw7kYTYs2+fpJ6cnJGHWIfaU2cz3C+empn3kZ6So+CM/8oHVpt0UjhTuqIav29OlouAxcv8eLPHPmTINyiaZ7b+slZBsNcUgW5r54sJvsXyzx9DQN+jkfwtucxN3JQcnIhZcYvD9KSZtHRtz9iLOYLL6Pimbb4K9l98+Br4G40Mjby3ElsAwtPGOLdimyZAD2t2eyDu64kOm2zS9jS6JJ9/8uKxlSyenUBxQ+ITwn1enEd4qq1qpnUT/F7PKqv9SSn6UBoMXq+uTFa5rXevOMhl7whAZjttyFokYQsacy6kbvlLMOWcsLqMw=="
   }
 
 validOwner :: Owner
 validOwner = Owner
-  { email
+  { comment: Nothing
   , keytype
   , public: publicKey
   }
@@ -84,9 +84,6 @@ name = unsafeFromRight $ PackageName.parse "foo"
 
 version :: Version
 version = unsafeFromRight $ Version.parse "1.2.3"
-
-email :: String
-email = "test@foo"
 
 keytype :: String
 keytype = "ssh-ed25519"

--- a/app/test/App/Auth.purs
+++ b/app/test/App/Auth.purs
@@ -4,10 +4,10 @@ import Registry.App.Prelude
 
 import Data.Newtype (over)
 import Data.String as String
-import Node.Buffer as Buffer
 import Registry.App.Auth as Auth
 import Registry.Operation (AuthenticatedData, AuthenticatedPackageOperation(..))
 import Registry.PackageName as PackageName
+import Registry.SSH (Signature(..))
 import Registry.Test.Assert as Assert
 import Registry.Version as Version
 import Test.Spec as Spec
@@ -20,52 +20,30 @@ spec = do
       Right _ -> mempty
 
   Spec.it "Fails to verify when public key is incorrect" do
-    let badPublicKey = over Owner (_ { public = "" }) validOwner
+    let badPublicKey = over Owner (_ { public = (un Owner pacchettibotti).public }) validOwner
     Auth.verifyPayload pacchettibotti [ badPublicKey ] validPayload >>= case _ of
-      Left err -> verifyError err ""
+      Left err -> verifyError err "Malformed OpenSSH public key"
       Right _ -> Assert.fail "Verified an invalid public key."
 
   Spec.it "Fails to verify when signature is incorrect" do
     let
-      badSignature =
-        [ "-----BEGIN SSH SIGNATURE-----"
-        , "U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgEAD8tAhhDMvn3Ydoy40uk7Ga7s"
-        , "rV9CGhaPk8UG3B5NAAAAAEZmlsZQAAAAAAAAAGc2hhNTEyAAAAUwAAAAtzc2gtZWQyNTUx"
-        , "OQAAAECB+9OSWkoZ5rHVg22oB8Ks56Jg3einV9tRw+6ypes1ZsmwdvJB2XjuvGPZG0iXdb"
-        , "/9KJFfXFSvUgP5PpuaAfkM"
-        , "-----END SSH SIGNATURE-----"
-        ]
-
+      badSignature = Signature ""
       badSignatureData = validPayload { signature = badSignature }
 
     Auth.verifyPayload pacchettibotti [ validOwner ] badSignatureData >>= case _ of
-      Left err -> verifyError err "Unsupported key format"
+      Left err -> verifyError err "None of the owner keys are suitable to verify the payload."
       Right _ -> Assert.fail "Verified an incorrect SSH signature for the payload."
-
-  Spec.it "Fails to verify when email is incorrect in authenticated data" do
-    let badEmailData = validPayload { email = "test@bar" }
-    Auth.verifyPayload pacchettibotti [ validOwner ] badEmailData >>= case _ of
-      Left err -> verifyError err ""
-      Right _ -> Assert.fail "Verified with an incorrect email address."
-
-  Spec.it "Fails to verify when email is incorrect in owner field" do
-    let badEmailOwner = over Owner (_ { email = "test@bar" }) validOwner
-    Auth.verifyPayload pacchettibotti [ badEmailOwner ] validPayload >>= case _ of
-      Left err -> verifyError err ""
-      Right _ -> Assert.fail "Verified with an incorrect email address."
 
   Spec.it "Fails to verify when payload is incorrect" do
     let badRawPayload = validPayload { rawPayload = "{}" }
     Auth.verifyPayload pacchettibotti [ validOwner ] badRawPayload >>= case _ of
-      Left err -> verifyError err ""
+      Left err -> verifyError err "None of the owner keys are suitable to verify the payload."
       Right _ -> Assert.fail "Verified with a modified payload."
 
   Spec.it "Signs and verifies payload" do
     case Auth.signPayload { rawPayload, privateKey: String.joinWith "\n" privateKey } of
       Left err -> Assert.fail err
-      Right signature -> do
-        signature' <- liftEffect $ Buffer.toString UTF8 signature
-        Assert.shouldEqual signature' (String.joinWith "\n" rawPayloadSignature)
+      Right signature -> Assert.shouldEqual signature rawPayloadSignature
   where
   verifyError err intended =
     unless (err == intended) do
@@ -77,7 +55,11 @@ spec = do
         ]
 
 pacchettibotti :: Owner
-pacchettibotti = Owner { email: "", keytype: "", public: "" }
+pacchettibotti = Owner
+  { email: "pacchettibotti@purescript.org"
+  , keytype: "ssh-rsa"
+  , public: "AAAAB3NzaC1yc2EAAAADAQABAAACAQDOHWfcD2vlrcaEngneZ2TlHjnjLKoQCuy9R95F1qrfRIE0N6xH7eHMuJGFIvqeuKivSXWLUKQslf2XIA7n0PEX0vmzzM7JZNvOkIFoOinBfCKqAx1dIle7yYPAUZPrzBidyLv+4aCJ+zu819yHA5tfoZB87+N0QAZcEptYw3taWHZGTZdNpgIgcpDGEnUihuQ9eYbdePokWbDsSgBT7AMjpAPTN5Yvg27jNNm6/WdooY7O9tP4Xdheb7GUIabKeNDX4sK0hBWVcS4SVTMVV8ifflKWXboJqIhXvUHcn1Te4o193aC+VgDFyzIAhPiZjfI/Fnha9XVPOXZMotIkJ0xiH7jzFljYshExCiecEDbLnV67Z/CEzVmw7kYTYs2+fpJ6cnJGHWIfaU2cz3C+empn3kZ6So+CM/8oHVpt0UjhTuqIav29OlouAxcv8eLPHPmTINyiaZ7b+slZBsNcUgW5r54sJvsXyzx9DQN+jkfwtucxN3JQcnIhZcYvD9KSZtHRtz9iLOYLL6Pimbb4K9l98+Br4G40Mjby3ElsAwtPGOLdimyZAD2t2eyDu64kOm2zS9jS6JJ9/8uKxlSyenUBxQ+ITwn1enEd4qq1qpnUT/F7PKqv9SSn6UBoMXq+uTFa5rXevOMhl7whAZjttyFokYQsacy6kbvlLMOWcsLqMw=="
+  }
 
 validOwner :: Owner
 validOwner = Owner
@@ -116,15 +98,8 @@ publicKey = "AAAAC3NzaC1lZDI1NTE5AAAAIF6B6R9yp8yFM3wYcOhGO0EyZAefKWkvsTET+KeaegY
 rawPayload :: String
 rawPayload = """{ "packageName": "foo", "unpublishVersion": "1.2.3", "unpublishReason": "Committed bad credentials" }"""
 
-rawPayloadSignature :: Array String
-rawPayloadSignature =
-  [ "-----BEGIN SSH SIGNATURE-----"
-  , "U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgXoHpH3KnzIUzfBhw6EY7QTJkB5"
-  , "8paS+xMRP4p5p6Bj8AAAAEZmlsZQAAAAAAAAAGc2hhNTEyAAAAUwAAAAtzc2gtZWQyNTUx"
-  , "OQAAAED8x4+yJphe3ELjnrVZLmPct/4w0R1KBryG2NnnRLY9sjQlrjMYGp+Gx6X0PQ7ylq"
-  , "xqhPdvut0pccR4WiMDjeIC"
-  , "-----END SSH SIGNATURE-----"
-  ]
+rawPayloadSignature :: Signature
+rawPayloadSignature = Signature "353588b6b6fe475c2be4afd72e4420acdfa66226234a0a09948cffa451e6554c5bced1e2f3e3aac668cb382317a939dde6348d33491ce31eca537011f6ab9e04"
 
 privateKey :: Array String
 privateKey =

--- a/app/test/App/Auth.purs
+++ b/app/test/App/Auth.purs
@@ -56,14 +56,14 @@ spec = do
 
 pacchettibotti :: Owner
 pacchettibotti = Owner
-  { comment: Just "pacchettibotti@purescript.org"
+  { id: Just "pacchettibotti@purescript.org"
   , keytype: "ssh-rsa"
   , public: "AAAAB3NzaC1yc2EAAAADAQABAAACAQDOHWfcD2vlrcaEngneZ2TlHjnjLKoQCuy9R95F1qrfRIE0N6xH7eHMuJGFIvqeuKivSXWLUKQslf2XIA7n0PEX0vmzzM7JZNvOkIFoOinBfCKqAx1dIle7yYPAUZPrzBidyLv+4aCJ+zu819yHA5tfoZB87+N0QAZcEptYw3taWHZGTZdNpgIgcpDGEnUihuQ9eYbdePokWbDsSgBT7AMjpAPTN5Yvg27jNNm6/WdooY7O9tP4Xdheb7GUIabKeNDX4sK0hBWVcS4SVTMVV8ifflKWXboJqIhXvUHcn1Te4o193aC+VgDFyzIAhPiZjfI/Fnha9XVPOXZMotIkJ0xiH7jzFljYshExCiecEDbLnV67Z/CEzVmw7kYTYs2+fpJ6cnJGHWIfaU2cz3C+empn3kZ6So+CM/8oHVpt0UjhTuqIav29OlouAxcv8eLPHPmTINyiaZ7b+slZBsNcUgW5r54sJvsXyzx9DQN+jkfwtucxN3JQcnIhZcYvD9KSZtHRtz9iLOYLL6Pimbb4K9l98+Br4G40Mjby3ElsAwtPGOLdimyZAD2t2eyDu64kOm2zS9jS6JJ9/8uKxlSyenUBxQ+ITwn1enEd4qq1qpnUT/F7PKqv9SSn6UBoMXq+uTFa5rXevOMhl7whAZjttyFokYQsacy6kbvlLMOWcsLqMw=="
   }
 
 validOwner :: Owner
 validOwner = Owner
-  { comment: Nothing
+  { id: Nothing
   , keytype
   , public: publicKey
   }

--- a/app/test/App/Auth.purs
+++ b/app/test/App/Auth.purs
@@ -70,8 +70,7 @@ validOwner = Owner
 
 validPayload :: AuthenticatedData
 validPayload =
-  { email
-  , signature: rawPayloadSignature
+  { signature: rawPayloadSignature
   , payload: Unpublish
       { name
       , version

--- a/lib/package.json
+++ b/lib/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "license": "BSD-3-Clause",
   "dependencies": {
-    "spdx-expression-parse": "^3.0.0"
+    "spdx-expression-parse": "^3.0.0",
+    "ssh2": "^1.11.0"
   }
 }

--- a/lib/src/Operation.purs
+++ b/lib/src/Operation.purs
@@ -94,7 +94,6 @@ type AuthenticatedData =
   { payload :: AuthenticatedPackageOperation
   , rawPayload :: String
   , signature :: Signature
-  , email :: String
   }
 
 -- | A codec for encoding and decoding authenticated operations as JSON.
@@ -102,7 +101,6 @@ authenticatedCodec :: JsonCodec AuthenticatedData
 authenticatedCodec = toPureScriptRep $ CA.Record.object "Authenticated"
   { payload: CA.string
   , signature: CA.string
-  , email: CA.string
   }
   where
   -- We first parse the payload as a simple string to use in verification so as
@@ -115,10 +113,10 @@ authenticatedCodec = toPureScriptRep $ CA.Record.object "Authenticated"
       rep <- CA.decode codec json
       payloadJson <- lmap (CA.TypeMismatch <<< append "Json: ") (Argonaut.Parser.jsonParser rep.payload)
       operation <- CA.decode payloadCodec payloadJson
-      pure { payload: operation, rawPayload: rep.payload, signature: Signature rep.signature, email: rep.email }
+      pure { payload: operation, rawPayload: rep.payload, signature: Signature rep.signature }
 
-    encode { rawPayload, email, signature: Signature signature } =
-      CA.encode codec { payload: rawPayload, email, signature }
+    encode { rawPayload, signature: Signature signature } =
+      CA.encode codec { payload: rawPayload, signature }
 
   -- The only acceptable payloads for an authenticated operation are the
   -- `AuthenticatedPackageOperation`s.

--- a/lib/src/Operation.purs
+++ b/lib/src/Operation.purs
@@ -45,6 +45,7 @@ import Registry.Location (Location)
 import Registry.Location as Location
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
+import Registry.SSH (Signature(..))
 import Registry.Version (Version)
 import Registry.Version as Version
 
@@ -92,7 +93,7 @@ publishCodec = CA.Record.object "Publish"
 type AuthenticatedData =
   { payload :: AuthenticatedPackageOperation
   , rawPayload :: String
-  , signature :: Array String
+  , signature :: Signature
   , email :: String
   }
 
@@ -100,7 +101,7 @@ type AuthenticatedData =
 authenticatedCodec :: JsonCodec AuthenticatedData
 authenticatedCodec = toPureScriptRep $ CA.Record.object "Authenticated"
   { payload: CA.string
-  , signature: CA.array CA.string
+  , signature: CA.string
   , email: CA.string
   }
   where
@@ -114,9 +115,9 @@ authenticatedCodec = toPureScriptRep $ CA.Record.object "Authenticated"
       rep <- CA.decode codec json
       payloadJson <- lmap (CA.TypeMismatch <<< append "Json: ") (Argonaut.Parser.jsonParser rep.payload)
       operation <- CA.decode payloadCodec payloadJson
-      pure { payload: operation, rawPayload: rep.payload, signature: rep.signature, email: rep.email }
+      pure { payload: operation, rawPayload: rep.payload, signature: Signature rep.signature, email: rep.email }
 
-    encode { rawPayload, email, signature } =
+    encode { rawPayload, email, signature: Signature signature } =
       CA.encode codec { payload: rawPayload, email, signature }
 
   -- The only acceptable payloads for an authenticated operation are the

--- a/lib/src/Operation/Validation.purs
+++ b/lib/src/Operation/Validation.purs
@@ -15,7 +15,7 @@ import Data.Maybe (Maybe(..))
 import Data.Newtype (un)
 import Data.String as String
 import Data.Time.Duration (Hours(..))
-import Data.Traversable (for, traverse)
+import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..), uncurry)
 import Data.Tuple.Nested (type (/\), (/\))
 import Effect.Aff as Aff

--- a/lib/src/Owner.purs
+++ b/lib/src/Owner.purs
@@ -14,12 +14,13 @@ import Prelude
 import Data.Codec.Argonaut (JsonCodec)
 import Data.Codec.Argonaut as CA
 import Data.Codec.Argonaut.Record as CA.Record
+import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Data.Profunctor as Profunctor
 
 -- | A public key which can be used to authenticate package operations.
 newtype Owner = Owner
-  { email :: String
+  { comment :: Maybe String
   , keytype :: String
   , public :: String
   }
@@ -31,7 +32,7 @@ derive newtype instance Eq Owner
 -- | object.
 codec :: JsonCodec Owner
 codec = Profunctor.wrapIso Owner $ CA.Record.object "Owner"
-  { email: CA.string
+  { comment: CA.Record.optional CA.string
   , keytype: CA.string
   , public: CA.string
   }

--- a/lib/src/Owner.purs
+++ b/lib/src/Owner.purs
@@ -20,7 +20,7 @@ import Data.Profunctor as Profunctor
 
 -- | A public key which can be used to authenticate package operations.
 newtype Owner = Owner
-  { comment :: Maybe String
+  { id :: Maybe String
   , keytype :: String
   , public :: String
   }
@@ -32,7 +32,7 @@ derive newtype instance Eq Owner
 -- | object.
 codec :: JsonCodec Owner
 codec = Profunctor.wrapIso Owner $ CA.Record.object "Owner"
-  { comment: CA.Record.optional CA.string
+  { id: CA.Record.optional CA.string
   , keytype: CA.string
   , public: CA.string
   }

--- a/lib/src/SSH.js
+++ b/lib/src/SSH.js
@@ -9,12 +9,12 @@ export function parseKeyImpl(left, right, buffer, passphrase) {
   }
 }
 
-export function signImpl(parsedKey, buffer) {
-  return parsedKey.sign(buffer);
+export function signImpl(parsedKey, data) {
+  return parsedKey.sign(data).toString("hex");
 }
 
-export function verifyImpl(parsedKey, buffer, signature) {
-  return parsedKey.verify(buffer, signature);
+export function verifyImpl(parsedKey, data, signature) {
+  return parsedKey.verify(data, Buffer.from(signature, "hex"));
 }
 
 export function keyTypeImpl(parsedKey) {

--- a/lib/src/SSH.js
+++ b/lib/src/SSH.js
@@ -1,0 +1,30 @@
+import ssh2 from "ssh2";
+
+export function parseKeyImpl(left, right, buffer, passphrase) {
+  const parsed = ssh2.utils.parseKey(buffer, passphrase);
+  if (parsed && parsed.type && parsed.comment) {
+    return right(parsed);
+  } else {
+    return left(parsed);
+  }
+}
+
+export function signImpl(parsedKey, buffer) {
+  return parsedKey.sign(buffer);
+}
+
+export function verifyImpl(parsedKey, buffer, signature) {
+  return parsedKey.verify(buffer, signature);
+}
+
+export function keyTypeImpl(parsedKey) {
+  return parsedKey.type;
+}
+
+export function isPrivateKeyImpl(parsedKey) {
+  return parsedKey.isPrivateKey();
+}
+
+export function equalsImpl(a, b) {
+  return a.equals(b);
+}

--- a/lib/src/SSH.purs
+++ b/lib/src/SSH.purs
@@ -1,7 +1,7 @@
 module Registry.SSH
   ( PublicKey
   , PrivateKey
-  , SignedData
+  , Signature(..)
   , parsePublicKey
   , parsePrivateKey
   , parsePrivateKeyWithPassword
@@ -13,30 +13,33 @@ import Prelude
 
 import Data.Either (Either(..))
 import Data.Function.Uncurried (Fn1, Fn2, Fn3, Fn4, runFn1, runFn2, runFn3, runFn4)
+import Data.Newtype (class Newtype)
 import Data.Nullable (Nullable, notNull, null)
-import Effect.Exception (Error)
 import Effect.Exception as Exception
-import Node.Buffer (Buffer)
 
 -- | A parsed SSH public key which can be used to verify payloads.
 newtype PublicKey = PublicKey ParsedKey
 
+derive instance Eq PublicKey
+
 -- | A parsed SSH private key which can be used to sign payloads.
 newtype PrivateKey = PrivateKey ParsedKey
+
+derive instance Eq PrivateKey
 
 data ParsedKey
 
 instance Eq ParsedKey where
   eq a b = runFn2 equalsImpl a b
 
-foreign import parseKeyImpl :: forall r. Fn4 (Error -> r) (ParsedKey -> r) String (Nullable String) r
+foreign import parseKeyImpl :: forall r. Fn4 (Exception.Error -> r) (ParsedKey -> r) String (Nullable String) r
 
 parse :: String -> Either String ParsedKey
 parse buf = runFn4 parseKeyImpl (Left <<< Exception.message) Right buf null
 
 -- | Parse a non-password-protected private SSH key
 parsePrivateKey :: String -> Either String PrivateKey
-parsePrivateKey buffer = case parse buffer of
+parsePrivateKey key = case parse key of
   Right parsed | not (isPrivateKey parsed) -> Left $ "Expected private key, but this is a public key of type " <> keyType parsed
   result -> map PrivateKey result
 
@@ -49,27 +52,28 @@ parsePrivateKeyWithPassword { key, passphrase } =
 
 -- | Parse a public SSH key
 parsePublicKey :: String -> Either String PublicKey
-parsePublicKey buffer = case parse buffer of
+parsePublicKey key = case parse key of
   Right parsed | isPrivateKey parsed -> Left $ "Expected public key, but this is a private key of type " <> keyType parsed
   result -> map PublicKey result
 
--- | A pair of data and a signature from the data being signed by a SSH key.
-type SignedData = { data :: String, signature :: Buffer }
+-- | A hex-encoded SSH signature
+newtype Signature = Signature String
 
-foreign import signImpl :: Fn2 ParsedKey String Buffer
+derive instance Newtype Signature _
+derive newtype instance Eq Signature
+
+foreign import signImpl :: Fn2 ParsedKey String Signature
 
 -- | Sign a payload using a parsed SSH key. Returns the signature.
-sign :: PrivateKey -> String -> SignedData
-sign (PrivateKey key) buffer = do
-  let signature = runFn2 signImpl key buffer
-  { data: buffer, signature }
+sign :: PrivateKey -> String -> Signature
+sign (PrivateKey key) = runFn2 signImpl key
 
-foreign import verifyImpl :: Fn3 ParsedKey String Buffer Boolean
+foreign import verifyImpl :: Fn3 ParsedKey String Signature Boolean
 
 -- | Verify that a payload was signed using the given key by matching the data,
 -- | signature, and public key against one another.
-verify :: PublicKey -> SignedData -> Boolean
-verify (PublicKey key) payload = runFn3 verifyImpl key payload.data payload.signature
+verify :: PublicKey -> String -> Signature -> Boolean
+verify (PublicKey key) payload signature = runFn3 verifyImpl key payload signature
 
 foreign import keyTypeImpl :: Fn1 ParsedKey String
 

--- a/lib/src/SSH.purs
+++ b/lib/src/SSH.purs
@@ -1,0 +1,65 @@
+module Registry.SSH
+  ( ParsedKey
+  , parse
+  , parsePrivate
+  , sign
+  , verify
+  , SignedData
+  , keyType
+  , isPrivateKey
+  ) where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Function.Uncurried (Fn1, Fn2, Fn3, Fn4, runFn1, runFn2, runFn3, runFn4)
+import Data.Maybe (Maybe(..))
+import Data.Nullable (Nullable, toNullable)
+import Effect.Exception (Error)
+import Effect.Exception as Exception
+import Node.Buffer (Buffer)
+
+-- | A parsed SSH key which can be used to sign or verify payloads.
+data ParsedKey
+
+instance Eq ParsedKey where
+  eq a b = runFn2 equalsImpl a b
+
+foreign import parseKeyImpl :: forall r. Fn4 (Error -> r) (ParsedKey -> r) Buffer (Nullable Buffer) r
+
+-- | Parse a public or non-password-protected SSH key
+parse :: Buffer -> Either String ParsedKey
+parse buf = parsePrivate { key: buf, passphrase: Nothing }
+
+-- | Parse a password-protected SSH key
+parsePrivate :: { key :: Buffer, passphrase :: Maybe Buffer } -> Either String ParsedKey
+parsePrivate { key, passphrase } = runFn4 parseKeyImpl (Left <<< Exception.message) Right key (toNullable passphrase)
+
+foreign import signImpl :: Fn2 ParsedKey Buffer Buffer
+
+-- | Sign a payload using a parsed SSH key. Returns the signature.
+sign :: ParsedKey -> Buffer -> Buffer
+sign key = runFn2 signImpl key
+
+foreign import verifyImpl :: Fn3 ParsedKey Buffer Buffer Boolean
+
+type SignedData = { data :: Buffer, signature :: Buffer }
+
+-- | Verify that a payload was signed using the given key by matching the data,
+-- | signature, and public key against one another.
+verify :: ParsedKey -> SignedData -> Boolean
+verify key payload = runFn3 verifyImpl key payload.data payload.signature
+
+foreign import keyTypeImpl :: Fn1 ParsedKey String
+
+-- | Retrieve the type of a key, such as ssh-rsa
+keyType :: ParsedKey -> String
+keyType = runFn1 keyTypeImpl
+
+foreign import isPrivateKeyImpl :: Fn1 ParsedKey Boolean
+
+-- | Determine whether a parsed key is a private or public key.
+isPrivateKey :: ParsedKey -> Boolean
+isPrivateKey = runFn1 isPrivateKeyImpl
+
+foreign import equalsImpl :: Fn2 ParsedKey ParsedKey Boolean

--- a/lib/src/SSH.purs
+++ b/lib/src/SSH.purs
@@ -16,6 +16,7 @@ import Data.Function.Uncurried (Fn1, Fn2, Fn3, Fn4, runFn1, runFn2, runFn3, runF
 import Data.Nullable (Nullable, notNull, null)
 import Effect.Exception (Error)
 import Effect.Exception as Exception
+import Node.Buffer (Buffer)
 
 -- | A parsed SSH public key which can be used to verify payloads.
 newtype PublicKey = PublicKey ParsedKey
@@ -53,9 +54,9 @@ parsePublicKey buffer = case parse buffer of
   result -> map PublicKey result
 
 -- | A pair of data and a signature from the data being signed by a SSH key.
-type SignedData = { data :: String, signature :: String }
+type SignedData = { data :: String, signature :: Buffer }
 
-foreign import signImpl :: Fn2 ParsedKey String String
+foreign import signImpl :: Fn2 ParsedKey String Buffer
 
 -- | Sign a payload using a parsed SSH key. Returns the signature.
 sign :: PrivateKey -> String -> SignedData
@@ -63,7 +64,7 @@ sign (PrivateKey key) buffer = do
   let signature = runFn2 signImpl key buffer
   { data: buffer, signature }
 
-foreign import verifyImpl :: Fn3 ParsedKey String String Boolean
+foreign import verifyImpl :: Fn3 ParsedKey String Buffer Boolean
 
 -- | Verify that a payload was signed using the given key by matching the data,
 -- | signature, and public key against one another.

--- a/lib/src/SSH.purs
+++ b/lib/src/SSH.purs
@@ -1,25 +1,29 @@
 module Registry.SSH
-  ( ParsedKey
-  , parse
-  , parsePrivate
+  ( PublicKey
+  , PrivateKey
+  , SignedData
+  , parsePublicKey
+  , parsePrivateKey
+  , parsePrivateKeyWithPassword
   , sign
   , verify
-  , SignedData
-  , keyType
-  , isPrivateKey
   ) where
 
 import Prelude
 
 import Data.Either (Either(..))
 import Data.Function.Uncurried (Fn1, Fn2, Fn3, Fn4, runFn1, runFn2, runFn3, runFn4)
-import Data.Maybe (Maybe(..))
-import Data.Nullable (Nullable, toNullable)
+import Data.Nullable (Nullable, notNull, null)
 import Effect.Exception (Error)
 import Effect.Exception as Exception
 import Node.Buffer (Buffer)
 
--- | A parsed SSH key which can be used to sign or verify payloads.
+-- | A parsed SSH public key which can be used to verify payloads.
+newtype PublicKey = PublicKey ParsedKey
+
+-- | A parsed SSH private key which can be used to sign payloads.
+newtype PrivateKey = PrivateKey ParsedKey
+
 data ParsedKey
 
 instance Eq ParsedKey where
@@ -27,28 +31,45 @@ instance Eq ParsedKey where
 
 foreign import parseKeyImpl :: forall r. Fn4 (Error -> r) (ParsedKey -> r) Buffer (Nullable Buffer) r
 
--- | Parse a public or non-password-protected SSH key
 parse :: Buffer -> Either String ParsedKey
-parse buf = parsePrivate { key: buf, passphrase: Nothing }
+parse buf = runFn4 parseKeyImpl (Left <<< Exception.message) Right buf null
 
--- | Parse a password-protected SSH key
-parsePrivate :: { key :: Buffer, passphrase :: Maybe Buffer } -> Either String ParsedKey
-parsePrivate { key, passphrase } = runFn4 parseKeyImpl (Left <<< Exception.message) Right key (toNullable passphrase)
+-- | Parse a non-password-protected private SSH key
+parsePrivateKey :: Buffer -> Either String PrivateKey
+parsePrivateKey buffer = case parse buffer of
+  Right parsed | not (isPrivateKey parsed) -> Left $ "Expected private key, but this is a public key of type " <> keyType parsed
+  result -> map PrivateKey result
+
+-- | Parse a password-protected private SSH key
+parsePrivateKeyWithPassword :: { key :: Buffer, passphrase :: Buffer } -> Either String PrivateKey
+parsePrivateKeyWithPassword { key, passphrase } =
+  case runFn4 parseKeyImpl (Left <<< Exception.message) Right key (notNull passphrase) of
+    Right parsed | not (isPrivateKey parsed) -> Left $ "Expected private key, but this is a public key of type " <> keyType parsed
+    result -> map PrivateKey result
+
+-- | Parse a public SSH key
+parsePublicKey :: Buffer -> Either String PublicKey
+parsePublicKey buffer = case parse buffer of
+  Right parsed | isPrivateKey parsed -> Left $ "Expected public key, but this is a private key of type " <> keyType parsed
+  result -> map PublicKey result
+
+-- | A pair of data and a signature from the data being signed by a SSH key.
+type SignedData = { data :: Buffer, signature :: Buffer }
 
 foreign import signImpl :: Fn2 ParsedKey Buffer Buffer
 
 -- | Sign a payload using a parsed SSH key. Returns the signature.
-sign :: ParsedKey -> Buffer -> Buffer
-sign key = runFn2 signImpl key
+sign :: PrivateKey -> Buffer -> SignedData
+sign (PrivateKey key) buffer = do
+  let signature = runFn2 signImpl key buffer
+  { data: buffer, signature }
 
 foreign import verifyImpl :: Fn3 ParsedKey Buffer Buffer Boolean
 
-type SignedData = { data :: Buffer, signature :: Buffer }
-
 -- | Verify that a payload was signed using the given key by matching the data,
 -- | signature, and public key against one another.
-verify :: ParsedKey -> SignedData -> Boolean
-verify key payload = runFn3 verifyImpl key payload.data payload.signature
+verify :: PublicKey -> SignedData -> Boolean
+verify (PublicKey key) payload = runFn3 verifyImpl key payload.data payload.signature
 
 foreign import keyTypeImpl :: Fn1 ParsedKey String
 

--- a/lib/test/Registry.purs
+++ b/lib/test/Registry.purs
@@ -36,7 +36,7 @@ main = Aff.launchAff_ $ Spec.Runner.runSpec [ Spec.Reporter.consoleReporter ] do
     Spec.describe "Package Set" Test.PackageSet.spec
     Spec.describe "Operation" Test.Operation.spec
 
-  Spec.describeOnly "SSH" Test.SSH.spec
+  Spec.describe "SSH" Test.SSH.spec
   Spec.describe "ManifestIndex" Test.ManifestIndex.spec
   Spec.describe "Solver" Test.Solver.spec
   Spec.describe "Operation Validation" Test.Operation.Validation.spec

--- a/lib/test/Registry.purs
+++ b/lib/test/Registry.purs
@@ -13,6 +13,7 @@ import Test.Registry.Operation.Validation as Test.Operation.Validation
 import Test.Registry.PackageName as Test.PackageName
 import Test.Registry.PackageSet as Test.PackageSet
 import Test.Registry.Range as Test.Range
+import Test.Registry.SSH as Test.SSH
 import Test.Registry.Sha256 as Test.Sha256
 import Test.Registry.Solver as Test.Solver
 import Test.Registry.Version as Test.Version
@@ -35,6 +36,7 @@ main = Aff.launchAff_ $ Spec.Runner.runSpec [ Spec.Reporter.consoleReporter ] do
     Spec.describe "Package Set" Test.PackageSet.spec
     Spec.describe "Operation" Test.Operation.spec
 
+  Spec.describeOnly "SSH" Test.SSH.spec
   Spec.describe "ManifestIndex" Test.ManifestIndex.spec
   Spec.describe "Solver" Test.Solver.spec
   Spec.describe "Operation Validation" Test.Operation.Validation.spec

--- a/lib/test/Registry/Operation.purs
+++ b/lib/test/Registry/Operation.purs
@@ -76,11 +76,7 @@ unpublish =
 {
   "email": "pacchettibotti@purescript.org",
   "payload": "{ \"name\": \"my-package\", \"version\": \"0.15.6\", \"reason\": \"Committed credentials.\" }",
-  "signature": [
-    "abc123",
-    "abc123",
-    "abc123"
-  ]
+  "signature": "1f4967eaa5de1076bb2185b818ea4fb7c18cfe83af951ab32c3bcb4a300dfe9b3795daaae1e7a6d5fb9f72c4cec8003f79a452f2dc9da9ec8cfa63b243c80503"
 }"""
 
 transfer :: String
@@ -89,9 +85,5 @@ transfer =
 {
   "email": "pacchettibotti@purescript.org",
   "payload": "{ \"name\": \"my-package\", \"newLocation\": { \"githubOwner\": \"purescript-deprecated\", \"githubRepo\": \"purescript-my-package\" } }",
-  "signature": [
-    "abc123",
-    "abc123",
-    "abc123"
-  ]
+  "signature": "1f4967eaa5de1076bb2185b818ea4fb7c18cfe83af951ab32c3bcb4a300dfe9b3795daaae1e7a6d5fb9f72c4cec8003f79a452f2dc9da9ec8cfa63b243c80503"
 }"""

--- a/lib/test/Registry/Operation.purs
+++ b/lib/test/Registry/Operation.purs
@@ -74,7 +74,6 @@ unpublish :: String
 unpublish =
   """
 {
-  "email": "pacchettibotti@purescript.org",
   "payload": "{ \"name\": \"my-package\", \"version\": \"0.15.6\", \"reason\": \"Committed credentials.\" }",
   "signature": "1f4967eaa5de1076bb2185b818ea4fb7c18cfe83af951ab32c3bcb4a300dfe9b3795daaae1e7a6d5fb9f72c4cec8003f79a452f2dc9da9ec8cfa63b243c80503"
 }"""
@@ -83,7 +82,6 @@ transfer :: String
 transfer =
   """
 {
-  "email": "pacchettibotti@purescript.org",
   "payload": "{ \"name\": \"my-package\", \"newLocation\": { \"githubOwner\": \"purescript-deprecated\", \"githubRepo\": \"purescript-my-package\" } }",
   "signature": "1f4967eaa5de1076bb2185b818ea4fb7c18cfe83af951ab32c3bcb4a300dfe9b3795daaae1e7a6d5fb9f72c4cec8003f79a452f2dc9da9ec8cfa63b243c80503"
 }"""

--- a/lib/test/Registry/SSH.purs
+++ b/lib/test/Registry/SSH.purs
@@ -1,0 +1,150 @@
+module Test.Registry.SSH (spec) where
+
+import Prelude
+
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Data.String as String
+import Effect.Class (liftEffect)
+import Node.Buffer as Buffer
+import Node.Encoding (Encoding(..))
+import Registry.SSH as SSH
+import Registry.Test.Assert as Assert
+import Registry.Test.Utils as Utils
+import Test.Spec as Spec
+
+spec :: Spec.Spec Unit
+spec = do
+  Spec.it "Parses an ED25519 private key" do
+    privateKey <- liftEffect $ Buffer.fromString id_ed25519 UTF8
+    case SSH.parse privateKey of
+      Left err -> Assert.fail $ "Failed to parse ed_25519 private key: " <> err
+      Right parsed -> do
+        SSH.keyType parsed `Assert.shouldEqual` "ssh-ed25519"
+        SSH.isPrivateKey parsed `Assert.shouldEqual` true
+
+  Spec.it "Parses an ED25519 public key" do
+    pubkey <- liftEffect $ Buffer.fromString id_ed25519_pub UTF8
+    case SSH.parse pubkey of
+      Left err ->
+        Assert.fail $ "Failed to parse ed_25519 public key: " <> err
+      Right parsed -> do
+        SSH.keyType parsed `Assert.shouldEqual` "ssh-ed25519"
+        SSH.isPrivateKey parsed `Assert.shouldEqual` false
+
+  Spec.it "Parses a password-protected RSA private key" do
+    privateKey <- liftEffect $ Buffer.fromString id_rsa UTF8
+    password <- liftEffect $ Buffer.fromString id_rsa_password UTF8
+    case SSH.parse privateKey of
+      Left err1 -> do
+        err1 `Assert.shouldEqual` "Encrypted private OpenSSH key detected, but no passphrase given"
+        case SSH.parsePrivate { key: privateKey, passphrase: Just password } of
+          Left err2 ->
+            Assert.fail $ "Failed to parse id_rsa private key with password: " <> err2
+          Right parsed -> do
+            SSH.keyType parsed `Assert.shouldEqual` "ssh-rsa"
+            SSH.isPrivateKey parsed `Assert.shouldEqual` true
+      Right parsed ->
+        Assert.fail $ "Expected parse failure, but got key " <> SSH.keyType parsed
+
+  Spec.it "Parses an RSA public key" do
+    pubkey <- liftEffect $ Buffer.fromString id_rsa_pub UTF8
+    case SSH.parse pubkey of
+      Left err -> Assert.fail $ "Failed to parse rsa public key: " <> err
+      Right parsed -> do
+        SSH.keyType parsed `Assert.shouldEqual` "ssh-rsa"
+        SSH.isPrivateKey parsed `Assert.shouldEqual` false
+
+  Spec.it "Signs and verifies payload" do
+    let privateKey = Utils.unsafeSSHKey id_ed25519
+    payloadBuffer <- liftEffect $ Buffer.fromString payload UTF8
+    let signedBuffer = SSH.sign privateKey payloadBuffer
+    unless (SSH.verify privateKey { data: payloadBuffer, signature: signedBuffer }) do
+      Assert.fail "Failed to verify signed payload."
+
+-- ssh-keygen -t ed25519 -C "your_email@example.com"
+id_ed25519 :: String
+id_ed25519 = String.joinWith "\n"
+  [ "-----BEGIN OPENSSH PRIVATE KEY-----"
+  , "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW"
+  , "QyNTUxOQAAACDdKoRtqQVRN+v7q4GpWn2oeJ3c6uKVhuMWenLEX3YFcAAAAKAMzocpDM6H"
+  , "KQAAAAtzc2gtZWQyNTUxOQAAACDdKoRtqQVRN+v7q4GpWn2oeJ3c6uKVhuMWenLEX3YFcA"
+  , "AAAEBx28Ox8iudqyeko/fOF47/79/HnNKyHsEIk3jPtr0CzN0qhG2pBVE36/urgalafah4"
+  , "ndzq4pWG4xZ6csRfdgVwAAAAFnlvdXJfZW1haWxAZXhhbXBsZS5jb20BAgMEBQYH"
+  , "-----END OPENSSH PRIVATE KEY-----"
+  ]
+
+id_ed25519_pub :: String
+id_ed25519_pub = String.joinWith " "
+  [ "ssh-ed25519"
+  , "AAAAC3NzaC1lZDI1NTE5AAAAIN0qhG2pBVE36/urgalafah4ndzq4pWG4xZ6csRfdgVw"
+  , "your_email@example.com"
+  ]
+
+-- ssh-keygen -t rsa -b 4096 -C "your_email@example.com"
+id_rsa :: String
+id_rsa = String.joinWith "\n"
+  [ "-----BEGIN OPENSSH PRIVATE KEY-----"
+  , "b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABBmy/ohkF"
+  , "9UYcgUOG4pSBPdAAAAEAAAAAEAAAIXAAAAB3NzaC1yc2EAAAADAQABAAACAQDOHWfcD2vl"
+  , "rcaEngneZ2TlHjnjLKoQCuy9R95F1qrfRIE0N6xH7eHMuJGFIvqeuKivSXWLUKQslf2XIA"
+  , "7n0PEX0vmzzM7JZNvOkIFoOinBfCKqAx1dIle7yYPAUZPrzBidyLv+4aCJ+zu819yHA5tf"
+  , "oZB87+N0QAZcEptYw3taWHZGTZdNpgIgcpDGEnUihuQ9eYbdePokWbDsSgBT7AMjpAPTN5"
+  , "Yvg27jNNm6/WdooY7O9tP4Xdheb7GUIabKeNDX4sK0hBWVcS4SVTMVV8ifflKWXboJqIhX"
+  , "vUHcn1Te4o193aC+VgDFyzIAhPiZjfI/Fnha9XVPOXZMotIkJ0xiH7jzFljYshExCiecED"
+  , "bLnV67Z/CEzVmw7kYTYs2+fpJ6cnJGHWIfaU2cz3C+empn3kZ6So+CM/8oHVpt0UjhTuqI"
+  , "av29OlouAxcv8eLPHPmTINyiaZ7b+slZBsNcUgW5r54sJvsXyzx9DQN+jkfwtucxN3JQcn"
+  , "IhZcYvD9KSZtHRtz9iLOYLL6Pimbb4K9l98+Br4G40Mjby3ElsAwtPGOLdimyZAD2t2eyD"
+  , "u64kOm2zS9jS6JJ9/8uKxlSyenUBxQ+ITwn1enEd4qq1qpnUT/F7PKqv9SSn6UBoMXq+uT"
+  , "Fa5rXevOMhl7whAZjttyFokYQsacy6kbvlLMOWcsLqMwAAB1BlCh6hghDjksoDC+To4PA2"
+  , "jQmCdyODiejDlpeBFjaKrYCfi1ZV8Q7FeIARo7zX094r5FPMkVR0Kvl5uVDVJPp1fC/wZ4"
+  , "MOUaOFQDCetK+IWmB2nzb71/xgQbdNESXeBBnVvI6EYiM9seU+Cq8S+qZix69ifYyqKZCo"
+  , "jmB/3WwVvdPa3moX3d4zQz3eWu6qLkcZHZuhMtM6AKFRMYky8lj8J0F0EgNq6rRmysBALT"
+  , "2U0IjKrx43yvaU3rzYcwoDHwe1gVKQM+rP7hZZ7OvQXk9QLrfFXWPFdrXDA/A2w0eZtS2q"
+  , "CRbwV3xJS4+AwYtmeH6Z4Q0Q9OoAnG9oIH643rmUFeeNBtJSuNIxOTibRDfRXj+E5AO3Ru"
+  , "62hcfzOl6LbXYDQYn9nraqNkYD9VMGu2uGVrYuz7jFMFZenFfRqw5/3UgMISC0a6AQw2Es"
+  , "lXgOJRsEggGlc7/8tTP3GHcDx4UF4GfTk8xzrXI7hgkFRT6nG+giVO1xNGnJxmAuPtBVRU"
+  , "GQ+WBH61oK7vw39iKewb6TkrTWza3/WuUa4C1tVO/cg4PfyDFQE8vV58z43p2PJ9ezqsBo"
+  , "EjuAcstNes73cMY1nt+jn/9XB+J5ZsukoG4Alw0mqapd/wlAzH0riWvVueO4uhZVWTft/O"
+  , "FiFS2fxjVy2ceNQq0930GenejwFM9c7o80pOajFixl8dbfJ3sIViy0CjgfeCc5Z9py2zPT"
+  , "durwMKnGFwvC+CctZCPvdWded3WOQgmz1GrWXyXvQS6bwVLQ+hJ5MtKdO+PfGicU6uEIbl"
+  , "nthZLF2DxjVE52GfkHM5btLfK+jmetLu3FcYCsx5E1ND1MWz2K7K9Yd9GJBoQ+d6NJl7Lm"
+  , "1laiLiCrgGheCgNsgldrDSYSpilg+BYil4z8RZGJ4CjpjsIEg1W1uIlKQxB+3MV1qDiCkX"
+  , "eSWgdpsxDjQD6Ep35e3j4G92AG3DCmsLahz/q9rUBRUHiHPLCAqWiqP1+NZJLMLFKYL2QE"
+  , "z5rEnm+xb0MytbUJsANkFActyyyPAS+Ts2u/3gNK4pPJ/gz1z3S0s7MdsV8qZ6kCR394fu"
+  , "XjZEoOh2bILMtsevZO78+BS8/dOlobpPh6KllDYsYVbkUxJC5aHtwXhPPS1FKyslyTnLAN"
+  , "ffKVkg5Tshxydi4d1hLBjXawfKAly9Nzo8jSlSydWz8HAqGoBypP3rJ69zw3Z+kb19QQyU"
+  , "M8YmCcA1PQdwoFaEyHIrsm2DfL/xnJVe3D+CRvWRoS9xZk9yggMp3SxF47doC6L6v56Fnk"
+  , "SKLzTe/wm1QrRvIYTQy9aMhmbMUVZ3IUNrEOY9wjj86qPJRniNAHq0LdZJIp1Y4SMPHEiD"
+  , "F6a7d9+it3sqp7lANJfMWhhz0YEVADAPTorSfBxuO6cDmqpfPkGBrBv9qEe5oFeU08HpOO"
+  , "O2u2ywj7YJIThPgHfCjrpVBz2gWtKw5qSWtdH0UiH/VJmoeN511n9yN5aGgbICK9oiLFM3"
+  , "CL0bHx4svafQxdEhvlNoBjzu7AMIVo7n+xfKPZI+q0/WpLY6Yx1G8Y8ivpk0L/DeDhTgSW"
+  , "YuKp+8KkRETgb/fD5GlvPtHTHqgHjpoKKvjcM6DF45En85/3iGz0jEzzVbzWkJzy9iYVul"
+  , "O246AAJla6ga8SRHbwTxw/d8AaFJnBYVw/zpG51yfIQxVqmKdthdChIoY4az8/ywByq1QR"
+  , "q0ujP46dk7CfBqCUMBFG3vh1ndTM7WkutDO17UXLYROQnrTsJQvErWSGzcFBydtfxuH0e3"
+  , "DnIcZKbbgs7RhySx1FFTDnyNBLyTFASVG4pvGIk6hVas5VEdySu6JPWm3lX37G2D7H/P8M"
+  , "bQ8AvuRbDGTYcbzmvwtPTb1cea6ZwZ8r1/OPr7fN+tBKgERG9U8vd9wq2h77FZ5nRvRu9k"
+  , "FGEPaQXUL95D2dMme4iYjBwBSHsY1bR2l0w1wKN5wdaDYNK09NPJGI4jg/z9rV1lzZ3XVH"
+  , "IqKBF0R1toe7fvps7kok6zDUUZtJyuTBVIDr1JC6HJU/Wv7ZvuJguUK/GM/9ZxeKGhefVQ"
+  , "EjWnI3M8kryz6wPBPcJz73Yl3EXiTcejiz5AWXo88QvJ3nWvK4A0SfWhVr0e7n7NaboMhb"
+  , "Co6+CLsN3t5w9nZE4dWfOchPQWdTmv48BrO6fraMdvnyNuiR7vjQv0AdtL4fRJWruIOCM3"
+  , "RR8dhUT2ci5EW2iIrwJ9OwXO2Zr+ERWHIkDWB27IKPuFycS9R/L9jowdSJ/INRdHS8jCnf"
+  , "xLdcnMsfbIFdKkpV9ROVPxbVVOVskKLZtg6nI8F5/lkUnaVN7X5zNCmcAWL85oLW19kG64"
+  , "Q6J6qwPHQ8JRpCelonvlySSGHjIy1ONfJnLU3EgtOm7FWU5mF7TTDieH8zmJVOTWmUovPa"
+  , "laO5cnDuuOvz0KPWyYrekCoIYtwc5G2l1KB3bddUh8Xq78A1/GNKbD6o8kADqYHHGnOG9e"
+  , "EwKrIJasPflNRLac079nrRaPw="
+  , "-----END OPENSSH PRIVATE KEY-----"
+  ]
+
+id_rsa_pub :: String
+id_rsa_pub = String.joinWith " "
+  [ "ssh-rsa"
+  , "AAAAB3NzaC1yc2EAAAADAQABAAACAQDOHWfcD2vlrcaEngneZ2TlHjnjLKoQCuy9R95F1qrfRIE0N6xH7eHMuJGFIvqeuKivSXWLUKQslf2XIA7n0PEX0vmzzM7JZNvOkIFoOinBfCKqAx1dIle7yYPAUZPrzBidyLv+4aCJ+zu819yHA5tfoZB87+N0QAZcEptYw3taWHZGTZdNpgIgcpDGEnUihuQ9eYbdePokWbDsSgBT7AMjpAPTN5Yvg27jNNm6/WdooY7O9tP4Xdheb7GUIabKeNDX4sK0hBWVcS4SVTMVV8ifflKWXboJqIhXvUHcn1Te4o193aC+VgDFyzIAhPiZjfI/Fnha9XVPOXZMotIkJ0xiH7jzFljYshExCiecEDbLnV67Z/CEzVmw7kYTYs2+fpJ6cnJGHWIfaU2cz3C+empn3kZ6So+CM/8oHVpt0UjhTuqIav29OlouAxcv8eLPHPmTINyiaZ7b+slZBsNcUgW5r54sJvsXyzx9DQN+jkfwtucxN3JQcnIhZcYvD9KSZtHRtz9iLOYLL6Pimbb4K9l98+Br4G40Mjby3ElsAwtPGOLdimyZAD2t2eyDu64kOm2zS9jS6JJ9/8uKxlSyenUBxQ+ITwn1enEd4qq1qpnUT/F7PKqv9SSn6UBoMXq+uTFa5rXevOMhl7whAZjttyFokYQsacy6kbvlLMOWcsLqMw=="
+  , "your_email@example.com"
+  ]
+
+id_rsa_password :: String
+id_rsa_password = "abc123"
+
+payload :: String
+payload = "{ \"name\": \"node-os\", \"newLocation\": { \"githubOwner\": \"purescript-node\", \"githubRepo\": \"purescript-node-os\" } }"

--- a/lib/test/Registry/Test/Utils.purs
+++ b/lib/test/Registry/Test/Utils.purs
@@ -87,9 +87,13 @@ unsafeDateTime str = fromRight ("Failed to parse DateTime: " <> str) (DateTime.F
 unsafeDate :: String -> Date.Date
 unsafeDate str = fromRight ("Failed to parse Date: " <> str) (map Date.date $ DateTime.Formatters.unformat Internal.Format.iso8601Date str)
 
--- | Unsafely parse a SSH key from a string
-unsafeSSHKey :: String -> SSH.ParsedKey
-unsafeSSHKey str = fromRight ("Failed to parse SSH key: " <> str) (SSH.parse (unsafePerformEffect (Buffer.fromString str UTF8)))
+-- | Unsafely parse a public SSH key from a string
+unsafeSSHPublicKey :: String -> SSH.PublicKey
+unsafeSSHPublicKey str = fromRight ("Failed to parse SSH key: " <> str) (SSH.parsePublicKey (unsafePerformEffect (Buffer.fromString str UTF8)))
+
+-- | Unsafely parse a private SSH key from a string
+unsafeSSHPrivateKey :: String -> SSH.PrivateKey
+unsafeSSHPrivateKey str = fromRight ("Failed to parse SSH key: " <> str) (SSH.parsePrivateKey (unsafePerformEffect (Buffer.fromString str UTF8)))
 
 -- | Unsafely create a manifest from a name, version, and array of dependencies
 -- | where keys are package names and values are ranges.

--- a/lib/test/Registry/Test/Utils.purs
+++ b/lib/test/Registry/Test/Utils.purs
@@ -14,9 +14,6 @@ import Data.Formatter.DateTime as DateTime.Formatters
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple)
-import Effect.Unsafe (unsafePerformEffect)
-import Node.Buffer as Buffer
-import Node.Encoding (Encoding(..))
 import Partial.Unsafe (unsafeCrashWith)
 import Partial.Unsafe as Partial
 import Registry.Internal.Format as Internal.Format
@@ -89,11 +86,11 @@ unsafeDate str = fromRight ("Failed to parse Date: " <> str) (map Date.date $ Da
 
 -- | Unsafely parse a public SSH key from a string
 unsafeSSHPublicKey :: String -> SSH.PublicKey
-unsafeSSHPublicKey str = fromRight ("Failed to parse SSH key: " <> str) (SSH.parsePublicKey (unsafePerformEffect (Buffer.fromString str UTF8)))
+unsafeSSHPublicKey str = fromRight ("Failed to parse SSH key: " <> str) (SSH.parsePublicKey str)
 
 -- | Unsafely parse a private SSH key from a string
 unsafeSSHPrivateKey :: String -> SSH.PrivateKey
-unsafeSSHPrivateKey str = fromRight ("Failed to parse SSH key: " <> str) (SSH.parsePrivateKey (unsafePerformEffect (Buffer.fromString str UTF8)))
+unsafeSSHPrivateKey str = fromRight ("Failed to parse SSH key: " <> str) (SSH.parsePrivateKey str)
 
 -- | Unsafely create a manifest from a name, version, and array of dependencies
 -- | where keys are package names and values are ranges.

--- a/lib/test/Registry/Test/Utils.purs
+++ b/lib/test/Registry/Test/Utils.purs
@@ -14,6 +14,9 @@ import Data.Formatter.DateTime as DateTime.Formatters
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple)
+import Effect.Unsafe (unsafePerformEffect)
+import Node.Buffer as Buffer
+import Node.Encoding (Encoding(..))
 import Partial.Unsafe (unsafeCrashWith)
 import Partial.Unsafe as Partial
 import Registry.Internal.Format as Internal.Format
@@ -23,6 +26,7 @@ import Registry.Manifest (Manifest(..))
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Range as Range
+import Registry.SSH as SSH
 import Registry.Sha256 (Sha256)
 import Registry.Sha256 as Sha256
 import Registry.Version (Version)
@@ -82,6 +86,10 @@ unsafeDateTime str = fromRight ("Failed to parse DateTime: " <> str) (DateTime.F
 -- | Unsafely parse a Date from an ISO8601 string
 unsafeDate :: String -> Date.Date
 unsafeDate str = fromRight ("Failed to parse Date: " <> str) (map Date.date $ DateTime.Formatters.unformat Internal.Format.iso8601Date str)
+
+-- | Unsafely parse a SSH key from a string
+unsafeSSHKey :: String -> SSH.ParsedKey
+unsafeSSHKey str = fromRight ("Failed to parse SSH key: " <> str) (SSH.parse (unsafePerformEffect (Buffer.fromString str UTF8)))
 
 -- | Unsafely create a manifest from a name, version, and array of dependencies
 -- | where keys are package names and values are ranges.

--- a/lib/test/_fixtures/manifests/prelude-4.1.1.json
+++ b/lib/test/_fixtures/manifests/prelude-4.1.1.json
@@ -9,7 +9,6 @@
   },
   "owners": [
     {
-      "email": "admin@purescript.org",
       "keytype": "ed-25519",
       "public": "abc123"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,8 @@
       "name": "registry-lib",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "ssh2": "^1.11.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -203,6 +204,14 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "license": "MIT",
@@ -214,8 +223,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1274.0",
-      "license": "Apache-2.0",
+      "version": "2.1357.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1357.0.tgz",
+      "integrity": "sha512-bSOfBCVPQ/0NWYpPl34MgqMbJf0eO6PsyVlmjbStlba+98hnE6X7z67tawBRot7S+qH3L49KW2u6dfJjvhDfdQ==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -226,7 +236,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -253,6 +263,14 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
@@ -289,6 +307,15 @@
         "isarray": "^1.0.0"
       }
     },
+    "node_modules/buildcheck": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.5.tgz",
+      "integrity": "sha512-jYWpRy8eedl/JZqkOeq0X0bNcaK04hXKhIi4gYsDKZUJWRjJJWViYfsMXO0BJQ40zSLcdLoa+iqe48Kz2PtQag==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "license": "MIT",
@@ -310,6 +337,20 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.6.tgz",
+      "integrity": "sha512-Rj33pk//oVNh25YjsBaKtOkXNW7IARYxejWJosJkXqVPpbK+FrdpThPk6f4m3d+CEh2qMlkGx/SFt2Y1XSWN6g==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "0.0.5",
+        "nan": "^2.17.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
@@ -702,6 +743,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "optional": true
+    },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "license": "MIT",
@@ -826,9 +873,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/sax": {
       "version": "1.2.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "node_modules/semver": {
       "version": "7.3.8",
@@ -858,6 +911,23 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.12",
       "license": "CC0-1.0"
+    },
+    "node_modules/ssh2": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
+      "integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.4",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.4",
+        "nan": "^2.16.0"
+      }
     },
     "node_modules/tar": {
       "version": "6.1.13",
@@ -897,6 +967,11 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "license": "MIT"
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
@@ -977,16 +1052,21 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "license": "MIT",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "license": "MIT",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "engines": {
         "node": ">=4.0"
       }
@@ -1123,11 +1203,21 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "available-typed-arrays": {
       "version": "1.0.5"
     },
     "aws-sdk": {
-      "version": "2.1274.0",
+      "version": "2.1357.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1357.0.tgz",
+      "integrity": "sha512-bSOfBCVPQ/0NWYpPl34MgqMbJf0eO6PsyVlmjbStlba+98hnE6X7z67tawBRot7S+qH3L49KW2u6dfJjvhDfdQ==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -1138,7 +1228,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       }
     },
     "balanced-match": {
@@ -1146,6 +1236,14 @@
     },
     "base64-js": {
       "version": "1.5.1"
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "before-after-hook": {
       "version": "2.2.3"
@@ -1174,6 +1272,12 @@
         "isarray": "^1.0.0"
       }
     },
+    "buildcheck": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.5.tgz",
+      "integrity": "sha512-jYWpRy8eedl/JZqkOeq0X0bNcaK04hXKhIi4gYsDKZUJWRjJJWViYfsMXO0BJQ40zSLcdLoa+iqe48Kz2PtQag==",
+      "optional": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "requires": {
@@ -1186,6 +1290,16 @@
     },
     "concat-map": {
       "version": "0.0.1"
+    },
+    "cpu-features": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.6.tgz",
+      "integrity": "sha512-Rj33pk//oVNh25YjsBaKtOkXNW7IARYxejWJosJkXqVPpbK+FrdpThPk6f4m3d+CEh2qMlkGx/SFt2Y1XSWN6g==",
+      "optional": true,
+      "requires": {
+        "buildcheck": "0.0.5",
+        "nan": "^2.17.0"
+      }
     },
     "deprecation": {
       "version": "2.3.1"
@@ -1417,6 +1531,12 @@
     "mkdirp": {
       "version": "1.0.4"
     },
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "optional": true
+    },
     "node-fetch": {
       "version": "2.6.7",
       "requires": {
@@ -1473,7 +1593,8 @@
     "registry-lib": {
       "version": "file:lib",
       "requires": {
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-expression-parse": "^3.0.0",
+        "ssh2": "^1.11.0"
       }
     },
     "reusify": {
@@ -1491,8 +1612,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "sax": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "semver": {
       "version": "7.3.8",
@@ -1512,6 +1640,17 @@
     },
     "spdx-license-ids": {
       "version": "3.0.12"
+    },
+    "ssh2": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
+      "integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
+      "requires": {
+        "asn1": "^0.2.4",
+        "bcrypt-pbkdf": "^1.0.2",
+        "cpu-features": "~0.0.4",
+        "nan": "^2.16.0"
+      }
     },
     "tar": {
       "version": "6.1.13",
@@ -1538,6 +1677,11 @@
     },
     "tr46": {
       "version": "0.0.3"
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "universal-user-agent": {
       "version": "6.0.0"
@@ -1593,14 +1737,18 @@
       "version": "0.2.1"
     },
     "xml2js": {
-      "version": "0.4.19",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7"
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "yallist": {
       "version": "4.0.0"

--- a/scripts/src/PackageTransferrer.purs
+++ b/scripts/src/PackageTransferrer.purs
@@ -129,8 +129,7 @@ transferPackage rawPackageName newLocation = do
     Right signature -> pure signature
 
   API.authenticated
-    { email: pacchettibottiEmail
-    , payload: Transfer payload
+    { payload: Transfer payload
     , rawPayload
     , signature
     }

--- a/scripts/src/PackageTransferrer.purs
+++ b/scripts/src/PackageTransferrer.purs
@@ -7,7 +7,6 @@ import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Map as Map
 import Data.String as String
 import Effect.Ref as Ref
-import Node.Buffer as Buffer
 import Node.Path as Path
 import Node.Process as Process
 import Registry.App.API as API
@@ -127,9 +126,7 @@ transferPackage rawPackageName newLocation = do
 
   signature <- case Auth.signPayload { privateKey, rawPayload } of
     Left _ -> Except.throw "Error signing transfer."
-    Right signature -> do
-      asString <- Run.liftEffect $ Buffer.toString UTF8 signature
-      pure $ String.split (String.Pattern "\n") asString
+    Right signature -> pure signature
 
   API.authenticated
     { email: pacchettibottiEmail

--- a/types/v1/Owner.dhall
+++ b/types/v1/Owner.dhall
@@ -1,1 +1,1 @@
-let Owner = { email : Text, keytype : Text, public : Text } in Owner
+let Owner = { comment : Optional Text, keytype : Text, public : Text } in Owner

--- a/types/v1/Owner.dhall
+++ b/types/v1/Owner.dhall
@@ -1,1 +1,1 @@
-let Owner = { comment : Optional Text, keytype : Text, public : Text } in Owner
+let Owner = { id : Optional Text, keytype : Text, public : Text } in Owner


### PR DESCRIPTION
This PR migrates the registry away from `ssh-keygen` and over to the [ssh2](https://github.com/mscdex/ssh2) node library as per #591. This is because mismatched ssh-keygen versions have been giving us a lot of headaches in the transfer operation and it would be nicer to be able to sign and verify data using a specific version of the ssh2 library via Spago (and anyone else who wants to sign data using the registry library).

Unfortunately, I'm not exactly sure how to handle translating the signature buffer that we receive from ssh2's `sign` method into a string suitable for use in a JSON payload and back; a first cut with `Buffer.toString` using a UTF8 encoding was no good, and I don't have time to dig in to what encoding should be used just yet.

For that reason you'll see the tests are failing. I'll need to come back and fix that part but everything else should be OK.