### PR TITLE
Render solver errors with backticks to prevent accidental quoting

### DIFF
--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -613,11 +613,12 @@ verifyResolutions manifest resolutions = do
         let
           printedError = String.joinWith "\n"
             [ "Could not produce valid dependencies for manifest."
-            , ""
+            , "```"
             , errors # foldMapWithIndex \index error -> String.joinWith "\n"
                 [ "[Error " <> show (index + 1) <> "]"
                 , Solver.printSolverError error
                 ]
+            , "```"
             ]
         Except.throw printedError
       Right solved -> pure solved


### PR DESCRIPTION
Wraps the solver error output in backticks to prevent accidental quoting when showing an error range that begins with `>`. See, for example:

https://github.com/purescript/registry/issues/249#issuecomment-1513535532

@f-f As a brief aside, this is something to keep in mind when recording logs. When notifying via GitHub we want markdown formatting; when storing a log for terminal output we don't.