### PR TITLE
Also add gnutar to builds

### DIFF
--- a/app/default.nix
+++ b/app/default.nix
@@ -14,7 +14,8 @@
   git,
   licensee,
   coreutils,
-  gzip
+  gzip,
+  gnutar
 }: let
   package-lock = slimlock.buildPackageLock {src = ../.; omit = ["dev" "peer"];};
   spago-lock = purix.buildSpagoLock {
@@ -67,7 +68,7 @@ in {
     '';
     postFixup = ''
       wrapProgram $out/bin/${name} \
-        --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git coreutils gzip ]}
+        --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git coreutils gzip gnutar ]}
     '';
   };
 
@@ -96,7 +97,7 @@ in {
     '';
     postFixup = ''
       wrapProgram $out/bin/${name} \
-        --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git coreutils gzip ]}
+        --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git coreutils gzip gnutar ]}
     '';
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -267,6 +267,7 @@
             licensee
             coreutils
             gzip
+            gnutar
             dhall
             dhall-json
 

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -1,4 +1,4 @@
-{ makeWrapper, lib, stdenv, purix, slimlock, esbuild, nodejs, writeText, compilers, dhall, dhall-json, licensee, git, coreutils, gzip }:
+{ makeWrapper, lib, stdenv, purix, slimlock, esbuild, nodejs, writeText, compilers, dhall, dhall-json, licensee, git, coreutils, gzip, gnutar }:
 let
   package-lock = slimlock.buildPackageLock { src = ../.; omit = ["dev" "peer"];};
 
@@ -35,7 +35,7 @@ let
       '';
       postFixup = ''
         wrapProgram $out/bin/${name} \
-          --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git coreutils gzip ]}
+          --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git coreutils gzip gnutar ]}
       '';
       };
 in {


### PR DESCRIPTION
The run of the importer showed an issue with empty tarballs being created, so this adds gnutar as well. I won't merge it yet — going to wait for the legacy importer to run and verify this is working as expected, as I expected the last PR to work (tar is available, but something is strange with the tar being used in the runner).