### PR TITLE
Include runtime deps in nix builds

### DIFF
--- a/app/default.nix
+++ b/app/default.nix
@@ -9,6 +9,7 @@
   writeText,
   nodejs,
   compilers,
+  dhall,
   dhall-json,
   git,
   licensee
@@ -64,7 +65,7 @@ in {
     '';
     postFixup = ''
       wrapProgram $out/bin/${name} \
-        --set PATH ${lib.makeBinPath [ compilers dhall-json licensee git ]}
+        --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git ]}
     '';
   };
 
@@ -93,7 +94,7 @@ in {
     '';
     postFixup = ''
       wrapProgram $out/bin/${name} \
-        --set PATH ${lib.makeBinPath [ compilers dhall-json licensee git ]}
+        --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git ]}
     '';
   };
 }

--- a/app/default.nix
+++ b/app/default.nix
@@ -1,12 +1,17 @@
 {
+  makeWrapper,
+  lib,
   stdenv,
   purix,
   slimlock,
   purs-backend-es,
   esbuild,
   writeText,
-  compilers,
   nodejs,
+  compilers,
+  dhall-json,
+  git,
+  licensee
 }: let
   package-lock = slimlock.buildPackageLock {src = ../.; omit = ["dev" "peer"];};
   spago-lock = purix.buildSpagoLock {
@@ -37,8 +42,8 @@ in {
   server = stdenv.mkDerivation rec {
     name = "registry-server";
     src = ./src;
-    nativeBuildInputs = [esbuild];
-    buildInputs = [compilers nodejs];
+    nativeBuildInputs = [esbuild makeWrapper];
+    buildInputs = [nodejs];
     entrypoint = writeText "entrypoint.js" ''
       import { main } from "./output/Registry.App.Server";
       main();
@@ -57,13 +62,17 @@ in {
       chmod +x $out/bin/${name}
       cp ${name}.js $out
     '';
+    postFixup = ''
+      wrapProgram $out/bin/${name} \
+        --set PATH ${lib.makeBinPath [ compilers dhall-json licensee git ]}
+    '';
   };
 
   github-importer = stdenv.mkDerivation rec {
     name = "registry-github-importer";
     src = ./src;
-    nativeBuildInputs = [esbuild];
-    buildInputs = [compilers nodejs];
+    nativeBuildInputs = [esbuild makeWrapper];
+    buildInputs = [nodejs];
     entrypoint = writeText "entrypoint.js" ''
       import { main } from "./output/Registry.App.Main";
       main();
@@ -74,16 +83,17 @@ in {
       cp ${entrypoint} entrypoint.js
       esbuild entrypoint.js --bundle --outfile=${name}.js --platform=node
     '';
-    checkPhase = ''
-
-    '';
     installPhase = ''
       mkdir -p $out/bin
       cp ${name}.js $out/${name}.js
       echo '#!/usr/bin/env sh' > $out/bin/${name}
-      echo 'exec node '"$out/${name}.js"' "$@"' >> $out/bin/${name}
+      echo 'exec ${nodejs}/bin/node '"$out/${name}.js"' "$@"' >> $out/bin/${name}
       chmod +x $out/bin/${name}
       cp ${name}.js $out
+    '';
+    postFixup = ''
+      wrapProgram $out/bin/${name} \
+        --set PATH ${lib.makeBinPath [ compilers dhall-json licensee git ]}
     '';
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -60,9 +60,9 @@
             stableOnly;
           };
       in {
+        inherit compilers;
         apps = prev.callPackages ./app {inherit compilers;};
         scripts = prev.callPackages ./scripts {inherit compilers;};
-        inherit compilers;
       };
     };
   in

--- a/flake.nix
+++ b/flake.nix
@@ -232,7 +232,7 @@
             registry.wait_for_unit("server.service")
             # We wait for the server to be ready; without this, in CI sometimes
             # the client starts sending requests before the server is ready.
-            client.wait_until_succeeds("${pkgs.curl}/bin/curl http://registry/api/v1/jobs/0", timeout=180)
+            client.wait_until_succeeds("${pkgs.curl}/bin/curl --fail-with-body http://registry/api/v1/jobs/0", timeout=180)
 
             def test_endpoint(endpoint, expected):
               actual = client.succeed(f"${pkgs.curl}/bin/curl http://registry/api/v1/{endpoint}")

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,8 +5,6 @@ in {
   environment = {
     systemPackages = [
       pkgs.vim
-      # FIXME: This should be picked up via the buildInputs, surely? It's not.
-      pkgs.registry.compilers
     ];
   };
 

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -1,4 +1,4 @@
-{ makeWrapper, lib, stdenv, purix, slimlock, esbuild, nodejs, writeText, compilers, dhall-json, licensee, git }:
+{ makeWrapper, lib, stdenv, purix, slimlock, esbuild, nodejs, writeText, compilers, dhall, dhall-json, licensee, git }:
 let
   package-lock = slimlock.buildPackageLock { src = ../.; omit = ["dev" "peer"];};
 
@@ -35,7 +35,7 @@ let
       '';
       postFixup = ''
         wrapProgram $out/bin/${name} \
-          --set PATH ${lib.makeBinPath [ compilers dhall-json licensee git ]}
+          --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git ]}
       '';
       };
 in {


### PR DESCRIPTION
In #618 and #619 I added full Nix builds for the registry such that we can run deployments to our NixOS machine via Colmena, and can run any script from this repository with a simple `nix run ...` command. Unfortunately, since you aren't running this from the context of the Nix shell, I forgot to ensure runtime dependencies were included in the builds.

If you were running these commands from within the local Nix shell then you were fine, but in CI and on the server we aren't in a shell and so runtime dependencies like `licensee` are not being picked up.

This PR adds those dependencies to the PATH for each build.