### PR TITLE
Fix warnings in the codebase

### DIFF
--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -16,7 +16,6 @@ module Registry.App.API
 
 import Registry.App.Prelude
 
-import Control.Alternative as Alternative
 import Data.Argonaut.Parser as Argonaut.Parser
 import Data.Array as Array
 import Data.Array.NonEmpty as NEA
@@ -177,7 +176,7 @@ packageSetUpdate payload = do
         prevVersion <- Map.lookup name prevPackages
         -- We want to fail if the existing version is greater than the
         -- new proposed version.
-        Alternative.guard (prevVersion > newVersion)
+        guard (prevVersion > newVersion)
         pure (Tuple name { old: prevVersion, new: newVersion })
 
   when (not (Array.null downgradedPackages)) do
@@ -707,7 +706,7 @@ validateResolutions manifest resolutions = do
         ]
 
       missingPackagesError = do
-        guardA (not Array.null missingPackages)
+        guard (not Array.null missingPackages)
         pure
           $ String.joinWith "\n  - "
           $ Array.cons "The build plan is missing dependencies that are listed in the manifest:"
@@ -724,7 +723,7 @@ validateResolutions manifest resolutions = do
         ]
 
       incorrectVersionsError = do
-        guardA (not Array.null incorrectVersions)
+        guard (not Array.null incorrectVersions)
         pure
           $ String.joinWith "\n  - "
           $ Array.cons "The build plan provides dependencies at versions outside the range listed in the manifest:"

--- a/app/src/App/Effect/PackageSets.purs
+++ b/app/src/App/Effect/PackageSets.purs
@@ -5,7 +5,6 @@ module Registry.App.Effect.PackageSets where
 
 import Registry.App.Prelude
 
-import Control.Alternative (guard)
 import Data.Array as Array
 import Data.DateTime as DateTime
 import Data.Filterable as Filterable
@@ -308,9 +307,9 @@ handle env = case _ of
 commitMessage :: PackageSet -> ChangeSet -> Version -> String
 commitMessage (PackageSet set) accepted newVersion = String.joinWith "\n" $ fold
   [ [ "Release " <> Version.print newVersion <> " package set.\n" ]
-  , guardA (not (Array.null added)) $> (addedLines <> "\n")
-  , guardA (not (Array.null updated)) $> (updatedLines <> "\n")
-  , guardA (not (Array.null removed)) $> (removedLines <> "\n")
+  , guard (not (Array.null added)) $> (addedLines <> "\n")
+  , guard (not (Array.null updated)) $> (updatedLines <> "\n")
+  , guard (not (Array.null removed)) $> (removedLines <> "\n")
   ]
   where
   added = do
@@ -318,7 +317,7 @@ commitMessage (PackageSet set) accepted newVersion = String.joinWith "\n" $ fold
     version <- case change of
       Remove -> []
       Update version -> [ version ]
-    guardA (not (Map.member packageName set.packages))
+    guard (not (Map.member packageName set.packages))
     pure $ Tuple packageName version
 
   addedLines = "New packages:\n" <> String.joinWith "\n" do
@@ -339,7 +338,7 @@ commitMessage (PackageSet set) accepted newVersion = String.joinWith "\n" $ fold
 
   removed = do
     Tuple packageName change <- Map.toUnfoldable accepted
-    guardA (change == Remove)
+    guard (change == Remove)
     version <- maybe [] pure (Map.lookup packageName set.packages)
     pure $ Tuple packageName version
 

--- a/app/src/App/Effect/Storage.purs
+++ b/app/src/App/Effect/Storage.purs
@@ -136,7 +136,7 @@ handleS3 env = Cache.interpret _storageCache (Cache.handleFs env.cache) <<< case
       $ resources
       >>= \resource -> do
         { name: parsedName, version } <- Array.fromFoldable $ parsePackagePath resource
-        version <$ guardA (name == parsedName)
+        version <$ guard (name == parsedName)
 
   Download name version path reply -> map (map reply) Except.runExcept do
     let package = formatPackageVersion name version

--- a/app/src/App/Prelude.purs
+++ b/app/src/App/Prelude.purs
@@ -5,7 +5,6 @@ module Registry.App.Prelude
   , class Functor2
   , formatPackageVersion
   , fromJust'
-  , guardA
   , map2
   , mapKeys
   , module Either
@@ -34,7 +33,7 @@ module Registry.App.Prelude
 import Prelude
 
 import Control.Alt ((<|>)) as Extra
-import Control.Alternative (class Alternative, empty)
+import Control.Alternative (guard) as Extra
 import Control.Monad.Except (ExceptT(..)) as Extra
 import Control.Monad.Trans.Class (lift) as Extra
 import Control.Parallel.Class as Parallel
@@ -147,9 +146,6 @@ mapKeys k = Map.fromFoldable <<< map (Extra.lmap k) <<< (Map.toUnfoldable :: _ -
 
 traverseKeys :: forall a b v. Ord a => Ord b => (a -> Either.Either String b) -> Extra.Map a v -> Either.Either String (Extra.Map b v)
 traverseKeys k = map Map.fromFoldable <<< Extra.traverse (Extra.ltraverse k) <<< (Map.toUnfoldable :: _ -> Array _)
-
-guardA :: forall f. Alternative f => Boolean -> f Unit
-guardA = if _ then pure unit else empty
 
 -- | Attempt an effectful computation with exponential backoff.
 withBackoff' :: forall a. Extra.Aff a -> Extra.Aff (Maybe.Maybe a)

--- a/app/test/App/CLI/Purs.purs
+++ b/app/test/App/CLI/Purs.purs
@@ -2,7 +2,6 @@ module Test.Registry.App.CLI.Purs (spec) where
 
 import Registry.App.Prelude
 
-import Data.Array as Array
 import Data.Foldable (traverse_)
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -7,7 +7,6 @@ import ArgParse.Basic as Arg
 import Data.Array as Array
 import Data.Array.NonEmpty as NEA
 import Data.Formatter.DateTime as Formatter.DateTime
-import Data.List (filterM)
 import Data.Map as Map
 import Data.String as String
 import Data.Tuple (uncurry)
@@ -35,7 +34,6 @@ import Registry.Internal.Format as Internal.Format
 import Registry.Manifest (Manifest(..))
 import Registry.ManifestIndex as ManifestIndex
 import Registry.PackageName as PackageName
-import Registry.Range as Range
 import Registry.Version as Version
 import Run (AFF, EFFECT, Run)
 import Run as Run

--- a/scripts/src/LegacyImporter.purs
+++ b/scripts/src/LegacyImporter.purs
@@ -10,7 +10,6 @@ import Registry.App.Prelude
 
 import ArgParse.Basic (ArgParser)
 import ArgParse.Basic as Arg
-import Control.Alternative (guard)
 import Control.Apply (lift2)
 import Data.Array as Array
 import Data.Codec.Argonaut as CA

--- a/scripts/src/PackageSetUpdater.purs
+++ b/scripts/src/PackageSetUpdater.purs
@@ -179,7 +179,7 @@ findRecentUploads limit = do
       versions <- Array.fromFoldable $ NonEmptyArray.fromArray do
         Tuple version { publishedTime } <- Map.toUnfoldable metadata.published
         let diff = DateTime.diff now publishedTime
-        guardA (diff <= limit)
+        guard (diff <= limit)
         pure version
       pure (Tuple name versions)
 


### PR DESCRIPTION
A few warnings have crept into the codebase over the last few pull requests. This addresses them so we're warning-free.