### PR TITLE
Update flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /output
 /scratch
 
+result
+
 .psc*
 .purs*
 .psa*
@@ -10,3 +12,4 @@
 
 # Keep it secret, keep it safe.
 .env
+

--- a/app/test/App/CLI/Purs.purs
+++ b/app/test/App/CLI/Purs.purs
@@ -11,7 +11,7 @@ import Test.Spec as Spec
 spec :: Spec.Spec Unit
 spec = do
   traverse_ testVersion [ "0.13.0", "0.14.0", "0.14.7", "0.15.4" ]
-  traverse_ testMissingVersion [ "0.13.1", "0.14.8" ]
+  traverse_ testMissingVersion [ "0.13.1", "0.13.7", "0.15.1", "0.12.0", "0.14.12345" ]
   where
   testVersion version =
     Spec.it ("Calls compiler version " <> version) do

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "easy-dhall-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1645736928,
-        "narHash": "sha256-jjEqfh+M73+t2Iq/IKjAGr2d2kGUeo9A7Wu7V0IxdzI=",
+        "lastModified": 1681943375,
+        "narHash": "sha256-gLWlMqkg0YKnRntOqU1CUcvb6by/ysvFS6IOdQh2Ipw=",
         "owner": "justinwoo",
         "repo": "easy-dhall-nix",
-        "rev": "dce9acbb99776a7f1344db4751d6080380f76f57",
+        "rev": "7f365c1daf7f7fde3827800ace2621cffa7bed6b",
         "type": "github"
       },
       "original": {
@@ -17,17 +17,19 @@
       }
     },
     "easy-purescript-nix": {
-      "flake": false,
+      "inputs": {
+        "flake-utils": "flake-utils"
+      },
       "locked": {
-        "lastModified": 1680076811,
-        "narHash": "sha256-vfzrVwBntXao3nMi2hkjYlWGUnuyUOVmYi95mQQ0EEY=",
-        "owner": "f-f",
+        "lastModified": 1686900973,
+        "narHash": "sha256-9whTjp8BYy8ZzyghhgbawS06/dVESduME3wsdNH/mpk=",
+        "owner": "justinwoo",
         "repo": "easy-purescript-nix",
-        "rev": "b02cff3db1671fc8fb76a680597a216a9c9b2d03",
+        "rev": "8cf400656945b2f2bacfd6a8775792aa701f60e9",
         "type": "github"
       },
       "original": {
-        "owner": "f-f",
+        "owner": "justinwoo",
         "repo": "easy-purescript-nix",
         "type": "github"
       }
@@ -53,11 +55,29 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681037374,
-        "narHash": "sha256-XL6X3VGbEFJZDUouv2xpKg2Aljzu/etPLv5e1FPt1q0=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "033b9f258ca96a10e543d4442071f614dc3f8412",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -68,11 +88,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672580127,
-        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
         "type": "github"
       },
       "original": {
@@ -82,16 +102,52 @@
         "type": "github"
       }
     },
+    "purix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1687105678,
+        "narHash": "sha256-Y7BZBiXXb6iKXE+cWSWbrc6eTCKsnuPJO01mGBb50Cs=",
+        "owner": "thomashoneyman",
+        "repo": "purix",
+        "rev": "796c9ec8c836df7cca18c5ea54c265579e02d5c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "easy-dhall-nix": "easy-dhall-nix",
         "easy-purescript-nix": "easy-purescript-nix",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "purix": "purix"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -71,10 +71,10 @@
       #   $ nix flake update
       compilers = let
         # Only include the compiler at normal MAJOR.MINOR.PATCH versions.
-        pursOnly =
+        stableOnly =
           pkgs.lib.filterAttrs
           (name: _: (builtins.match "^purs-[0-9]_[0-9]+_[0-9]$" name != null))
