### PR TITLE
Make dhall types directory configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ PACCHETTIBOTTI_ED25519="YWJjeHl6"
 
 # The location of the sqlite database file.
 DATABASE_URL="sqlite:db/registry.sqlite3"
+
+# The location of the Dhall specifications
+DHALL_TYPES="types"

--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,4 @@ PACCHETTIBOTTI_ED25519="YWJjeHl6"
 DATABASE_URL="sqlite:db/registry.sqlite3"
 
 # The location of the Dhall specifications
-DHALL_TYPES="types"
+DHALL_TYPES="./types"

--- a/app/default.nix
+++ b/app/default.nix
@@ -44,7 +44,6 @@ in {
     name = "registry-server";
     src = ./.;
     database = ../db;
-    dhallTypes = ../types;
     nativeBuildInputs = [esbuild makeWrapper];
     buildInputs = [nodejs];
     entrypoint = writeText "entrypoint.js" ''
@@ -64,9 +63,6 @@ in {
       cp ${name}.js $out/${name}.js
       ln -s ${package-lock}/js/node_modules $out
 
-      echo "Copying Dhall types..."
-      cp -r ${dhallTypes} $out/bin/types
-
       echo "Copying database..."
       cp -r ${database} $out/bin/db
 
@@ -77,7 +73,8 @@ in {
     '';
     postFixup = ''
       wrapProgram $out/bin/${name} \
-        --set PATH ${lib.makeBinPath [compilers purs-versions dhall dhall-json licensee git coreutils gzip gnutar]}
+        --set PATH ${lib.makeBinPath [compilers purs-versions dhall dhall-json licensee git coreutils gzip gnutar]} \
+        --set DHALL_TYPES ${../types}
     '';
   };
 
@@ -110,7 +107,8 @@ in {
     '';
     postFixup = ''
       wrapProgram $out/bin/${name} \
-        --set PATH ${lib.makeBinPath [compilers purs-versions dhall dhall-json licensee git coreutils gzip gnutar]}
+        --set PATH ${lib.makeBinPath [compilers purs-versions dhall dhall-json licensee git coreutils gzip gnutar]} \
+        --set DHALL_TYPES ${../types}
     '';
   };
 }

--- a/app/src/App/CLI/Git.purs
+++ b/app/src/App/CLI/Git.purs
@@ -261,11 +261,11 @@ gitPush { address, committer } cwd = Except.runExcept do
       let
         inRepoErr error = " in local checkout " <> cwd <> ": " <> error
 
-        origin :: URL
-        origin = coerce (mkOrigin address committer)
+        repoOrigin :: URL
+        repoOrigin = coerce (mkOrigin address committer)
 
-      _ <- withGit cwd [ "push", origin ] \error ->
-        "Failed to push to " <> origin <> " from " <> status.branch <> inRepoErr error
+      _ <- withGit cwd [ "push", repoOrigin ] \error ->
+        "Failed to push to " <> address.owner <> "/" <> address.repo <> " from " <> status.branch <> inRepoErr error
 
       pure Changed
 

--- a/app/src/App/Effect/Env.purs
+++ b/app/src/App/Effect/Env.purs
@@ -18,6 +18,23 @@ import Run.Reader as Run.Reader
 
 -- | Environment fields available in the GitHub Event environment, namely
 -- | pointers to the user who created the event and the issue associated with it.
+type DhallEnv =
+  { typesDir :: FilePath
+  }
+
+type DHALL_ENV r = (dhallEnv :: Reader DhallEnv | r)
+
+_dhallEnv :: Proxy "dhallEnv"
+_dhallEnv = Proxy
+
+askDhallEnv :: forall r. Run (DHALL_ENV + r) DhallEnv
+askDhallEnv = Run.Reader.askAt _dhallEnv
+
+runDhallEnv :: forall r a. DhallEnv -> Run (DHALL_ENV + r) a -> Run r a
+runDhallEnv = Run.Reader.runReaderAt _dhallEnv
+
+-- | Environment fields available in the GitHub Event environment, namely
+-- | pointers to the user who created the event and the issue associated with it.
 type GitHubEventEnv =
   { username :: String
   , issue :: IssueNumber
@@ -117,6 +134,10 @@ type DatabaseUrl = { prefix :: String, path :: FilePath }
 -- | The location of the sqlite database
 databaseUrl :: EnvKey DatabaseUrl
 databaseUrl = EnvKey { key: "DATABASE_URL", decode: decodeDatabaseUrl }
+
+-- | The location of the Dhall specifications directory
+dhallTypes :: EnvKey FilePath
+dhallTypes = EnvKey { key: "DHALL_TYPES", decode: pure }
 
 -- | A GitHub token for the @pacchettibotti user at the PACCHETTIBOTTI_TOKEN key.
 pacchettibottiToken :: EnvKey GitHubToken

--- a/app/src/App/GitHubIssue.purs
+++ b/app/src/App/GitHubIssue.purs
@@ -93,6 +93,7 @@ main = launchAff_ $ do
     thrownRef <- liftEffect $ Ref.new false
 
     run
+      # Env.runDhallEnv { typesDir: env.dhallTypes }
       # Env.runGitHubEventEnv { username: env.username, issue: env.issue }
       # Env.runPacchettiBottiEnv { publicKey: env.publicKey, privateKey: env.privateKey }
       -- App effects
@@ -127,6 +128,7 @@ type GitHubEventEnv =
   , spacesConfig :: SpaceKey
   , publicKey :: String
   , privateKey :: String
+  , dhallTypes :: FilePath
   }
 
 initializeGitHub :: Aff (Maybe GitHubEventEnv)
@@ -136,6 +138,7 @@ initializeGitHub = do
   privateKey <- Env.lookupRequired Env.pacchettibottiED25519
   spacesKey <- Env.lookupRequired Env.spacesKey
   spacesSecret <- Env.lookupRequired Env.spacesSecret
+  dhallTypes <- Env.lookupRequired Env.dhallTypes
   eventPath <- Env.lookupRequired Env.githubEventPath
 
   octokit <- Octokit.newOctokit token
@@ -171,6 +174,7 @@ initializeGitHub = do
         , spacesConfig: { key: spacesKey, secret: spacesSecret }
         , publicKey
         , privateKey
+        , dhallTypes
         }
 
 data OperationDecoding

