### PR TITLE
`compiler-versions` script: Compute supported compiler versions for all packages

### DIFF
--- a/app/src/App/CLI/Purs.purs
+++ b/app/src/App/CLI/Purs.purs
@@ -123,7 +123,7 @@ callCompiler compilerArgs = do
       | originalMessage == Just (String.joinWith " " [ "spawn", purs, "ENOENT" ]) -> Left MissingCompiler
     Left { stdout, stderr } -> Left do
       case parseJson errorsCodec stdout of
-        Left err -> UnknownError $ String.joinWith "\n" [ stdout, stderr, CA.printJsonDecodeError err ]
+        Left err -> UnknownError $ String.joinWith "\n" [ "\n[STDOUT]", stdout, "[STDERR]", stderr, "[DECODE ERROR]", CA.printJsonDecodeError err ]
         Right ({ errors } :: { errors :: Array CompilerError })
           | Array.null errors -> UnknownError "Non-normal exit code, but no errors reported."
           | otherwise -> CompilationError errors

--- a/app/src/App/CLI/Purs.purs
+++ b/app/src/App/CLI/Purs.purs
@@ -71,12 +71,15 @@ printCompilerErrors errors = do
   String.joinWith "\n" printed
   where
   printCompilerError :: CompilerError -> String
-  printCompilerError { moduleName, filename, message, errorLink } =
+  printCompilerError { moduleName, filename, message, errorLink, position } =
     String.joinWith "\n"
