### PR TITLE
Fix purs stable filtering regex

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
         compilers = let
           # Only include the compiler at normal MAJOR.MINOR.PATCH versions.
           stableOnly =
-            prev.lib.filterAttrs (name: _: (builtins.match "^purs-[0-9]_[0-9]+_[0-9]$" name != null))
+            prev.lib.filterAttrs (name: _: (builtins.match "^purs-[0-9]+_[0-9]+_[0-9]+$" name != null))
             prev.purs-bin;
         in
           prev.symlinkJoin {


### PR DESCRIPTION
While we indeed have support for 0.15.10, the Nix filter in the compilers attribute was poorly written (my bad) and only admitted purs versions with a single major or patch digit instead of multiple.