### PR TITLE
Exclude Main and Test.Main as module names

### DIFF
--- a/app/test/App/API.purs
+++ b/app/test/App/API.purs
@@ -138,7 +138,6 @@ copySourceFiles = Spec.hoistSpec identity (\_ -> Assert.Run.runTest) $ Spec.befo
 
     for_ acceptedPaths \path -> do
       paths.succeeded `Assert.Run.shouldContain` path
-
   where
   runBefore :: forall r. Run (EFFECT + r) _
   runBefore = do
@@ -153,6 +152,6 @@ copySourceFiles = Spec.hoistSpec identity (\_ -> Assert.Run.runTest) $ Spec.befo
       writeDirectories = traverse_ (FS.Extra.ensureDirectory <<< inTmp)
 
       writeFiles :: Array FilePath -> _
-      writeFiles = Run.liftAff <<< traverse_ (\path -> FS.Aff.writeTextFile UTF8 (inTmp path) "<test>")
+      writeFiles = Run.liftAff <<< traverse_ (\path -> FS.Aff.writeTextFile UTF8 (inTmp path) "module Module where")
 
     pure { source: tmp, destination: destTmp, writeDirectories, writeFiles }

--- a/lib/spago.yaml
+++ b/lib/spago.yaml
@@ -20,6 +20,7 @@ package:
     - functors
     - graphs
     - integers
+    - language-cst-parser
     - lists
     - maybe
     - newtype

--- a/lib/src/Internal/Path.purs
+++ b/lib/src/Internal/Path.purs
@@ -3,13 +3,23 @@ module Registry.Internal.Path where
 import Prelude
 
 import Control.Monad.Except (ExceptT(..), runExceptT)
+import Data.Array as Array
+import Data.Array.NonEmpty (NonEmptyArray)
+import Data.Array.NonEmpty as NEA
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.String as String
+import Data.String.Regex (Regex)
+import Data.String.Regex as Regex
+import Data.String.Regex.Flags as Regex.Flags
+import Data.String.Regex.Unsafe as Regex.Unsafe
+import Effect.Aff (Aff)
 import Effect.Aff as Aff
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Node.FS.Aff as FS
+import Node.FS.Aff as FS.Aff
+import Node.FS.Stats as FS.Stats
 import Node.Path (FilePath)
 import Node.Path as Path
 
@@ -25,3 +35,25 @@ sanitizePath baseDirectory path = liftAff $ runExceptT do
   ExceptT $ pure $ case String.indexOf (String.Pattern absoluteRoot) absolutePath of
     Just 0 -> Right path
     _ -> Left path
+
+-- | Read all .purs files in the given directory.
+readPursFiles :: forall m. MonadAff m => FilePath -> m (Maybe (NonEmptyArray FilePath))
+readPursFiles init = liftAff do
+  result <- Aff.attempt (go 0 init)
+  case result of
+    Left _ -> pure Nothing
+    Right files -> pure (NEA.fromArray files)
+  where
+  go :: Int -> FilePath -> Aff (Array FilePath)
+  go depth root = do
+    FS.Aff.readdir root >>= Array.foldMap \file -> do
+      let path = Path.concat [ root, Path.sep, file ]
+      stats <- FS.Aff.stat path
+      if FS.Stats.isDirectory stats then
+        go (depth + 1) path
+      else if Regex.test pursFileExtensionRegex path then
+        pure [ path ]
+      else pure []
+
+pursFileExtensionRegex :: Regex
+pursFileExtensionRegex = Regex.Unsafe.unsafeRegex "\\.purs$" Regex.Flags.noFlags


### PR DESCRIPTION
Fixes #566 by disallowing `Main` and `Test.Main` module names in library code due to their high chance of colliding with user module names. These really ought not be published to libraries and we now explicitly disallow it.

This PR uses `parsePartialModule` from `lanugage-cst-parser` as suggested by @natefaubion to reliably parse just the module header of a file:
https://github.com/natefaubion/purescript-language-cst-parser/blob/7a0a4484f8abd91d688d297461209a75667e0da6/src/PureScript/CST.purs#L83-L84

I've adjusted our `containsPursFile` check to instead be `validatePursModules`; instead of walking their `src` directory to ensure there is at least one PureScript file, we now parse the module header of each module in their `src` directory and fail if either a) there are no modules or b) a module uses a reserved name.