### PR TITLE
Fix `CompilerError` decoding in 0.13.x series of purs

### DIFF
--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -777,7 +777,7 @@ compilePackage { packageSourceDir, compiler, resolutions } = Except.runExcept do
   Log.debug "Compiling..."
   compilerOutput <- Run.liftAff $ Purs.callCompiler
     { command: Purs.Compile { globs }
-    , version: Just (Version.print compiler)
+    , version: Just compiler
     , cwd: Just packageSourceDir
     }
 
@@ -834,7 +834,7 @@ publishToPursuit { packageSourceDir, dependenciesDir, compiler, resolutions } = 
   -- with the format used by Pursuit in PureScript versions at least up to 0.16
   compilerOutput <- Run.liftAff $ Purs.callCompiler
     { command: Purs.Publish { resolutions: resolutionsFilePath }
-    , version: Just (Version.print compiler)
+    , version: Just compiler
     , cwd: Just packageSourceDir
     }
 

--- a/app/src/App/CLI/Purs.purs
+++ b/app/src/App/CLI/Purs.purs
@@ -9,9 +9,10 @@ import Data.Codec.Argonaut.Record as CA.Record
 import Data.Foldable (foldMap)
 import Data.String as String
 import Node.Library.Execa as Execa
+import Registry.Version as Version
 
 -- | Call a specific version of the PureScript compiler
-callCompiler_ :: { version :: Maybe String, command :: PursCommand, cwd :: Maybe FilePath } -> Aff Unit
+callCompiler_ :: { version :: Maybe Version, command :: PursCommand, cwd :: Maybe FilePath } -> Aff Unit
 callCompiler_ = void <<< callCompiler
 
 data CompilerFailure
@@ -83,7 +84,7 @@ printCompilerErrors errors = do
       ]
 
 type CompilerArgs =
