### PR TITLE
Re-enable Pursuit publishing if package docs are missing

### DIFF
--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -1,4 +1,18 @@
-module Registry.App.API where
+module Registry.App.API
+  ( Source(..)
+  , PackageSetUpdateEffects
+  , packageSetUpdate
+  , PublishEffects
+  , publish
+  , AuthenticatedEffects
+  , authenticated
+  , packagingTeam
+  -- The below are exported for tests, but aren't otherwise intended for use
+  -- outside this module.
+  , formatPursuitResolutions
+  , removeIgnoredTarballFiles
+  , copyPackageSourceFiles
+  ) where
 
 import Registry.App.Prelude
 
@@ -483,15 +497,6 @@ publish source payload = do
   when (Operation.Validation.isMetadataPackage (Manifest manifest)) do
     Except.throw "The `metadata` package cannot be uploaded to the registry because it is a protected package."
 
-  for_ (Operation.Validation.isNotPublished (Manifest manifest) (Metadata metadata)) \info -> do
-    Except.throw $ String.joinWith "\n"
-      [ "You tried to upload a version that already exists: " <> Version.print manifest.version
-      , "Its metadata is:"
-      , "```json"
-      , printJson Metadata.publishedMetadataCodec info
-      , "```"
-      ]
-
   for_ (Operation.Validation.isNotUnpublished (Manifest manifest) (Metadata metadata)) \info -> do
     Except.throw $ String.joinWith "\n"
       [ "You tried to upload a version that has been unpublished: " <> Version.print manifest.version
@@ -501,6 +506,69 @@ publish source payload = do
       , "```"
       ]
 
+  for_ (Operation.Validation.isNotPublished (Manifest manifest) (Metadata metadata)) \info -> do
+    -- If the package has been published already, then we check whether the published
+    -- version has made it to Pursuit or not. If it has, then we terminate here. If
+    -- it hasn't then we skip to Pursuit publishing.
+    published <- Pursuit.getPublishedVersions manifest.name >>= case _ of
+      Left error -> Except.throw error
+      Right versions -> pure versions
+
+    case Map.lookup manifest.version published of
+      Nothing -> do
+        Notify.notify $ Array.fold
+          [ "This version has already been published to the registry, but the docs have not been "
+          , "uploaded to Pursuit. Skipping registry publishing and retrying Pursuit publishing..."
+          ]
+        verifiedResolutions <- verifyResolutions (Manifest manifest) payload.resolutions
+        compilationResult <- compilePackage { packageSourceDir: packageDirectory, compiler: payload.compiler, resolutions: verifiedResolutions }
+        case compilationResult of
+          Left error -> do
+            Log.error $ "Compilation failed, cannot upload to pursuit: " <> error
+            Except.throw "Cannot publish to Pursuit because this package failed to compile."
+          Right dependenciesDir -> do
+            Log.debug "Uploading to Pursuit"
+            publishToPursuit { packageSourceDir: packageDirectory, compiler: payload.compiler, resolutions: verifiedResolutions, dependenciesDir }
+
+      Just url -> do
+        Except.throw $ String.joinWith "\n"
+          [ "You tried to upload a version that already exists: " <> Version.print manifest.version
+          , ""
+          , "Its metadata is:"
+          , "```json"
+          , printJson Metadata.publishedMetadataCodec info
+          , "```"
+          , ""
+          , "and its documentation is available here:"
+          , url
+          ]
+
+    publishRegistry
+      { source
+      , manifest: Manifest manifest
+      , metadata: Metadata metadata
+      , payload
+      , publishedTime
+      , tmp
+      , packageDirectory
+      }
+
+type PublishRegistry =
+  { source :: Source
+  , manifest :: Manifest
+  , metadata :: Metadata
+  , payload :: PublishData
+  , publishedTime :: DateTime
+  , tmp :: FilePath
+  , packageDirectory :: FilePath
+  }
+
+-- A private helper function for publishing to the registry. Separated out of
+-- the main 'publish' function because we sometimes use the publish function to
+-- publish to Pursuit only (in the case the package has been pushed to the
+-- registry, but docs have not been uploaded).
+publishRegistry :: forall r. PublishRegistry -> Run (PublishEffects + r) Unit
+publishRegistry { source, payload, metadata: Metadata metadata, manifest: Manifest manifest, publishedTime, tmp, packageDirectory } = do
   Log.debug "Verifying the package build plan..."
   verifiedResolutions <- verifyResolutions (Manifest manifest) payload.resolutions
 

--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -543,15 +543,15 @@ publish source payload = do
           , url
           ]
 
