### PR TITLE
Enable debug database logs

### DIFF
--- a/app/spago.yaml
+++ b/app/spago.yaml
@@ -29,6 +29,7 @@ package:
     - foldable-traversable
     - foreign-object
     - formatters
+    - halogen-subscriptions
     - http-methods
     - httpurple
     - identity

--- a/app/src/App/SQLite.purs
+++ b/app/src/App/SQLite.purs
@@ -5,6 +5,7 @@ module Registry.App.SQLite
   , NewJob
   , SQLite
   , connect
+  , close
   , createJob
   , deleteIncompleteJobs
   , finishJob
@@ -30,6 +31,8 @@ data SQLite
 
 foreign import connectImpl :: EffectFn2 FilePath (EffectFn1 String Unit) SQLite
 
+foreign import closeImpl :: EffectFn1 SQLite Unit
+
 foreign import insertLogImpl :: EffectFn2 SQLite JSLogLine Unit
 
 foreign import selectLogsByJobImpl :: EffectFn3 SQLite String Int (Array JSLogLine)
@@ -49,8 +52,13 @@ type ConnectOptions =
   , logger :: String -> Effect Unit
   }
 
+-- | Open a new database connection
 connect :: ConnectOptions -> Effect SQLite
 connect { database, logger } = Uncurried.runEffectFn2 connectImpl database (Uncurried.mkEffectFn1 logger)
+
+-- | Close the database connection
+close :: SQLite -> Effect Unit
+close = Uncurried.runEffectFn1 closeImpl
 
 type JSLogLine =
   { level :: Int

--- a/app/src/App/Server.purs
+++ b/app/src/App/Server.purs
@@ -184,13 +184,14 @@ createServerEnv = do
   octokit <- Octokit.newOctokit vars.token
   debouncer <- Registry.newDebouncer
 
-  db <- liftEffect $ SQLite.connect { database: vars.databaseUrl.path, logger: mempty }
-
   -- At server startup we clean out all the jobs that are not completed,
   -- because they are stale runs from previous startups of the server.
   -- We can just remove the jobs, and all the logs belonging to them will be
   -- removed automatically by the foreign key constraint.
-  liftEffect $ SQLite.deleteIncompleteJobs db
+  liftEffect do
+    db <- SQLite.connect { database: vars.databaseUrl.path, logger: mempty }
+    SQLite.deleteIncompleteJobs db
+    SQLite.close db
 
   pure
     { debouncer

--- a/app/src/App/Server.purs
+++ b/app/src/App/Server.purs
@@ -284,7 +284,13 @@ runEffects env operation = Aff.attempt do
 
   subscription <- liftEffect $ Subscription.subscribe env.dbLogger (runDbLogger <<< Log.debug)
 
-  operation
+  let
+    operation' = do
+      result <- operation
+      liftEffect $ Subscription.unsubscribe subscription
+      pure result
+
+  operation'
     # Env.runPacchettiBottiEnv { publicKey: env.vars.publicKey, privateKey: env.vars.privateKey }
     # Env.runDhallEnv { typesDir: env.vars.dhallTypes }
     # Registry.interpret

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -7,10 +7,9 @@ import ArgParse.Basic as Arg
 import Data.Array as Array
 import Data.Array.NonEmpty as NEA
 import Data.Formatter.DateTime as Formatter.DateTime
-import Data.List (filterM)
 import Data.Map as Map
 import Data.String as String
-import Data.Tuple (uncurry)
+import Data.Tuple as Tuple
 import Effect.Class.Console as Console
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
@@ -35,7 +34,6 @@ import Registry.Internal.Format as Internal.Format
 import Registry.Manifest (Manifest(..))
 import Registry.ManifestIndex as ManifestIndex
 import Registry.PackageName as PackageName
-import Registry.Range as Range
 import Registry.Version as Version
 import Run (AFF, EFFECT, Run)
 import Run as Run
@@ -56,7 +54,7 @@ parser = Arg.choose "input (--file or --package or --all)"
   , Arg.argument [ "--package" ]
       "Compute supported compiler versions for the indicated package"
       # Arg.unformat "NAME@VERSION" parsePackage
-      # map (uncurry Package)
+      # map (Tuple.uncurry Package)
   , Arg.flag [ "--all" ] "Compute supported compiler versions for all packages" $> AllPackages
   ]
   where

--- a/spago.lock
+++ b/spago.lock
@@ -26,6 +26,7 @@ workspace:
         - foldable-traversable
         - foreign-object
         - formatters
+        - halogen-subscriptions
         - http-methods
         - httpurple
         - identity
@@ -754,6 +755,18 @@ packages:
     dependencies:
       - catenable-lists
       - ordered-collections
+  halogen-subscriptions:
+    type: registry
+    version: 2.0.0
+    integrity: sha256-8/BPME/sC/kWMDxp0+n4k09gA1IIedXn2yUJ4pCH5xw=
+    dependencies:
+      - arrays
+      - effect
+      - foldable-traversable
+      - functors
+      - refs
+      - safe-coerce
+      - unsafe-reference
   heterogeneous:
     type: registry
     version: 0.6.0


### PR DESCRIPTION
In #631 I disabled the database logger because it was so noisy and we could only log to the terminal. Now, these logs are proper `debug` logs and are written to the database. (Of course, given the sheer number of these things, we might want to be a bit more judicious about how many get written).

The way it works is a little funky because we need the log function at the time we connect to the database, but we can't log to the database until we're connected. So we defer it:

1. We set up an emitter/listener pair
2. The "log" function provided during db connection pushes to the listener
3. We subscribe to the emitter, interpreting messages as calls to `Log.debug`, and running the effect using the Log effect's database handler.
4. Once the operation is complete (or threw an exception) we clean up the subscription

I noticed that we're using a single database connection across all jobs, which means there's no way to distinguish debug logs coming from the database for one operation vs. another one. Now, calls to `runEffect` will set up a new database connection, logs will associate with the given job id (if there is one — to the terminal if not), and the database connection will be cleaned up once the operation completes.

@f-f you may wish to handle these db connections differently. I'm not sure what issues may arise from having too many database connections open at once, or whether we want to be smarter than "any call to runEffects sets up and tears down a database connection".