-          pkgs.pursPackages;
+          pkgs.purs-bin;
       in
         pkgs.symlinkJoin {
           name = "purs-compilers";
@@ -82,7 +82,7 @@
             pkgs.writeShellScriptBin name ''
               exec ${drv}/bin/purs "$@"
             '')
-          pursOnly;
+          stableOnly;
         };
 
       # Various scripts we would like to be able to run via a Nix shell. Once

--- a/flake.nix
+++ b/flake.nix
@@ -4,17 +4,21 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/release-22.05";
 
-    flake-utils = { url = "github:numtide/flake-utils"; };
+    flake-utils = {url = "github:numtide/flake-utils";};
 
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
 
-    # Temporary until spago@next is published as alpha
+    purix = {
+      url = "github:thomashoneyman/purix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # Temporary until purs-tidy is supported by purix
     easy-purescript-nix = {
-      url = "github:f-f/easy-purescript-nix";
-      flake = false;
+      url = "github:justinwoo/easy-purescript-nix";
     };
 
     easy-dhall-nix = {
@@ -23,166 +27,177 @@
     };
   };
 
-  outputs =
-    { self, nixpkgs, flake-utils, easy-purescript-nix, easy-dhall-nix, ... }:
-    let
-      supportedSystems =
-        [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    purix,
+    easy-purescript-nix,
+    easy-dhall-nix,
+    ...
+  }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
 