-    publishRegistry
-      { source
-      , manifest: Manifest manifest
-      , metadata: Metadata metadata
-      , payload
-      , publishedTime
-      , tmp
-      , packageDirectory
-      }
+  publishRegistry
+    { source
+    , manifest: Manifest manifest
+    , metadata: Metadata metadata
+    , payload
+    , publishedTime
+    , tmp
+    , packageDirectory
+    }
 
 type PublishRegistry =
   { source :: Source

--- a/app/src/App/Effect/Pursuit.purs
+++ b/app/src/App/Effect/Pursuit.purs
@@ -3,23 +3,35 @@ module Registry.App.Effect.Pursuit where
 
 import Registry.App.Prelude
 
+import Affjax.Node (URL)
 import Affjax.Node as Affjax.Node
 import Affjax.RequestBody as RequestBody
 import Affjax.RequestHeader as RequestHeader
 import Affjax.ResponseFormat as ResponseFormat
 import Affjax.StatusCode (StatusCode(..))
+import Data.Argonaut.Core as Argonaut
+import Data.Array as Array
+import Data.Codec.Argonaut as CA
 import Data.HTTP.Method as Method
+import Data.Map as Map
 import Data.MediaType.Common as MediaType
+import Data.Profunctor as Profunctor
 import Effect.Aff (Milliseconds(..))
 import Effect.Aff as Aff
 import Registry.App.Effect.Log (LOG)
 import Registry.App.Effect.Log as Log
+import Registry.App.Legacy.LenientVersion (LenientVersion(..))
+import Registry.App.Legacy.LenientVersion as LenientVersion
 import Registry.Foreign.Octokit (GitHubToken(..))
+import Registry.PackageName as PackageName
+import Registry.Version as Version
 import Run (AFF, Run)
 import Run as Run
 
 -- | An effect for interacting with Pursuit
-data Pursuit a = Publish Json (Either String Unit -> a)
+data Pursuit a
+  = Publish Json (Either String Unit -> a)
+  | GetPublishedVersions PackageName (Either String (Map Version URL) -> a)
 
 derive instance Functor Pursuit
 
@@ -32,6 +44,10 @@ _pursuit = Proxy
 publish :: forall r. Json -> Run (PURSUIT + r) (Either String Unit)
 publish json = Run.lift _pursuit (Publish json identity)
 
+-- | List published versions from Pursuit
+getPublishedVersions :: forall r. PackageName -> Run (PURSUIT + r) (Either String (Map Version URL))
+getPublishedVersions name = Run.lift _pursuit (GetPublishedVersions name identity)
+
 -- | Run the PURSUIT effect given a handler.
 interpret :: forall r a. (Pursuit ~> Run r) -> Run (PURSUIT + r) a -> Run r a
 interpret handler = Run.interpret (Run.on _pursuit handler Run.send)
@@ -40,6 +56,7 @@ interpret handler = Run.interpret (Run.on _pursuit handler Run.send)
 handlePure :: forall r a. Pursuit a -> Run r a
 handlePure = case _ of
   Publish _ reply -> pure $ reply $ Right unit
+  GetPublishedVersions _ reply -> pure $ reply $ Right Map.empty
 
 -- | Handle Pursuit by executing HTTP requests using the provided auth token.
 handleAff :: forall r a. GitHubToken -> Pursuit a -> Run (LOG + AFF + r) a
@@ -85,3 +102,52 @@ handleAff (GitHubToken token) = case _ of
             pure $ Left "Could not reach Pursuit due to an HTTP error."
 
     reply <$> loop 2
+
+  GetPublishedVersions pname reply -> do
+    let name = PackageName.print pname
+    let url = "https://pursuit.purescript.org/packages/purescript-" <> name <> "/available-versions"
+    Log.debug $ "Checking if package docs for " <> name <> " are published on Pursuit using endpoint " <> url
+    result <- Run.liftAff $ withBackoff' $ Affjax.Node.request
+      { content: Nothing
+      , headers: [ RequestHeader.Accept MediaType.applicationJSON ]
+      , method: Left Method.GET
+      , username: Nothing
+      , withCredentials: false
+      , password: Nothing
+      , responseFormat: ResponseFormat.json
+      , timeout: Nothing
+      , url
+      }
+
+    case result of
+      Nothing -> do
+        Log.error $ "Could not reach Pursuit after multiple retries at URL " <> url
+        pure $ reply $ Left $ "Could not reach Pursuit to determine published versions for " <> name
+      Just (Left httpError) -> do
+        let printedError = Affjax.Node.printError httpError
+        Log.error $ "Pursuit publishing failed because of an HTTP error: " <> printedError
+        pure $ reply $ Left "Could not reach Pursuit due to an HTTP error."
+      Just (Right { body, status: StatusCode status }) | status /= 200 -> do
+        Log.error $ "Could not fetch published versions from Pursuit (received non-200 response) " <> show status <> " and body\n" <> Argonaut.stringify body
+        pure $ reply $ Left $ "Received non-200 response from Pursuit: " <> show status
+      Just (Right { body }) -> case CA.decode availableVersionsCodec body of
+        Left error -> do
+          let printed = CA.printJsonDecodeError error
+          Log.error $ "Failed to decode body " <> Argonaut.stringify body <> "\n with error: " <> printed
+          pure $ reply $ Left $ "Received a response from Pursuit, but it could not be decoded:\n\n" <> printed <> "\n\ncc: @purescript/packaging"
+        Right versions -> do
+          Log.debug "Found versions from Pursuit!"
+          pure $ reply $ Right versions
+
+-- The Pursuit /available-versions endpoint returns versions as a tuple of the
+-- version number and documentation URL, represented as a two-element array.
+-- [["2.0.0","https://pursuit.purescript.org/packages/purescript-halogen/2.0.0"]]
+availableVersionsCodec :: JsonCodec (Map Version URL)
+availableVersionsCodec = Profunctor.dimap toRep fromRep (CA.array (CA.array CA.string))
+  where
+  toRep = map (\(Tuple version url) -> [ Version.print version, url ]) <<< Map.toUnfoldable
+  fromRep = Map.fromFoldable <<< Array.mapMaybe \array -> do
+    rawVersion <- Array.index array 0
+    LenientVersion { version } <- hush $ LenientVersion.parse rawVersion
+    url <- Array.index array 1
+    pure $ Tuple version url


### PR DESCRIPTION
Reverts #605, which disabled #604. The culprint was a _level of indentation!_. Fixed in e91c0ce.