### PR TITLE
Add valid LGPL-2.1-only license to tests

### DIFF
--- a/lib/test/Registry/License.purs
+++ b/lib/test/Registry/License.purs
@@ -33,6 +33,7 @@ valid =
   , "BSD-3-Clause"
   , "CC-BY-1.0"
   , "APACHE-2.0"
+  , "LGPL-2.1-only"
 
   -- deprecated licenses are acceptable
   , "GPL-3.0"


### PR DESCRIPTION
In https://github.com/purescript/registry/issues/284#issuecomment-1575517970, @albertprz noticed that the LGPL-2.1-only license fails to publish to Pursuit with an "invalid license" error — though the package did get registered — despite this being a valid SPDX license.

Thought I'd test if the license is considered valid in our tests and indeed it is — as seen in this PR. Will have to dig to see why we ever consider it invalid.