--- a/app/src/App/GitHubIssue.purs
+++ b/app/src/App/GitHubIssue.purs
@@ -138,7 +138,9 @@ initializeGitHub = do
   privateKey <- Env.lookupRequired Env.pacchettibottiED25519
   spacesKey <- Env.lookupRequired Env.spacesKey
   spacesSecret <- Env.lookupRequired Env.spacesSecret
-  dhallTypes <- Env.lookupRequired Env.dhallTypes
+  dhallTypes <- do
+    types <- Env.lookupRequired Env.dhallTypes
+    liftEffect $ Path.resolve [] types
   eventPath <- Env.lookupRequired Env.githubEventPath
 
   octokit <- Octokit.newOctokit token

--- a/app/src/App/Server.purs
+++ b/app/src/App/Server.purs
@@ -26,7 +26,7 @@ import Registry.App.Effect.Comment (COMMENT)
 import Registry.App.Effect.Comment as Comment
 import Registry.App.Effect.Db (DB)
 import Registry.App.Effect.Db as Db
-import Registry.App.Effect.Env (DatabaseUrl, PACCHETTIBOTTI_ENV)
+import Registry.App.Effect.Env (DHALL_ENV, DatabaseUrl, PACCHETTIBOTTI_ENV)
 import Registry.App.Effect.Env as Env
 import Registry.App.Effect.GitHub (GITHUB)
 import Registry.App.Effect.GitHub as GitHub
@@ -65,19 +65,17 @@ router env { route, method, body } = HTTPurple.usingCont case route, method of
   Publish, Post -> do
     publish <- HTTPurple.fromJson (jsonDecoder Operation.publishCodec) body
     lift $ Log.info $ "Received Publish request: " <> printJson Operation.publishCodec publish
-    forkPipelineJob publish.name publish.ref PublishJob
-      \jobId -> do
-        Log.info $ "Received Publish request, job id: " <> unwrap jobId
-        API.publish Current publish
+    forkPipelineJob publish.name publish.ref PublishJob \jobId -> do
+      Log.info $ "Received Publish request, job id: " <> unwrap jobId
+      API.publish Current publish
 
   Unpublish, Post -> do
     auth <- HTTPurple.fromJson (jsonDecoder Operation.authenticatedCodec) body
     case auth.payload of
       Operation.Unpublish { name, version } -> do
