### PR TITLE
Add `pursVersions` CLI script

### DIFF
--- a/app/src/App/CLI/PursVersions.purs
+++ b/app/src/App/CLI/PursVersions.purs
@@ -1,0 +1,26 @@
+module Registry.App.CLI.PursVersions where
+
+import Registry.App.Prelude
+
+import Data.Array as Array
+import Data.Array.NonEmpty as NEA
+import Data.String as String
+import Node.Library.Execa as Execa
+import Registry.Version as Version
+import Run (AFF, Run)
+import Run as Run
+import Run.Except (EXCEPT)
+import Run.Except as Except
+
+pursVersions :: forall r. Run (EXCEPT String + AFF + r) (NonEmptyArray Version)
+pursVersions = do
+  result <- Run.liftAff $ _.result =<< Execa.execa "purs-versions" [] identity
+  { stdout } <- Except.rethrow $ lmap (\{ stdout, stderr } -> stdout <> stderr) result
+  let { fail, success } = partitionEithers $ map Version.parse (String.split (String.Pattern " ") stdout)
+
+  when (Array.length fail > 0) do
+    Except.throw (String.joinWith ", " fail)
+
+  case NEA.fromArray success of
+    Nothing -> Except.throw "No purs versions"
+    Just arr -> pure arr

--- a/app/test/App/CLI/PursVersions.purs
+++ b/app/test/App/CLI/PursVersions.purs
@@ -4,21 +4,11 @@ import Registry.App.Prelude
 
 import Data.Array as Array
 import Data.Array.NonEmpty as NEA
-import Effect.Class.Console as Console
-import Node.Process as Process
 import Registry.App.CLI.PursVersions (pursVersions)
 import Registry.Test.Assert as Assert
+import Registry.Test.Assert.Run as Test.Run
 import Registry.Version as Version
-import Run (AFF, EFFECT, Run)
-import Run as Run
-import Run.Except (EXCEPT)
-import Run.Except as Except
 import Test.Spec as Spec
-
-interpret :: forall a. Run (EXCEPT String + AFF + EFFECT + ()) a -> Aff a
-interpret =
-  Except.catch (\error -> Run.liftEffect (Console.log error *> Process.exit 1))
-    >>> Run.runBaseAff'
 
 -- NOTE: This should be kept up to date as new versions of the compiler are released.
 -- Upon release of a new compiler version and update of `purescript-overlay`, the tests below will fail until the version is added here.
@@ -56,6 +46,6 @@ knownCompilers = map (unsafeFromRight <<< Version.parse)
 spec :: Spec.Spec Unit
 spec = do
   Spec.it "All expected versions are present in purs-version" do
-    versionsNonEmpty <- interpret pursVersions
+    versionsNonEmpty <- Test.Run.runBaseEffects pursVersions
     let versions = NEA.toArray versionsNonEmpty
     Array.sort versions `Assert.shouldEqual` Array.sort knownCompilers

--- a/app/test/App/CLI/PursVersions.purs
+++ b/app/test/App/CLI/PursVersions.purs
@@ -1,0 +1,61 @@
+module Test.Registry.App.CLI.PursVersions (spec) where
+
+import Registry.App.Prelude
+
+import Data.Array as Array
+import Data.Array.NonEmpty as NEA
+import Effect.Class.Console as Console
+import Node.Process as Process
+import Registry.App.CLI.PursVersions (pursVersions)
+import Registry.Test.Assert as Assert
+import Registry.Version as Version
+import Run (AFF, EFFECT, Run)
+import Run as Run
+import Run.Except (EXCEPT)
+import Run.Except as Except
+import Test.Spec as Spec
+
+interpret :: forall a. Run (EXCEPT String + AFF + EFFECT + ()) a -> Aff a
+interpret =
+  Except.catch (\error -> Run.liftEffect (Console.log error *> Process.exit 1))
+    >>> Run.runBaseAff'
+
+-- NOTE: This should be kept up to date as new versions of the compiler are released.
+-- Upon release of a new compiler version and update of `purescript-overlay`, the tests below will fail until the version is added here.
+knownCompilers :: Array Version
+knownCompilers = map (unsafeFromRight <<< Version.parse)
+  [ "0.13.0"
+  , "0.13.2"
+  , "0.13.3"
+  , "0.13.4"
+  , "0.13.5"
+  , "0.13.6"
+  , "0.13.8"
+  , "0.14.0"
+  , "0.14.1"
+  , "0.14.2"
+  , "0.14.3"
+  , "0.14.4"
+  , "0.14.5"
+  , "0.14.6"
+  , "0.14.7"
+  , "0.14.8"
+  , "0.14.9"
+  , "0.15.0"
+  , "0.15.2"
+  , "0.15.3"
+  , "0.15.4"
+  , "0.15.5"
+  , "0.15.6"
+  , "0.15.7"
+  , "0.15.8"
+  , "0.15.9"
+  , "0.15.10"
+  ]
+
+spec :: Spec.Spec Unit
+spec = do
+  Spec.it "All expected versions are present in purs-version" do
+    versionsNonEmpty <- interpret pursVersions
+    let versions = NEA.toArray versionsNonEmpty
+    Array.sort versions `Assert.shouldEqual` Array.sort knownCompilers

--- a/app/test/Main.purs
+++ b/app/test/Main.purs
@@ -7,6 +7,7 @@ import Test.Registry.App.API as Test.API
 import Test.Registry.App.Auth as Test.Auth
 import Test.Registry.App.CLI.Licensee as Test.CLI.Licensee
 import Test.Registry.App.CLI.Purs as Test.CLI.Purs
+import Test.Registry.App.CLI.PursVersions as Test.CLI.PursVersions
 import Test.Registry.App.CLI.Tar as Test.CLI.Tar
 import Test.Registry.App.Effect.PackageSets as Test.Effect.PackageSets
 import Test.Registry.App.GitHubIssue as Test.GitHubIssue
@@ -24,6 +25,7 @@ main = launchAff_ $ runSpec' (defaultConfig { timeout = Just $ Milliseconds 10_0
     Spec.describe "Licensee" Test.CLI.Licensee.spec
     Spec.describe "Tar" Test.CLI.Tar.spec
     Spec.describe "Purs" Test.CLI.Purs.spec
+    Spec.describe "PursVersions" Test.CLI.PursVersions.spec
 
   Spec.describe "Registry.App.Effect" do
     Test.Effect.PackageSets.spec


### PR DESCRIPTION
To support https://github.com/purescript/registry-dev/issues/255 we need to know the full list of compilers that the registry supports.

#628 added a script we can run to fetch all supported versions of the `purs` executable.

This PR adds the `Registry.App.CLI.PursVersions` module, which can be used to call that script within the registry codebase.

Errors are handled in the following way:
* An error that occurs calling `purs-versions` is thrown
* An error is thrown with all output of `purs-version` which fail to parse
* An error is thrown if the output of `purs-versions` is empty

I've added a test that makes sure the output of this utility matches what we expect it to be.
This means that when a new compiler version is released and `purescript-overlay` is updated, registry things will start failing until the new version is added to the snapshot. I've discussed this with @thomashoneyman and we think that behavior is desired, as it allows us to make sure we are supporting the full set of compiler versions we expect, without having to hard code them anywhere in registry app code.