### PR TITLE
Source env from state dir

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -92,14 +92,14 @@ in {
             # Initialize environment variables
             set -o allexport
             source ${defaultEnvFile}
-            set +o allexport
 
-            # If a .env file exists in the stateDir then the server will load it
-            # at startup; any env vars included will overwrite those provided
-            # via the 'cfg.envVars' option.
+            # If a .env file exists in the stateDir then we will use it instead;
+            # this overwrites the cfg.envVars settings.
             if [ -f ${cfg.stateDir}/.env ]; then
               echo "Production .env file found! Values will overwrite the defaults."
+              source ${defaultEnvFile}
             fi
+            set +o allexport
 
             export DATABASE_URL="sqlite:${cfg.stateDir}/db/registry.sqlite3"
             pushd ${pkgs.registry.apps.server}/bin

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -97,7 +97,7 @@ in {
             # this overwrites the cfg.envVars settings.
             if [ -f ${cfg.stateDir}/.env ]; then
               echo "Production .env file found! Values will overwrite the defaults."
-              source ${defaultEnvFile}
+              source ${cfg.stateDir}/.env
             fi
             set +o allexport
 


### PR DESCRIPTION
In #641 I assumed that the .env file on the server would be loaded at startup by the `Server.purs` module. But that is not the case: it attempts to load the one present in the current working directory. We need to source the values from the /var/lib/registry-server directory instead. This PR accomplishes that, while still allowing local overrides via a .env file.

An alternate approach would be to adjust the 'loadEnv' function such that it tries to load the /var/lib/registry-server/.env file, then the local .env file, and do nothing in the module.nix service definition itself.