-        forkPipelineJob name (Version.print version) UnpublishJob
-          \jobId -> do
-            Log.info $ "Received Unpublish request, job id: " <> unwrap jobId
-            API.authenticated auth
+        forkPipelineJob name (Version.print version) UnpublishJob \jobId -> do
+          Log.info $ "Received Unpublish request, job id: " <> unwrap jobId
+          API.authenticated auth
       _ ->
         HTTPurple.badRequest "Expected unpublish operation."
 
@@ -85,10 +83,9 @@ router env { route, method, body } = HTTPurple.usingCont case route, method of
     auth <- HTTPurple.fromJson (jsonDecoder Operation.authenticatedCodec) body
     case auth.payload of
       Operation.Transfer { name } -> do
-        forkPipelineJob name "" TransferJob
-          \jobId -> do
-            Log.info $ "Received Transfer request, job id: " <> unwrap jobId
-            API.authenticated auth
+        forkPipelineJob name "" TransferJob \jobId -> do
+          Log.info $ "Received Transfer request, job id: " <> unwrap jobId
+          API.authenticated auth
       _ ->
         HTTPurple.badRequest "Expected transfer operation."
 
@@ -127,9 +124,12 @@ router env { route, method, body } = HTTPurple.usingCont case route, method of
         let newEnv = env { jobId = Just jobId }
 
         _fiber <- liftAff $ Aff.forkAff $ Aff.attempt $ do
-          void $ runEffects newEnv (action jobId)
-          finishedAt <- nowUTC
-          void $ runEffects newEnv (Db.finishJob { jobId, finishedAt, success: true })
+          result <- runEffects newEnv (action jobId)
+          case result of
+            Left _ -> pure unit
+            Right _ -> do
+              finishedAt <- nowUTC
+              void $ runEffects newEnv (Db.finishJob { jobId, finishedAt, success: true })
         jsonOk V1.jobCreatedResponseCodec { jobId }
 
 type ServerEnvVars =
@@ -139,6 +139,7 @@ type ServerEnvVars =
   , spacesKey :: String
   , spacesSecret :: String
   , databaseUrl :: DatabaseUrl
+  , dhallTypes :: FilePath
   }
 
 readServerEnvVars :: Aff ServerEnvVars
@@ -150,7 +151,8 @@ readServerEnvVars = do
   spacesKey <- Env.lookupRequired Env.spacesKey
   spacesSecret <- Env.lookupRequired Env.spacesSecret
   databaseUrl <- Env.lookupRequired Env.databaseUrl
-  pure { token, publicKey, privateKey, spacesKey, spacesSecret, databaseUrl }
+  dhallTypes <- Env.lookupRequired Env.dhallTypes
+  pure { token, publicKey, privateKey, spacesKey, spacesSecret, databaseUrl, dhallTypes }
 
 type ServerEnv =
   { cacheDir :: FilePath
@@ -204,7 +206,7 @@ createServerEnv = do
     , jobId: Nothing
     }
 
-type ServerEffects = (PACCHETTIBOTTI_ENV + REGISTRY + STORAGE + PURSUIT + SOURCE + DB + GITHUB + LEGACY_CACHE + COMMENT + LOG + EXCEPT String + AFF + EFFECT ())
+type ServerEffects = (DHALL_ENV + PACCHETTIBOTTI_ENV + REGISTRY + STORAGE + PURSUIT + SOURCE + DB + GITHUB + LEGACY_CACHE + COMMENT + LOG + EXCEPT String + AFF + EFFECT ())
 
 runServer :: ServerEnv -> (ServerEnv -> Request Route -> Run ServerEffects Response) -> Request Route -> Aff Response
 runServer env router' request = do
@@ -257,6 +259,7 @@ runEffects env operation = Aff.attempt do
   let logPath = Path.concat [ env.logsDir, logFile ]
   operation
     # Env.runPacchettiBottiEnv { publicKey: env.vars.publicKey, privateKey: env.vars.privateKey }
