### PR TITLE
Add purs-versions script to list supported registry versions

### DIFF
--- a/app/default.nix
+++ b/app/default.nix
@@ -8,6 +8,7 @@
   writeText,
   nodejs,
   compilers,
+  purs-versions,
   dhall,
   dhall-json,
   git,
@@ -76,7 +77,7 @@ in {
     '';
     postFixup = ''
       wrapProgram $out/bin/${name} \
-        --set PATH ${lib.makeBinPath [compilers dhall dhall-json licensee git coreutils gzip gnutar]}
+        --set PATH ${lib.makeBinPath [compilers purs-versions dhall dhall-json licensee git coreutils gzip gnutar]}
     '';
   };
 
@@ -109,7 +110,7 @@ in {
     '';
     postFixup = ''
       wrapProgram $out/bin/${name} \
-        --set PATH ${lib.makeBinPath [compilers dhall dhall-json licensee git coreutils gzip gnutar]}
+        --set PATH ${lib.makeBinPath [compilers purs-versions dhall dhall-json licensee git coreutils gzip gnutar]}
     '';
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
           };
 
         purs-versions = prev.writeShellScriptBin "purs-versions" ''
-          echo ${builtins.concatStringsSep " " (prev.lib.attrNames supportedCompilers)}
+          echo ${prev.lib.concatMapStringsSep " " (x: prev.lib.removePrefix "purs-" (builtins.replaceStrings ["_"] ["."] x)) (prev.lib.attrNames supportedCompilers)}
         '';
       in {
         apps = prev.callPackages ./app {

--- a/flake.nix
+++ b/flake.nix
@@ -71,28 +71,31 @@
         #
         # To add a new compiler to the list, just update the flake:
         #   $ nix flake update
-        compilers = let
-          # Only include the compiler at normal MAJOR.MINOR.PATCH versions.
-          stableOnly =
-            prev.lib.filterAttrs (name: _: (builtins.match "^purs-[0-9]+_[0-9]+_[0-9]+$" name != null))
-            prev.purs-bin;
-        in
+        supportedCompilers = prev.lib.filterAttrs (name: _: (builtins.match "^purs-[0-9]+_[0-9]+_[0-9]+$" name != null)) prev.purs-bin;
+
+        # An attrset containing all the PureScript binaries we want to make
+        # available.
+        compilers = 
           prev.symlinkJoin {
             name = "purs-compilers";
             paths = prev.lib.mapAttrsToList (name: drv:
               prev.writeShellScriptBin name ''
                 exec ${drv}/bin/purs "$@"
               '')
-            stableOnly;
+            supportedCompilers;
           };
+
+        purs-versions = prev.writeShellScriptBin "purs-versions" ''
+          echo ${builtins.concatStringsSep " " (prev.lib.attrNames supportedCompilers)}
+        '';
       in {
         apps = prev.callPackages ./app {
-          inherit compilers package-lock spago-lock;
+          inherit compilers purs-versions package-lock spago-lock;
         };
         scripts = prev.callPackages ./scripts {
-          inherit compilers package-lock spago-lock;
+          inherit compilers purs-versions package-lock spago-lock;
         };
-        inherit compilers package-lock spago-lock;
+        inherit purs-versions compilers package-lock spago-lock;
       };
     };
   in
@@ -278,6 +281,7 @@
           packages = with pkgs; [
             # All stable PureScript compilers
             registry.compilers
+            registry.purs-versions
 
             # TODO: Hacky, remove when I can run spago test in a pure env
             run-tests-script

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -7,6 +7,7 @@
   nodejs,
   writeText,
   compilers,
+  purs-versions,
   dhall,
   dhall-json,
   licensee,
@@ -48,7 +49,7 @@
       '';
       postFixup = ''
         wrapProgram $out/bin/${name} \
-          --set PATH ${lib.makeBinPath [ compilers dhall dhall-json licensee git coreutils gzip gnutar ]}
+          --set PATH ${lib.makeBinPath [ compilers purs-versions dhall dhall-json licensee git coreutils gzip gnutar ]}
       '';
       };
 in {


### PR DESCRIPTION
To support #255 we need to know the full list of compilers that the registry supports. The registry supports whatever the `compilers` attrset in the `flake.nix` is, and that in turn comes from the `purescript-overlay` repository, which seeks to support all compilers from 0.13.0 onwards.

This PR adds a script named `purs-versions` that, when called, will spit out all the compilers supported by the registry separated by spaces. For example:

```
λ purs-versions
0.13.0 0.13.2 0.13.3 0.13.4 0.13.5 0.13.6 0.13.8 0.14.0 0.14.1 0.14.2 0.14.3 0.14.4 0.14.5 0.14.6 0.14.7 0.14.8 0.14.9 0.15.0 0.15.10 0.15.2 0.15.3 0.15.4 0.15.5 0.15.6 0.15.7 0.15.9
```

Note: the output is sorted by the string keys seen here, which is not suitable to order by versions because (for example) a string "0.15.10" is considered greater than "0.15.1" but less than "0.15.2", which is obviously incorrect as far as SemVer goes. So anyone consuming this should parse these strings into actual `Version`s and sort them, if they need a sorted order.