### PR TITLE
`compiler-versions` script: Compute supported compiler versions for a single package

### DIFF
--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -59,4 +59,5 @@ in {
   package-transferrer = build-script "registry-package-transferrer" "PackageTransferrer";
   solver = build-script "registry-solver" "Solver";
   verify-integrity = build-script "registry-verify-integrity" "VerifyIntegrity";
+  compiler-versions = build-script "compiler-versions" "CompilerVersions";
 }

--- a/scripts/default.nix
+++ b/scripts/default.nix
@@ -59,5 +59,5 @@ in {
   package-transferrer = build-script "registry-package-transferrer" "PackageTransferrer";
   solver = build-script "registry-solver" "Solver";
   verify-integrity = build-script "registry-verify-integrity" "VerifyIntegrity";
-  compiler-versions = build-script "compiler-versions" "CompilerVersions";
+  compiler-versions = build-script "registry-compiler-versions" "CompilerVersions";
 }

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -36,7 +36,7 @@ import Registry.ManifestIndex as ManifestIndex
 import Registry.PackageName as PackageName
 import Registry.Range as Range
 import Registry.Version as Version
-import Run (EFFECT, Run, AFF)
+import Run (AFF, EFFECT, Run)
 import Run as Run
 import Run.Except (EXCEPT, rethrow, throw)
 import Run.Except as Except

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -1,0 +1,151 @@
+module Registry.Scripts.CompilerVersions where
+
+import Registry.App.Prelude
+
+import Data.Array as Array
+import Data.Formatter.DateTime as Formatter.DateTime
+import Data.Map as Map
+import Data.String as String
+import Effect.Class.Console as Console
+import Effect.Ref as Ref
+import Node.Path as Path
+import Node.Process as Process
+import Registry.App.CLI.Git as Git
+import Registry.App.Effect.Cache as Cache
+import Registry.App.Effect.Env as Env
+import Registry.App.Effect.GitHub as GitHub
+import Registry.App.Effect.Log (LOG)
+import Registry.App.Effect.Log as Log
+import Registry.App.Effect.Registry (REGISTRY)
+import Registry.App.Effect.Registry as Registry
+import Registry.Foreign.FSExtra as FS.Extra
+import Registry.Foreign.Octokit as Octokit
+import Registry.Internal.Format as Internal.Format
+import Registry.License as License
+import Registry.Location as Location
+import Registry.Manifest (Manifest(..))
+import Registry.ManifestIndex (toSortedArray)
+import Registry.PackageName as PackageName
+import Registry.Range as Range
+import Registry.Solver as Solver
+import Registry.Version as Version
+import Run (Run, EFFECT)
+import Run as Run
+import Run.Except (EXCEPT)
+import Run.Except as Except
+
+main :: Effect Unit
+main = launchAff_ do
+  -- Environment
+  _ <- Env.loadEnvFile ".env"
+  token <- Env.lookupRequired Env.pacchettibottiToken
+
+  -- Caching
+  let cache = Path.concat [ scratchDir, ".cache" ]
+  FS.Extra.ensureDirectory cache
+  githubCacheRef <- Cache.newCacheRef
+  registryCacheRef <- Cache.newCacheRef
+
+  -- GitHub
+  octokit <- Octokit.newOctokit token
+
+  -- Registry
+  debouncer <- Registry.newDebouncer
+  let
+    registryEnv :: Registry.RegistryEnv
+    registryEnv =
+      { write: Registry.ReadOnly
+      , pull: Git.Autostash
+      , repos: Registry.defaultRepos
+      , workdir: scratchDir
+      , debouncer
+      , cacheRef: registryCacheRef
+      }
+
+  -- Logging
+  now <- nowUTC
+  let logDir = Path.concat [ scratchDir, "logs" ]
+  FS.Extra.ensureDirectory logDir
+  let logFile = "verify-" <> String.take 19 (Formatter.DateTime.format Internal.Format.iso8601DateTime now) <> ".log"
+  let logPath = Path.concat [ logDir, logFile ]
+  Console.log $ "Logs available at " <> logPath
+
+  solveCompilerVersions
+    # Except.catch (\error -> Run.liftEffect (Console.log error *> Process.exit 1))
+    # Registry.interpret (Registry.handle registryEnv)
+    # GitHub.interpret (GitHub.handle { octokit, cache, ref: githubCacheRef })
+    # Log.interpret (\log -> Log.handleTerminal Normal log *> Log.handleFs Verbose logPath log)
+    # Run.runBaseAff'
+
+solveCompilerVersions :: forall r. Run (LOG + EFFECT + REGISTRY + EXCEPT String + r) Unit
+solveCompilerVersions = do
+  --allMetadata <- Registry.readAllMetadata
+  allManifests <- Registry.readAllManifests
+  let
+    compilerPackage = unsafeFromRight $ PackageName.parse "compiler"
+    compilerVersions = map (unsafeFromRight <<< Version.parse)
+      [ "0.13.0"
+      , "0.13.2"
+      , "0.13.3"
+      , "0.13.4"
+      , "0.13.5"
+      , "0.13.6"
+      , "0.13.8"
+      , "0.14.0"
+      , "0.14.1"
+      , "0.14.2"
+      , "0.14.3"
+      , "0.14.4"
+      , "0.14.5"
+      , "0.14.6"
+      , "0.14.7"
+      , "0.14.8"
+      , "0.14.9"
+      , "0.15.0"
+      , "0.15.2"
+      , "0.15.3"
+      , "0.15.4"
+      , "0.15.5"
+      , "0.15.6"
+      , "0.15.7"
+      , "0.15.8"
+      , "0.15.9"
+      , "0.15.10"
+      ]
+
+    compilerManifests =  do
+      let
+        go :: Version -> Maybe (Tuple Version Manifest)
+        go version = do
+          license <- hush $ License.parse "MIT"
+          pure $ Tuple version $ Manifest
+            { name: compilerPackage
+            , version
+            , license
+            , location: Location.GitHub { owner: "purescript", repo: "purescript", subdir: Nothing }
+            , owners: Nothing
+            , description: Nothing
+            , files: Nothing
+            , dependencies: Map.empty
+            }
+
+      Map.fromFoldable
+        [ Tuple compilerPackage $ Map.fromFoldable $ Array.mapMaybe go compilerVersions
+        ]
+
+  newManifestsRef <- liftEffect $ Ref.new compilerManifests
+
+  for_ (toSortedArray allManifests) \manifest -> do
+    let
+      getDependencies = _.dependencies <<< un Manifest
+
+      insertCompilerDependency :: Manifest -> Version ->  Manifest
+      insertCompilerDependency (Manifest manifest) version = Manifest $ manifest
+        { dependencies = Map.insert compilerPackage (unsafeFromJust (Range.mk version (Version.bumpMinor version))) manifest.dependencies
+        }
+
+    newManifests <- liftEffect $ Ref.read newManifestsRef
+    Log.info "here"
+    pure $ Solver.solve (map (map getDependencies) newManifests) (getDependencies manifest)
+
+  pure unit

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -49,14 +49,14 @@ data InputMode
 parser :: ArgParser InputMode
 parser = Arg.choose "input (--file or --package or --all)"
   [ Arg.argument [ "--file" ]
-      """Verify packages from a JSON file like: [ "prelude", "console" ]"""
+      """Compute supported compiler versions for packages from a JSON file like: [ "prelude", "console" ]"""
       # Arg.unformat "FILE_PATH" pure
       # map File
   , Arg.argument [ "--package" ]
-      "Verify the indicated package"
+      "Compute supported compiler versions for the indicated package"
       # Arg.unformat "NAME@VERSION" parsePackage
       # map (uncurry Package)
-  , Arg.flag [ "--all" ] "Verify all packages" $> AllPackages
+  , Arg.flag [ "--all" ] "Compute supported compiler versions for all packages" $> AllPackages
   ]
   where
   parsePackage :: String -> Either String (Tuple PackageName Version)

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -38,7 +38,7 @@ import Registry.Range as Range
 import Registry.Version as Version
 import Run (AFF, EFFECT, Run)
 import Run as Run
