### PR TITLE
Remove easy-purescript-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,24 +16,6 @@
         "type": "github"
       }
     },
-    "easy-purescript-nix": {
-      "inputs": {
-        "flake-utils": "flake-utils"
-      },
-      "locked": {
-        "lastModified": 1686900973,
-        "narHash": "sha256-9whTjp8BYy8ZzyghhgbawS06/dVESduME3wsdNH/mpk=",
-        "owner": "justinwoo",
-        "repo": "easy-purescript-nix",
-        "rev": "8cf400656945b2f2bacfd6a8775792aa701f60e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "justinwoo",
-        "repo": "easy-purescript-nix",
-        "type": "github"
-      }
-    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -55,29 +37,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1687171271,
+        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
         "type": "github"
       },
       "original": {
@@ -109,11 +73,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687105678,
-        "narHash": "sha256-Y7BZBiXXb6iKXE+cWSWbrc6eTCKsnuPJO01mGBb50Cs=",
+        "lastModified": 1687203811,
+        "narHash": "sha256-TA4mYTlo1pSBezRqlsvUZEFX386FGXe3aj84Me+qBVU=",
         "owner": "thomashoneyman",
         "repo": "purix",
-        "rev": "796c9ec8c836df7cca18c5ea54c265579e02d5c7",
+        "rev": "8840b72a182d79ad85156a308affe249eb0f7595",
         "type": "github"
       },
       "original": {
@@ -125,29 +89,13 @@
     "root": {
       "inputs": {
         "easy-dhall-nix": "easy-dhall-nix",
-        "easy-purescript-nix": "easy-purescript-nix",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "purix": "purix"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -16,11 +16,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Temporary until purs-tidy is supported by purix
-    easy-purescript-nix = {
-      url = "github:justinwoo/easy-purescript-nix";
-    };
-
     easy-dhall-nix = {
       url = "github:justinwoo/easy-dhall-nix";
       flake = false;
@@ -32,22 +27,14 @@
     nixpkgs,
     flake-utils,
     purix,
-    easy-purescript-nix,
     easy-dhall-nix,
     ...
   }: let
     supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
 
     registryOverlay = final: prev: {
-      # Annoyingly, easy-purescript-nix refers to 'nodejs_18' instead of
-      # 'nodejs-18_x', so we need to add that name and then have easy-ps-nix
-      # refer to the final result.
-      nodejs_18 = prev.nodejs-18_x;
-      pursPackages = final.callPackage easy-purescript-nix {};
-
-      dhallPackages = prev.callPackage easy-dhall-nix {};
-
       nodejs = prev.nodejs-18_x;
+      dhallPackages = prev.callPackage easy-dhall-nix {};
 
       # We don't want to force everyone to update their configs if they aren't
       # normally on flakes.
@@ -62,12 +49,13 @@
         overlays = [purix.overlays.default registryOverlay];
       };
 
-      # Produces a list of all PureScript binaries supported by easy-purescript-nix,
-      # callable using the naming convention `purs-MAJOR_MINOR_PATCH`.
+      # Produces a list of all PureScript binaries supported by purix, ie. those
+      # from 0.13 onwards, callable using the naming convention
+      # `purs-MAJOR_MINOR_PATCH`.
       #   $ purs-0_14_0 --version
       #   0.14.0
       #
-      # To add a new compiler to the list, just update easy-purescript-nix:
+      # To add a new compiler to the list, just update purix:
       #   $ nix flake update
       compilers = let
         # Only include the compiler at normal MAJOR.MINOR.PATCH versions.
@@ -193,9 +181,10 @@
             dhallPackages.dhall-json-simple
 
             # Development tooling
-            pursPackages.purs
+            purs-unstable
             spago-unstable
-            pursPackages.purs-tidy
+            purs-tidy-unstable
+            purs-backend-es-unstable
           ];
         };
       };


### PR DESCRIPTION
[purix](https://github.com/thomashoneyman/purix) supports all the dev tools we need, namely purs, spago, purs-tidy, and purs-backend-es, and we already use it to gain access to purescript compilers, so this unifies our tooling via purix and drops easy-purescript-nix.