-  { version :: Maybe String
+  { version :: Maybe Version
   , cwd :: Maybe FilePath
   , command :: PursCommand
   }
@@ -111,8 +112,7 @@ callCompiler compilerArgs = do
         Just version ->
           append "purs-"
             $ String.replaceAll (String.Pattern ".") (String.Replacement "_")
-            $ fromMaybe version
-            $ String.stripPrefix (String.Pattern "v") version
+            $ Version.print version
 
     errorsCodec = CA.Record.object "CompilerErrors"
       { errors: CA.array compilerErrorCodec }
@@ -122,7 +122,12 @@ callCompiler compilerArgs = do
     Left { originalMessage }
       | originalMessage == Just (String.joinWith " " [ "spawn", purs, "ENOENT" ]) -> Left MissingCompiler
     Left { stdout, stderr } -> Left do
-      case parseJson errorsCodec stdout of
+      let
+        output = case compilerArgs.version of
+          Nothing -> stdout
+          Just version | Right min <- Version.parse "0.14.0", version < min -> stderr
+          Just _ -> stdout
+      case parseJson errorsCodec output of
         Left err -> UnknownError $ String.joinWith "\n" [ stdout, stderr, CA.printJsonDecodeError err ]
         Right ({ errors } :: { errors :: Array CompilerError })
           | Array.null errors -> UnknownError "Non-normal exit code, but no errors reported."

--- a/app/src/App/Effect/PackageSets.purs
+++ b/app/src/App/Effect/PackageSets.purs
@@ -240,8 +240,7 @@ handle env = case _ of
   compileInstalledPackages compiler = do
     Log.debug "Compiling installed packages..."
     let command = Purs.Compile { globs: [ Path.concat [ Path.basename packagesWorkDir, "**/*.purs" ] ] }
-    let version = Version.print compiler
-    Run.liftAff $ Purs.callCompiler { command, version: Just version, cwd: Just env.workdir }
+    Run.liftAff $ Purs.callCompiler { command, version: Just compiler, cwd: Just env.workdir }
 
   attemptChanges :: Version -> PackageSet -> ChangeSet -> Run _ (Either CompilerFailure PackageSet)
   attemptChanges compiler (PackageSet set) changes = do

--- a/app/test/App/CLI/Purs.purs
+++ b/app/test/App/CLI/Purs.purs
@@ -18,7 +18,7 @@ spec :: Spec.Spec Unit
 spec = do
   traverse_ (testVersion <<< Utils.unsafeVersion) [ "0.13.0", "0.14.0", "0.14.7", "0.15.4" ]
   traverse_ (testMissingVersion <<< Utils.unsafeVersion) [ "0.13.1", "0.13.7", "0.15.1", "0.12.0", "0.14.12345" ]
-  traverse_ (testCompilationError <<< hush) [ Version.parse "0.13.0", Version.parse "0.13.8", Version.parse "0.14.0", Version.parse "0.15.0", Left "latest" ]
+  traverse_ testCompilationError [ Just (Utils.unsafeVersion "0.13.0"), Just (Utils.unsafeVersion "0.13.8"), Just (Utils.unsafeVersion "0.14.0"), Just (Utils.unsafeVersion "0.15.0"), Nothing ]
   where
   testVersion version =
     Spec.it ("Calls compiler version " <> Version.print version) do

--- a/app/test/App/CLI/Purs.purs
+++ b/app/test/App/CLI/Purs.purs
@@ -16,9 +16,9 @@ import Test.Spec as Spec
 
 spec :: Spec.Spec Unit
 spec = do
-  traverse_ testVersion (map Utils.unsafeVersion [ "0.13.0", "0.14.0", "0.14.7", "0.15.4" ])
-  traverse_ testMissingVersion (map Utils.unsafeVersion [ "0.13.1", "0.13.7", "0.15.1", "0.12.0", "0.14.12345" ])
-  traverse_ testCompilationError (map hush [ Version.parse "0.13.0", Version.parse "0.13.8", Version.parse "0.14.0", Version.parse "0.15.0", Left "latest" ])
+  traverse_ (testVersion <<< Utils.unsafeVersion) [ "0.13.0", "0.14.0", "0.14.7", "0.15.4" ]
+  traverse_ (testMissingVersion <<< Utils.unsafeVersion) [ "0.13.1", "0.13.7", "0.15.1", "0.12.0", "0.14.12345" ]
+  traverse_ (testCompilationError <<< hush) [ Version.parse "0.13.0", Version.parse "0.13.8", Version.parse "0.14.0", Version.parse "0.15.0", Left "latest" ]
   where
   testVersion version =
     Spec.it ("Calls compiler version " <> Version.print version) do

--- a/app/test/App/CLI/Purs.purs
+++ b/app/test/App/CLI/Purs.purs
@@ -10,13 +10,14 @@ import Registry.App.CLI.Purs (CompilerFailure(..))
 import Registry.App.CLI.Purs as Purs
 import Registry.Foreign.Tmp as Tmp
 import Registry.Test.Assert as Assert
+import Registry.Test.Utils as Utils
 import Registry.Version as Version
 import Test.Spec as Spec
 
 spec :: Spec.Spec Unit
 spec = do
-  traverse_ testVersion (Array.mapMaybe (hush <<< Version.parse) [ "0.13.0", "0.14.0", "0.14.7", "0.15.4" ])
-  traverse_ testMissingVersion (Array.mapMaybe (hush <<< Version.parse) [ "0.13.1", "0.13.7", "0.15.1", "0.12.0", "0.14.12345" ])
+  traverse_ testVersion (map Utils.unsafeVersion [ "0.13.0", "0.14.0", "0.14.7", "0.15.4" ])
+  traverse_ testMissingVersion (map Utils.unsafeVersion [ "0.13.1", "0.13.7", "0.15.1", "0.12.0", "0.14.12345" ])
   traverse_ testCompilationError (map hush [ Version.parse "0.13.0", Version.parse "0.13.8", Version.parse "0.14.0", Version.parse "0.15.0", Left "latest" ])
   where
   testVersion version =

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -161,7 +161,7 @@ determineCompilerVersionsForPackage package version = do
 
       result <- Run.liftAff $ Purs.callCompiler
         { command: Purs.Compile { globs: [ Path.concat [ formattedName, "src/**/*.purs" ] ] }
-        , version: Just (Version.print compiler)
+        , version: Just compiler
         , cwd: Just tmp
         }
 


### PR DESCRIPTION
While working on #255, @thomashoneyman noticed some log lines reporting unknown compiler errors, like

```
[STDOUT]
Compiling Data.NaturalTransformation
Compiling Data.Boolean
Compiling Data.Show
Compiling Control.Semigroupoid
Compiling Control.Category
Compiling Data.Unit
Compiling Data.Void
Compiling Data.Semiring
Compiling Data.HeytingAlgebra
Compiling Data.Semigroup
Compiling Data.Eq
Compiling Data.Ring
Compiling Data.BooleanAlgebra
Compiling Data.Ordering
Compiling Data.CommutativeRing
Compiling Data.EuclideanRing
Compiling Data.Ord.Unsafe
Compiling Data.Ord
Compiling Data.DivisionRing
Compiling Data.Field
Compiling Data.Bounded
Compiling Data.Function
Compiling Data.Functor
Compiling Control.Apply
Compiling Control.Applicative
Compiling Control.Bind
Compiling Control.Monad
Compiling Prelude
Compiling Debug.Trace
[STDERR]
{"warnings":[],"errors":[{"position":{"startLine":8,"startColumn":1,"endLine":8,"endColumn":58},"message":"  Unknown type class Warn\n","errorCode":"UnknownName","errorLink":"https://github.com/purescript/documentation/blob/master/errors/UnknownName.md","filename":"/run/user/1000/tmp-714974-ghvoRncaz00A/.registry/debug-3.0.0/src/Debug/Trace.purs","moduleName":"Debug.Trace","suggestion":null,"allSpans":[{"start":[8,1],"name":"/run/user/1000/tmp-714974-ghvoRncaz00A/.registry/debug-3.0.0/src/Debug/Trace.purs","end":[8,58]}]}]}
[DECODE ERROR]
An error occurred while decoding a JSON value:
  Expected value of type 'JSON: Unexpected token C in JSON at position 0'.
```

It turns out that starting in 0.14.0, compiler errors were switched to being reported to stdout, whereas they used to be in stderr: https://github.com/purescript/purescript/releases/tag/v0.14.0

 This PR changes `CompilerArgs` to take a `Version`, so we can check that we can get proper `Version` `Ord` and check compiler versions before deciding where to try to parse the compiler errors from, and propagates the changes needed to make that typecheck. It also adds tests to catch this case.