### PR TITLE
Upgrade to nodejs_20

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689715163,
-        "narHash": "sha256-HgBowH0RUU+6SpvpXYfTSunAqaME/6d0bqAW+shW6e4=",
+        "lastModified": 1690892192,
+        "narHash": "sha256-Upe0iAfAGL7r0NGgY47R3rUbsAPIah+3zZFB9YKevEc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0171976ee0a1fa795b105c19a323e67b9c6094d9",
+        "rev": "519676d102838a2345cb0f87ccddc517c6aee06f",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "slimlock": "slimlock"
       },
       "locked": {
-        "lastModified": 1689725005,
-        "narHash": "sha256-NqpH/tNK0fuDNWfKW+guYbhfzPl6G9E+xUpNBq96usI=",
+        "lastModified": 1690468696,
+        "narHash": "sha256-WsPg+/n/REyVQjYVxwMa15kBVCx1Ngwal/125GIyMzY=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "6a7feaf0b0dc8ac5d9fdfd92e80b0aea306109b0",
+        "rev": "8fc4e7929ecba966356672c3c4d0a44b0b5bc4b1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     deployers = import ./nix/deployers.nix;
 
     registryOverlay = final: prev: rec {
-      nodejs = prev.nodejs-18_x;
+      nodejs = prev.nodejs_20;
 
       # We don't want to force everyone to update their configs if they aren't
       # normally on flakes.


### PR DESCRIPTION
This updates our infrastructure to use Node 20, the current Node active release (Node 18 reaches end of active support in a month or two).