### PR TITLE
Use package set compiler, not local compiler

### DIFF
--- a/scripts/src/PackageSetUpdater.purs
+++ b/scripts/src/PackageSetUpdater.purs
@@ -125,16 +125,7 @@ updater = do
 
   PackageSets.validatePackageSet prevPackageSet
 
-  let
-    -- This record comes from the build directory (.spago) and records information
-    -- from the most recent build.
-    localCompiler = unsafeFromRight (Version.parse BuildInfo.buildInfo.pursVersion)
-    -- We use the greater of the local compiler version or the last package set
-    -- version to upgrade the package sets. This automatically bumps the purs
-    -- version when the registry upgrades to a new compiler.
-    compiler = do
-      let prev = (un PackageSet prevPackageSet).compiler
-      if localCompiler > prev then localCompiler else prev
+  let compiler = (un PackageSet prevPackageSet).compiler
 
   Log.info $ "Using compiler " <> Version.print compiler
 


### PR DESCRIPTION
This [workflow run of the package set updater](https://github.com/purescript/registry/actions/runs/5374953693/jobs/9750836769) failed with the following logs because the script tries to use the local compiler (the one in the development shell) if it is greater than the latest package sets compiler. But the local compiler is an unstable version (0.15.0 prerelease) and there is no stable version of that compiler available, so the run fails.

We really ought to use the current compiler in the package sets and manually run a package set update if we want to change that version. Having it depend on the development shell means we can easily inadvertently downgrade the package sets or upgrade them when all we meant to do was change our dev setup.

This PR fixes the issue by always using the latest package set's compiler version. To upgrade the set version, we'd go through the ordinary package set update process on the registry repo.

Here are the relevant logs:

```console
> nix develop --command 'registry-package-set-updater' 'commit'

Reading Spago workspace configuration...
Read the package set from the registry

✅ Selecting package to build: registry-scripts

Downloading dependencies...
Building...
           Src   Lib   All
Warnings     0     0     0
Errors       0     0     0

✅ Build succeeded.

(node:12618) NOTE: We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
(Use `node --trace-warnings ...` to show where the warning was created)
Reading latest package set from directory scratch/registry/package-sets
No cached manifest index, reading from disk...
Using compiler 0.15.10
No cached metadata map, reading from disk...
Reading metadata for all packages from directory scratch/registry/metadata
Found package versions eligible for inclusion in package set: 
  - bookhound@0.1.3
Performing atomic upgrade of package set 27.3.0
[ERROR] Compilation failed because compiler 0.15.10 is missing.
```