-      [ foldMap (\name -> "  Module: " <> name <> "\n") moduleName <> "  File: " <> filename
+      [ foldMap (\name -> "  Module: " <> name <> "\n") moduleName <> "  File: " <> filename <> "\n"
       , "  Message:"
       , ""
-      , "  " <> message
+      , message
+      -- The message has a newline, so no need for another.
+      , "  Position:"
+      , "  " <> show position.startLine <> ":" <> show position.startColumn <> " - " <> show position.endLine <> ":" <> show position.endColumn
       , ""
       , "  Error details:"
       , "  " <> errorLink

--- a/app/src/App/CLI/PursVersions.purs
+++ b/app/src/App/CLI/PursVersions.purs
@@ -12,6 +12,7 @@ import Run as Run
 import Run.Except (EXCEPT)
 import Run.Except as Except
 
+-- | Returns a sorted array of PureScript compilers supported by the Registry
 pursVersions :: forall r. Run (EXCEPT String + AFF + r) (NonEmptyArray Version)
 pursVersions = do
   result <- Run.liftAff $ _.result =<< Execa.execa "purs-versions" [] identity
@@ -23,4 +24,4 @@ pursVersions = do
 
   case NEA.fromArray success of
     Nothing -> Except.throw "No purs versions"
-    Just arr -> pure arr
+    Just arr -> pure $ NEA.sort arr

--- a/app/src/App/Effect/PackageSets.purs
+++ b/app/src/App/Effect/PackageSets.purs
@@ -126,7 +126,7 @@ handle env = case _ of
     index <- Registry.readAllManifests
 
     let
-      sortedPackages = ManifestIndex.toSortedArray index
+      sortedPackages = ManifestIndex.toSortedArray ManifestIndex.IgnoreRanges index
       sortedBatch = sortedPackages # Array.mapMaybe \(Manifest { name, version }) -> do
         update <- Map.lookup name changes
         case update of

--- a/app/test/App/CLI/Purs.purs
+++ b/app/test/App/CLI/Purs.purs
@@ -46,13 +46,6 @@ spec = do
       FS.Aff.writeTextFile UTF8 file "<contents>"
       result <- Purs.callCompiler { command: Purs.Compile { globs: [ file ] }, cwd: Nothing, version }
       case result of
-        Left (CompilationError [ { position: { startLine: 1, startColumn: 8 } } ]) ->
+        Left (CompilationError [ { position: { startLine: 1, startColumn: 1 } } ]) ->
           pure unit
-        Left (CompilationError errors) ->
-          Assert.fail $ "Should have failed with CompilationError at position 1:8 but failed with a different compilation error:\n\n" <> Purs.printCompilerErrors errors
-        Left MissingCompiler ->
-          Assert.fail "Should have failed with CompilationError but failed with MissingCompiler"
-        Left (UnknownError err) ->
-          Assert.fail $ "Should have failed with CompilationError but failed with UnknownError " <> err
-        Right _ ->
-          Assert.fail $ "Should have failed with CompilationError but succeeded"
+        _ -> Assert.fail "Should have failed with CompilationError"

--- a/lib/src/ManifestIndex.purs
+++ b/lib/src/ManifestIndex.purs
@@ -23,6 +23,7 @@ module Registry.ManifestIndex
   , toMap
   , toSortedArray
   , topologicalSort
+  , IncludeRanges(..)
   , writeEntryFile
   ) where
 
@@ -87,8 +88,8 @@ toMap :: ManifestIndex -> Map PackageName (Map Version Manifest)
 toMap (ManifestIndex index) = index
 
 -- | Produce an array of manifests topologically sorted by dependencies.
-toSortedArray :: ManifestIndex -> Array Manifest
-toSortedArray (ManifestIndex index) = topologicalSort $ Set.fromFoldable do
+toSortedArray :: IncludeRanges -> ManifestIndex -> Array Manifest
+toSortedArray includeRanges (ManifestIndex index) = topologicalSort includeRanges $ Set.fromFoldable do
   Tuple _ versions <- Map.toUnfoldableUnordered index
   Tuple _ manifest <- Map.toUnfoldableUnordered versions
   [ manifest ]
@@ -164,12 +165,16 @@ maximalIndex manifests = do
       Left errors -> Tuple (Map.insertWith Map.union name (Map.singleton version errors) failed) index
       Right newIndex -> Tuple failed newIndex
 
-  Array.foldl insertManifest (Tuple Map.empty empty) (topologicalSort manifests)
+  Array.foldl insertManifest (Tuple Map.empty empty) (topologicalSort IgnoreRanges manifests)
+
+data IncludeRanges
+  = ConsiderRanges
+  | IgnoreRanges
 
 -- | Topologically sort a set of manifests so that each manifest in the array
 -- | depends only on package versions that have already been encountered.
-topologicalSort :: Set Manifest -> Array Manifest
-topologicalSort manifests =
+topologicalSort :: IncludeRanges -> Set Manifest -> Array Manifest
+topologicalSort includeRanges manifests =
   Array.fromFoldable
     $ List.reverse
     $ List.mapMaybe (flip Graph.lookup graph)
@@ -196,12 +201,9 @@ topologicalSort manifests =
       -- This case should not be possible: it means that the manifest indicates
       -- a dependency that does not exist at all. (TODO: Explain)
       let versions = Maybe.fromMaybe [] $ Map.lookup dependency allPackageVersions
-      -- Technically, we should restrict the sort to only apply to package
-      -- versions admitted by the given range. This is faster and correct, but
-      -- fails in the case where we want to produce a maximal index while
-      -- ignoring version bounds.
-      included <- Array.filter (Range.includes range) versions
-      --included <- versions
+      included <- case includeRanges of
+        ConsiderRanges -> Array.filter (Range.includes range) versions
+        IgnoreRanges -> versions
       [ Tuple dependency included ]
 
 -- | Calculate the directory containing this package in the registry index,

--- a/lib/src/ManifestIndex.purs
+++ b/lib/src/ManifestIndex.purs
@@ -68,6 +68,7 @@ import Registry.Manifest as Manifest
 import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Range (Range)
+import Registry.Range as Range
 import Registry.Version (Version)
 
 -- | An index of package manifests, keyed by package name and version. The index
@@ -191,7 +192,7 @@ topologicalSort manifests =
   resolveDependencies :: Manifest -> Tuple (Tuple PackageName Version) (Tuple Manifest (List (Tuple PackageName Version)))
   resolveDependencies manifest@(Manifest { name, version, dependencies }) =
     Tuple (Tuple name version) $ Tuple manifest $ List.fromFoldable do
-      Tuple dependency _ <- Map.toUnfoldable dependencies
+      Tuple dependency range <- Map.toUnfoldable dependencies
       -- This case should not be possible: it means that the manifest indicates
       -- a dependency that does not exist at all. (TODO: Explain)
       let versions = Maybe.fromMaybe [] $ Map.lookup dependency allPackageVersions
@@ -199,8 +200,8 @@ topologicalSort manifests =
       -- versions admitted by the given range. This is faster and correct, but
       -- fails in the case where we want to produce a maximal index while
       -- ignoring version bounds.
-      --     included <- Array.filter (Range.includes range) versions
-      included <- versions
+      included <- Array.filter (Range.includes range) versions
+      --included <- versions
       [ Tuple dependency included ]
 
 -- | Calculate the directory containing this package in the registry index,

--- a/lib/test/Registry/ManifestIndex.purs
+++ b/lib/test/Registry/ManifestIndex.purs
@@ -201,7 +201,7 @@ testIndex { satisfied, unsatisfied } = case ManifestIndex.maximalIndex (Set.from
 
 testSorted :: forall m. MonadThrow Error m => Array Manifest -> m Unit
 testSorted input = do
-  let sorted = ManifestIndex.topologicalSort (Set.fromFoldable input)
+  let sorted = ManifestIndex.topologicalSort ManifestIndex.IgnoreRanges (Set.fromFoldable input)
   unless (input == sorted) do
     Assert.fail $ String.joinWith "\n"
       [ Argonaut.stringifyWithIndent 2 $ CA.encode (CA.array manifestCodec') input

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -252,7 +252,7 @@ determineAllCompilerVersions = do
     Log.debug $ "Compiling with purs@" <> Version.print compiler <> " and globs " <> String.joinWith " " globs
     compilerOutput <- Run.liftAff $ Purs.callCompiler
       { command: Purs.Compile { globs }
-      , version: Just (Version.print compiler)
+      , version: Just compiler
       , cwd: Just tmp
       }
 

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -201,7 +201,7 @@ determineCompilerVersionsForPackage package version = do
 
 determineAllCompilerVersions :: forall r. Run (AFF + EFFECT + REGISTRY + EXCEPT String + LOG + STORAGE + r) (Map (Tuple PackageName Version) (Array Version))
 determineAllCompilerVersions = do
-  allManifests <- ManifestIndex.toSortedArray <$> Registry.readAllManifests
+  allManifests <- ManifestIndex.toSortedArray ManifestIndex.ConsiderRanges <$> Registry.readAllManifests
   compilerVersions <- PursVersions.pursVersions
   supportedForVersion <- map Map.fromFoldable $ for (Just (NEA.last compilerVersions)) \compiler -> do
     Log.info $ "Starting checks for " <> Version.print compiler

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -10,8 +10,6 @@ import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Map as Map
 import Data.String as String
 import Data.Tuple (uncurry)
-import Debug (traceM)
-import Effect.Aff as Aff
 import Effect.Class.Console as Console
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path

--- a/scripts/src/CompilerVersions.purs
+++ b/scripts/src/CompilerVersions.purs
@@ -233,7 +233,7 @@ failureReasonCodec = Profunctor.dimap toVariant fromVariant $ CA.Variant.variant
 
   fromVariant = Variant.match
     { cannotSolve: \_ -> CannotSolve
-    , cannotCompile: \_ ->  CannotCompile
+    , cannotCompile: \_ -> CannotCompile
     , unknownReason: \_ -> UnknownReason
     }
 

--- a/scripts/src/LegacyImporter.purs
+++ b/scripts/src/LegacyImporter.purs
@@ -227,7 +227,7 @@ runLegacyImport mode logs = do
   Log.info $ formatImportStats $ calculateImportStats legacyRegistry importedIndex
 
   Log.info "Sorting packages for upload..."
-  let allIndexPackages = ManifestIndex.toSortedArray importedIndex.registryIndex
+  let allIndexPackages = ManifestIndex.toSortedArray ManifestIndex.IgnoreRanges importedIndex.registryIndex
 
   Log.info "Removing packages that previously failed publish"
   indexPackages <- allIndexPackages # Array.filterA \(Manifest { name, version }) ->


### PR DESCRIPTION
This PR builds on #632 and is a step towards #255. It extends to `compiler-versions` script with the option to compute the supported compiler versions for all packages in the manifest index.

The algorithm for finding the supported packages for a specific compiler version is the following:

1. Topologically sort the current manifest index, initialize an empty `DependencyIndex`
2. For each `Manifest`, try to solve via the previous `DependencyIndex` and then compile - if it succeeds, add the entry to the `DependencyIndex`, else record failure and continue

The end result is a `DependencyIndex` with as many entries as we could solve and then compile with that compiler version. Any `Manifest` not found there either didn't solve (meaning its dependencies are not supported by that compiler version) or didn't compiler (meaning its dependencies are supported by that compiler version, but that package is not). We record all entries and continue to the next compiler.

I am currently dumping results to a file and logging progress messages per entry we check. There are comprehensive debug logs. The failure results are sorted in topological order so that we can see how failures propagate throughout.

### Usage:

For all packages, all compilers:
`GITHUB_TOKEN=xxx spago run -p registry-scripts -m Registry.Scripts.CompilerVersions -- --all-packages --all-compilers`

For all packages, with a single compiler:
`GITHUB_TOKEN=xxx spago run -p registry-scripts -m Registry.Scripts.CompilerVersions -- --all-packages --compiler 0.13.0`

For a single package, checking all compilers:
`GITHUB_TOKEN=xxx spago run -p registry-scripts -m Registry.Scripts.CompilerVersions -- --package prelude@3.0.0 --all-compilers`

For a single package, checking a single compiler:
`GITHUB_TOKEN=xxx spago run -p registry-scripts -m Registry.Scripts.CompilerVersions -- --package prelude@3.0.0 --compiler 0.13.0`

### Future Work:

I've ran the script on 0.15.0 and 0.13.0 and the output looked fine at a glance. In the future we will need to add some verification checks (perhaps making sure the package sets for that compiler version are all included in this output), but I've left that as follow on work.

I've ran into spurious API failures while installing packages quite often, which should be alleviated by #638.