### PR TITLE
Only deploy on push to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,11 @@
 name: deploy
 
 on:
-  # This event is triggered once per non-Github Actions check-suite. If the only
-  # check suites we are running are garnix and Github Actions-based ones, this
-  # will be triggered only once, when garnix is done with all the builds for a
-  # commit.
-  check_suite:
-    types: [completed]
+  push:
+    branches: [master]
 
 jobs:
   deploy:
-    # Deploys should only occur from the master branch
-    if: github.ref_name == 'master'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   deploy:
+    # Deploys should only occur from the master branch
+    if: github.ref_name == 'master'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The deploy workflow (https://github.com/purescript/registry-dev/actions/workflows/deploy.yml) is running every time a check_suite completes, ie. any time a commit is pushed to this repository and tests are run. It is _supposed_ to be running when a check suite completes on the master branch, but clearly my understanding of this filter is wrong.

The result is that the master branch is being redeployed any time any work on any PR is done. We really just want to be deploying off the master branch so I've updated the workflow accordingly.