-import Run.Except (EXCEPT, rethrow, throw)
+import Run.Except (EXCEPT)
 import Run.Except as Except
 
 data InputMode
@@ -134,10 +134,10 @@ determineCompilerVersionsForPackage package version = do
   allManifests <- map ManifestIndex.toMap Registry.readAllManifests
   compilerVersions <- PursVersions.pursVersions
   Log.debug $ "Checking Manifest Index for " <> formatPackageVersion package version
-  Manifest { dependencies } <- rethrow $ (note "Invalid Version" <<< Map.lookup version <=< note "Invalid PackageName" <<< Map.lookup package) allManifests
+  Manifest { dependencies } <- Except.rethrow $ (note "Invalid Version" <<< Map.lookup version <=< note "Invalid PackageName" <<< Map.lookup package) allManifests
   unless (Map.isEmpty dependencies) do
     Log.error "Cannot check package that has dependencies."
-    throw "Cannot check package that has dependencies."
+    Except.throw "Cannot check package that has dependencies."
   tmp <- Run.liftAff Tmp.mkTmpDir
   let formattedName = formatPackageVersion package version
   let extractedName = PackageName.print package <> "-" <> Version.print version


### PR DESCRIPTION
This PR is a first step towards #255. It adds a new script, `compiler-versions`, which will be used to compute the supported compiler versions for packages.

Currently the script can only work on a single package@version that has no dependencies. No attempt is made to modify the `Metadata` type.

In follow up PRs, I will start to introduce more sophisticated routines to get the supported compiler ranges for all existing packages, and eventually get to modifying the `Manifest` type.

Note: This currently computes a `Range` of supported compiler versions. In particular, since we use simple ranges, this means that once the package@version previously compiled for a lower compiler version and stops compiling for a later compiler, we stop checking to see if it becomes supported by a different compiler in the future. In general, I think this is fine, but wanted to call it out explicitly. 

I've run this on various versions of prelude - here's an example of the final output:

```
Found supported compiler versions for prelude@6.0.0: >=0.15.0 <0.15.11
```