### PR TITLE
Support purs-0.15.10

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688722168,
-        "narHash": "sha256-UDqeQd2neUXICpHAZSS965kGCJsfHkrOFS/vl80I7d8=",
+        "lastModified": 1689715163,
+        "narHash": "sha256-HgBowH0RUU+6SpvpXYfTSunAqaME/6d0bqAW+shW6e4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "28d812a63a0f0d6c1170aac16f5219e506c44b79",
+        "rev": "0171976ee0a1fa795b105c19a323e67b9c6094d9",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "slimlock": "slimlock"
       },
       "locked": {
-        "lastModified": 1688687419,
-        "narHash": "sha256-r0pgkPXAVu2MXJObZ6kFNHj1uHSRIZZeAsULBwjY1W4=",
+        "lastModified": 1689725005,
+        "narHash": "sha256-NqpH/tNK0fuDNWfKW+guYbhfzPl6G9E+xUpNBq96usI=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "a32ad9c1b4f8661cef6ea8fc1b70aa02576c5041",
+        "rev": "6a7feaf0b0dc8ac5d9fdfd92e80b0aea306109b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates to the latest `purescript-overlay`, which includes the newly-released PureScript 0.15.10.