+    # Env.runDhallEnv { typesDir: env.vars.dhallTypes }
     # Registry.interpret
         ( Registry.handle
             { repos: Registry.defaultRepos

--- a/app/src/App/Server.purs
+++ b/app/src/App/Server.purs
@@ -130,6 +130,7 @@ router env { route, method, body } = HTTPurple.usingCont case route, method of
             Right _ -> do
               finishedAt <- nowUTC
               void $ runEffects newEnv (Db.finishJob { jobId, finishedAt, success: true })
+
         jsonOk V1.jobCreatedResponseCodec { jobId }
 
 type ServerEnvVars =
@@ -186,7 +187,7 @@ createServerEnv = do
 
   db <- liftEffect $ SQLite.connect
     { database: vars.databaseUrl.path
-    , logger: Run.runBaseEffect <<< Log.interpret (Log.handleTerminal Verbose) <<< Log.info
+    , logger: mempty -- Run.runBaseEffect <<< Log.interpret (Log.handleTerminal Normal) <<< Log.info
     }
 
   -- At server startup we clean out all the jobs that are not completed,

--- a/app/src/App/Server.purs
+++ b/app/src/App/Server.purs
@@ -187,7 +187,10 @@ createServerEnv = do
 
   db <- liftEffect $ SQLite.connect
     { database: vars.databaseUrl.path
-    , logger: mempty -- Run.runBaseEffect <<< Log.interpret (Log.handleTerminal Normal) <<< Log.info
+    -- To see all database queries logged in the terminal, use this instead
+    -- of 'mempty'. Turned off by default because this is so verbose.
+    -- Run.runBaseEffect <<< Log.interpret (Log.handleTerminal Normal) <<< Log.info
+    , logger: mempty
     }
 
   -- At server startup we clean out all the jobs that are not completed,

--- a/app/src/App/Server.purs
+++ b/app/src/App/Server.purs
@@ -151,7 +151,9 @@ readServerEnvVars = do
   spacesKey <- Env.lookupRequired Env.spacesKey
   spacesSecret <- Env.lookupRequired Env.spacesSecret
   databaseUrl <- Env.lookupRequired Env.databaseUrl
-  dhallTypes <- Env.lookupRequired Env.dhallTypes
+  dhallTypes <- do
+    types <- Env.lookupRequired Env.dhallTypes
+    liftEffect $ Path.resolve [] types
   pure { token, publicKey, privateKey, spacesKey, spacesSecret, databaseUrl, dhallTypes }
 
 type ServerEnv =

--- a/app/test/Test/Assert/Run.purs
+++ b/app/test/Test/Assert/Run.purs
@@ -20,7 +20,6 @@ import Data.String as String
 import Effect.Aff as Aff
 import Effect.Now as Now
 import Effect.Ref as Ref
-import Effect.Unsafe (unsafePerformEffect)
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
 import Registry.App.CLI.Git as Git

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689715163,
-        "narHash": "sha256-HgBowH0RUU+6SpvpXYfTSunAqaME/6d0bqAW+shW6e4=",
+        "lastModified": 1689885880,
+        "narHash": "sha256-2ikAcvHKkKh8J/eUrwMA+wy1poscC+oL1RkN1V3RmT8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0171976ee0a1fa795b105c19a323e67b9c6094d9",
+        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "slimlock": "slimlock"
       },
       "locked": {
-        "lastModified": 1689725005,
-        "narHash": "sha256-NqpH/tNK0fuDNWfKW+guYbhfzPl6G9E+xUpNBq96usI=",
+        "lastModified": 1689891382,
+        "narHash": "sha256-VaKBXKg1FbE/Ov+P/Wdq/lo2SqHryH2Awu40U+EkWpY=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "6a7feaf0b0dc8ac5d9fdfd92e80b0aea306109b0",
+        "rev": "b23706d88822746fa494f60f3c47b7aa3d5a6484",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689885880,
-        "narHash": "sha256-2ikAcvHKkKh8J/eUrwMA+wy1poscC+oL1RkN1V3RmT8=",
+        "lastModified": 1689715163,
+        "narHash": "sha256-HgBowH0RUU+6SpvpXYfTSunAqaME/6d0bqAW+shW6e4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fa793b06f56896b7d1909e4b69977c7bf842b2f0",
+        "rev": "0171976ee0a1fa795b105c19a323e67b9c6094d9",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "slimlock": "slimlock"
       },
       "locked": {
-        "lastModified": 1689891382,
-        "narHash": "sha256-VaKBXKg1FbE/Ov+P/Wdq/lo2SqHryH2Awu40U+EkWpY=",
+        "lastModified": 1689725005,
+        "narHash": "sha256-NqpH/tNK0fuDNWfKW+guYbhfzPl6G9E+xUpNBq96usI=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "b23706d88822746fa494f60f3c47b7aa3d5a6484",
+        "rev": "6a7feaf0b0dc8ac5d9fdfd92e80b0aea306109b0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -75,15 +75,14 @@
 
         # An attrset containing all the PureScript binaries we want to make
         # available.
-        compilers = 
-          prev.symlinkJoin {
-            name = "purs-compilers";
-            paths = prev.lib.mapAttrsToList (name: drv:
-              prev.writeShellScriptBin name ''
-                exec ${drv}/bin/purs "$@"
-              '')
-            supportedCompilers;
-          };
+        compilers = prev.symlinkJoin {
+          name = "purs-compilers";
+          paths = prev.lib.mapAttrsToList (name: drv:
+            prev.writeShellScriptBin name ''
+              exec ${drv}/bin/purs "$@"
+            '')
+          supportedCompilers;
+        };
 
         purs-versions = prev.writeShellScriptBin "purs-versions" ''
           echo ${prev.lib.concatMapStringsSep " " (x: prev.lib.removePrefix "purs-" (builtins.replaceStrings ["_"] ["."] x)) (prev.lib.attrNames supportedCompilers)}
@@ -278,6 +277,7 @@
         default = pkgs.mkShell {
           name = "registry-dev";
           inherit DHALL_PRELUDE;
+          DHALL_TYPES = ./types;
           packages = with pkgs; [
             # All stable PureScript compilers
             registry.compilers

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -36,7 +36,7 @@ in {
 
   config = lib.mkIf cfg.enable {
     environment = {
-      systemPackages = [pkgs.vim];
+      systemPackages = [pkgs.vim pkgs.git];
     };
 
     nix = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -36,7 +36,7 @@ in {
 
   config = lib.mkIf cfg.enable {
     environment = {
-      systemPackages = [ pkgs.vim ];
+      systemPackages = [pkgs.vim];
     };
 
     nix = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -36,7 +36,7 @@ in {
 
   config = lib.mkIf cfg.enable {
     environment = {
-      systemPackages = [pkgs.vim pkgs.git];
+      systemPackages = [pkgs.vim];
     };
 
     nix = {

--- a/scripts/src/LegacyImporter.purs
+++ b/scripts/src/LegacyImporter.purs
@@ -162,8 +162,11 @@ main = launchAff_ do
     logFile = "legacy-importer-" <> String.take 19 (Formatter.DateTime.format Internal.Format.iso8601DateTime now) <> ".log"
     logPath = Path.concat [ logDir, logFile ]
 
+  dhallTypes <- Env.lookupRequired Env.dhallTypes
+
   runLegacyImport mode logPath
     # runAppEffects
+    # Env.runDhallEnv { typesDir: dhallTypes }
     # Cache.interpret Legacy.Manifest._legacyCache (Cache.handleMemoryFs { cache, ref: legacyCacheRef })
     # Cache.interpret _importCache (Cache.handleMemoryFs { cache, ref: importCacheRef })
     # Except.catch (\msg -> Log.error msg *> Run.liftEffect (Process.exit 1))

--- a/scripts/src/LegacyImporter.purs
+++ b/scripts/src/LegacyImporter.purs
@@ -162,7 +162,9 @@ main = launchAff_ do
     logFile = "legacy-importer-" <> String.take 19 (Formatter.DateTime.format Internal.Format.iso8601DateTime now) <> ".log"
     logPath = Path.concat [ logDir, logFile ]
 
-  dhallTypes <- Env.lookupRequired Env.dhallTypes
+  dhallTypes <- do
+    types <- Env.lookupRequired Env.dhallTypes
+    liftEffect $ Path.resolve [] types
 
   runLegacyImport mode logPath
     # runAppEffects

--- a/scripts/src/PackageDeleter.purs
+++ b/scripts/src/PackageDeleter.purs
@@ -106,7 +106,9 @@ main = launchAff_ do
   -- Environment
   _ <- Env.loadEnvFile ".env"
   token <- Env.lookupRequired Env.pacchettibottiToken
-  dhallTypes <- Env.lookupRequired Env.dhallTypes
+  dhallTypes <- do
+    types <- Env.lookupRequired Env.dhallTypes
+    liftEffect $ Path.resolve [] types
   s3 <- lift2 { key: _, secret: _ } (Env.lookupRequired Env.spacesKey) (Env.lookupRequired Env.spacesSecret)
 
   -- GitHub

--- a/scripts/src/PackageDeleter.purs
+++ b/scripts/src/PackageDeleter.purs
@@ -106,6 +106,7 @@ main = launchAff_ do
   -- Environment
   _ <- Env.loadEnvFile ".env"
   token <- Env.lookupRequired Env.pacchettibottiToken
+  dhallTypes <- Env.lookupRequired Env.dhallTypes
   s3 <- lift2 { key: _, secret: _ } (Env.lookupRequired Env.spacesKey) (Env.lookupRequired Env.spacesSecret)
 
   -- GitHub
@@ -149,7 +150,8 @@ main = launchAff_ do
 
   let
     interpret =
-      Registry.interpret (Registry.handle registryEnv)
+      Env.runDhallEnv { typesDir: dhallTypes }
+        >>> Registry.interpret (Registry.handle registryEnv)
         >>> Storage.interpret (if arguments.upload then Storage.handleS3 { s3, cache } else Storage.handleReadOnly cache)
         >>> Source.interpret Source.handle
         >>> GitHub.interpret (GitHub.handle { octokit, cache, ref: githubCacheRef })

--- a/scripts/src/Solver.purs
+++ b/scripts/src/Solver.purs
@@ -118,7 +118,9 @@ main = launchAff_ do
 
   debouncer <- Registry.newDebouncer
   let registryEnv pull write = { pull, write, repos: Registry.defaultRepos, workdir: scratchDir, debouncer, cacheRef: registryCacheRef }
-  dhallTypes <- Env.lookupRequired Env.dhallTypes
+  dhallTypes <- do
+    types <- Env.lookupRequired Env.dhallTypes
+    liftEffect $ Path.resolve [] types
   token <- Env.lookupRequired Env.githubToken
   octokit <- Octokit.newOctokit token
 

--- a/scripts/src/Solver.purs
+++ b/scripts/src/Solver.purs
@@ -118,8 +118,10 @@ main = launchAff_ do
 
   debouncer <- Registry.newDebouncer
   let registryEnv pull write = { pull, write, repos: Registry.defaultRepos, workdir: scratchDir, debouncer, cacheRef: registryCacheRef }
+  dhallTypes <- Env.lookupRequired Env.dhallTypes
   token <- Env.lookupRequired Env.githubToken
   octokit <- Octokit.newOctokit token
+
   let
     runAppEffects =
       Registry.interpret (Registry.handle (registryEnv Git.Autostash Registry.ReadOnly))
@@ -144,6 +146,7 @@ main = launchAff_ do
 
   doTheThing
     # runAppEffects
+    # Env.runDhallEnv { typesDir: dhallTypes }
     # Cache.interpret Legacy.Manifest._legacyCache (Cache.handleMemoryFs { cache, ref: legacyCacheRef })
     # Cache.interpret _importCache (Cache.handleMemoryFs { cache, ref: importCacheRef })
     # Except.catch (\msg -> Log.error msg *> Run.liftEffect (Process.exit 1))


### PR DESCRIPTION
We historically have included a relative path to the `./types` directory, assuming that scripts will be executed from the root of the repository. However, now that we've packaged the server for deployment, we no longer run the server from a git checkout of this repository and need to configure where the Dhall type specifications are located on the file system.

This PR makes the directory configurable and puts it into the publishing environment, as well as setting that environment variable where appropriate. For the Nix builds that means reading it from the store; for tests and the Nix shell, that means a local path to the repository itself.