-      registryOverlay = final: prev: {
-        pursPackages = prev.callPackage easy-purescript-nix { };
+    registryOverlay = final: prev: {
+      # Annoyingly, easy-purescript-nix refers to 'nodejs_18' instead of
+      # 'nodejs-18_x', so we need to add that name and then have easy-ps-nix
+      # refer to the final result.
+      nodejs_18 = prev.nodejs-18_x;
+      pursPackages = final.callPackage easy-purescript-nix {};
 
-        dhallPackages = prev.callPackage easy-dhall-nix { };
+      dhallPackages = prev.callPackage easy-dhall-nix {};
 
-        nodejs = prev.nodejs-16_x;
+      nodejs = prev.nodejs-18_x;
 
-        # We don't want to force everyone to update their configs if they aren't
-        # normally on flakes.
-        nixFlakes = prev.writeShellScriptBin "nixFlakes" ''
-          exec ${prev.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
-        '';
+      # We don't want to force everyone to update their configs if they aren't
+      # normally on flakes.
+      nixFlakes = prev.writeShellScriptBin "nixFlakes" ''
+        exec ${prev.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
+      '';
+    };
+  in
+    flake-utils.lib.eachSystem supportedSystems (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [purix.overlays.default registryOverlay];
       };
-    in flake-utils.lib.eachSystem supportedSystems (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ registryOverlay ];
-        };
 
-        # Produces a list of all PureScript binaries supported by easy-purescript-nix,
-        # callable using the naming convention `purs-MAJOR_MINOR_PATCH`.
-        #   $ purs-0_14_0 --version
-        #   0.14.0
-        #
-        # To add a new compiler to the list, just update easy-purescript-nix:
-        #   $ nix flake update
-        compilers = let
-          # Only include the compiler at normal MAJOR.MINOR.PATCH versions.
-          pursOnly = pkgs.lib.filterAttrs
-            (name: _: (builtins.match "^purs-[0-9]_[0-9]+_[0-9]$" name != null))
-            pkgs.pursPackages;
-        in pkgs.symlinkJoin {
+      # Produces a list of all PureScript binaries supported by easy-purescript-nix,
+      # callable using the naming convention `purs-MAJOR_MINOR_PATCH`.
+      #   $ purs-0_14_0 --version
+      #   0.14.0
+      #
+      # To add a new compiler to the list, just update easy-purescript-nix:
+      #   $ nix flake update
+      compilers = let
+        # Only include the compiler at normal MAJOR.MINOR.PATCH versions.
+        pursOnly =
+          pkgs.lib.filterAttrs
+          (name: _: (builtins.match "^purs-[0-9]_[0-9]+_[0-9]$" name != null))
+          pkgs.pursPackages;
+      in
+        pkgs.symlinkJoin {
           name = "purs-compilers";
           paths = pkgs.lib.mapAttrsToList (name: drv:
             pkgs.writeShellScriptBin name ''
               exec ${drv}/bin/purs "$@"
-            '') pursOnly;
+            '')
+          pursOnly;
         };
 
-        # Various scripts we would like to be able to run via a Nix shell. Once
-        # in a shell via `nix develop`, these can be run, e.g.
-        #
-        #   $ registry-check-format
-        #   All files formatted.
-        #
-        scripts = pkgs.symlinkJoin {
-          name = "scripts";
-          paths = pkgs.lib.mapAttrsToList pkgs.writeShellScriptBin {
-            registry-build = ''
-              cd $(git rev-parse --show-toplevel)
-              npm ci
-              spago build
-            '';
+      # Various scripts we would like to be able to run via a Nix shell. Once
+      # in a shell via `nix develop`, these can be run, e.g.
+      #
+      #   $ registry-check-format
+      #   All files formatted.
+      #
+      scripts = pkgs.symlinkJoin {
+        name = "scripts";
+        paths = pkgs.lib.mapAttrsToList pkgs.writeShellScriptBin {
+          registry-build = ''
+            cd $(git rev-parse --show-toplevel)
+            npm ci
+            spago build
+          '';
 
-            registry-test = ''
-              cd $(git rev-parse --show-toplevel)
-              npm ci
-              spago test
-            '';
+          registry-test = ''
+            cd $(git rev-parse --show-toplevel)
+            npm ci
+            spago test
+          '';
 
-            registry-check-format = ''
-              cd $(git rev-parse --show-toplevel)
-              purs-tidy check app lib scripts
-            '';
+          registry-check-format = ''
+            cd $(git rev-parse --show-toplevel)
+            purs-tidy check app lib scripts
+          '';
 
-            registry-api = ''
-              cd $(git rev-parse --show-toplevel)
-              spago run -p registry-app
-            '';
+          registry-api = ''
+            cd $(git rev-parse --show-toplevel)
+            spago run -p registry-app
+          '';
 
-            registry-importer = ''
-              cd $(git rev-parse --show-toplevel)
-              spago run -p registry-scripts -m Registry.Scripts.LegacyImporter -- $@
-            '';
+          registry-importer = ''
+            cd $(git rev-parse --show-toplevel)
+            spago run -p registry-scripts -m Registry.Scripts.LegacyImporter -- $@
+          '';
 
-            registry-package-set-updater = ''
-              cd $(git rev-parse --show-toplevel)
-              spago run -p registry-scripts -m Registry.Scripts.PackageSetUpdater -- $@
-            '';
+          registry-package-set-updater = ''
+            cd $(git rev-parse --show-toplevel)
+            spago run -p registry-scripts -m Registry.Scripts.PackageSetUpdater -- $@
+          '';
 
-            registry-package-transferrer = ''
-              cd $(git rev-parse --show-toplevel)
-              spago run -p registry-scripts -m Registry.Scripts.PackageTransferrer -- $@
-            '';
+          registry-package-transferrer = ''
+            cd $(git rev-parse --show-toplevel)
+            spago run -p registry-scripts -m Registry.Scripts.PackageTransferrer -- $@
+          '';
 
-            registry-package-deleter = ''
-              cd $(git rev-parse --show-toplevel)
-              spago run -p registry-scripts -m Registry.Scripts.PackageDeleter -- $@
-            '';
+          registry-package-deleter = ''
+            cd $(git rev-parse --show-toplevel)
+            spago run -p registry-scripts -m Registry.Scripts.PackageDeleter -- $@
+          '';
 
-            registry-solver = ''
-              cd $(git rev-parse --show-toplevel)
-              spago run -p registry-scripts -m Registry.Scripts.Solver -- $@
-            '';
+          registry-solver = ''
+            cd $(git rev-parse --show-toplevel)
+            spago run -p registry-scripts -m Registry.Scripts.Solver -- $@
+          '';
 
-            registry-verify = ''
-              cd $(git rev-parse --show-toplevel)
-              spago run -p registry-scripts -m Registry.Scripts.VerifyIntegrity -- $@
-            '';
+          registry-verify = ''
+            cd $(git rev-parse --show-toplevel)
+            spago run -p registry-scripts -m Registry.Scripts.VerifyIntegrity -- $@
+          '';
 
-            # This script verifies that
-            # - all the dhall we have in the repo actually compiles
-            # - all the example manifests actually typecheck as Manifests
-            registry-verify-dhall = ''
-              cd $(git rev-parse --show-toplevel)
-              set -euo pipefail
+          # This script verifies that
+          # - all the dhall we have in the repo actually compiles
+          # - all the example manifests actually typecheck as Manifests
+          registry-verify-dhall = ''
+            cd $(git rev-parse --show-toplevel)
+            set -euo pipefail
 
-              for FILE in $(find ./types/v1 -iname "*.dhall")
-              do
-                echo "Typechecking ''${FILE}";
-                dhall <<< "./''${FILE}" > /dev/null
-              done
+            for FILE in $(find ./types/v1 -iname "*.dhall")
+            do
+              echo "Typechecking ''${FILE}";
+              dhall <<< "./''${FILE}" > /dev/null
+            done
 
-              for FILE in $(find ./lib/test/_fixtures/manifests -iname "*.json")
-              do
-                echo "Conforming ''${FILE} to the Manifest type"
-                cat "''${FILE}" | json-to-dhall --records-loose --unions-strict "./types/v1/Manifest.dhall" > /dev/null
-              done
-            '';
-          };
+            for FILE in $(find ./lib/test/_fixtures/manifests -iname "*.json")
+            do
+              echo "Conforming ''${FILE} to the Manifest type"
+              cat "''${FILE}" | json-to-dhall --records-loose --unions-strict "./types/v1/Manifest.dhall" > /dev/null
+            done
+          '';
         };
-      in {
-        devShells = {
-          default = pkgs.mkShell {
-            name = "registry";
-            packages = with pkgs; [
-              # Helpful utilities
-              scripts
-              compilers
+      };
+    in {
+      devShells = {
+        default = pkgs.mkShell {
+          name = "registry";
+          packages = with pkgs; [
+            # Helpful utilities
+            scripts
+            compilers
 
-              # Project tooling
-              nixFlakes
-              nixfmt
-              openssh
-              git
-              bash
-              nodejs
-              jq
-              licensee
-              coreutils
-              gzip
+            # Project tooling
+            nixFlakes
+            nixfmt
+            openssh
+            git
+            bash
+            nodejs
+            jq
+            licensee
+            coreutils
+            gzip
+            nodePackages.bower
 
-              dhallPackages.dhall-simple
-              dhallPackages.dhall-json-simple
+            dhallPackages.dhall-simple
+            dhallPackages.dhall-json-simple
 
-              # Development tooling
-              pursPackages.purs
-              pursPackages.spago-next
-              pursPackages.psa
-              pursPackages.purs-tidy
-              nodePackages.bower
-            ];
-          };
+            # Development tooling
+            pursPackages.purs
+            spago-unstable
+            pursPackages.purs-tidy
+          ];
         };
-      });
+      };
+    });
 }


### PR DESCRIPTION
This updates the flake to the latest versions (and formats it). The only significant changes are:

* easy-purescript-nix now supports flakes, so we switch to that and the usual upstream
* purix supports spago-unstable and we'll use it to develop the nix build, so we add that flake input
* easy-purescript-nix refers to "nodejs_18" instead of the nixpkgs "nodejs-18_x", so we add that name to our overlay