### PR TITLE
Replace Affjax with Fetch 

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,6 @@
     "better-sqlite3": "^8.4.0",
     "registry-foreign": "file:../foreign",
     "registry-lib": "file:../lib",
-    "xhr2": "^0.2.1",
     "yaml": "^2.2.2"
   }
 }

--- a/app/spago.yaml
+++ b/app/spago.yaml
@@ -7,8 +7,6 @@ package:
     version: 0.0.1
   dependencies:
     - aff
-    - affjax
-    - affjax-node
     - ansi
     - argonaut-core
     - arrays
@@ -26,6 +24,7 @@ package:
     - exceptions
     - exists
     - filterable
+    - fetch
     - foldable-traversable
     - foreign-object
     - formatters
@@ -35,6 +34,7 @@ package:
     - integers
     - js-date
     - js-uri
+    - js-promise-aff
     - lists
     - maybe
     - media-types

--- a/app/src/App/CLI/Git.purs
+++ b/app/src/App/CLI/Git.purs
@@ -2,7 +2,6 @@ module Registry.App.CLI.Git where
 
 import Registry.App.Prelude
 
-import Affjax (URL)
 import Data.Array as Array
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.String as String

--- a/app/src/App/Effect/Env.purs
+++ b/app/src/App/Effect/Env.purs
@@ -3,7 +3,6 @@ module Registry.App.Effect.Env where
 
 import Registry.App.Prelude
 
-import Affjax (URL)
 import Data.Array as Array
 import Data.String as String
 import Data.String.Base64 as Base64

--- a/app/src/App/Effect/Storage.purs
+++ b/app/src/App/Effect/Storage.purs
@@ -18,14 +18,13 @@ module Registry.App.Effect.Storage
 
 import Registry.App.Prelude
 
-import Affjax.Node as Affjax.Node
-import Affjax.ResponseFormat as ResponseFormat
 import Data.Array as Array
 import Data.Exists as Exists
-import Data.HTTP.Method (Method(..))
 import Data.Set as Set
 import Data.String as String
 import Effect.Aff as Aff
+import Effect.Exception as Exception
+import Fetch.Retry as Fetch
 import Node.Buffer as Buffer
 import Node.FS.Aff as FS.Aff
 import Registry.App.Effect.Cache (class FsEncodable, Cache, FsEncoding(..))
@@ -98,7 +97,7 @@ parsePackagePath input = do
       if Array.length parts > 2 then "Too many parts in path: " <> input
       else "Too few parts in path: " <> input
 
-formatPackageUrl :: forall r. PackageName -> Version -> Run (RESOURCE_ENV + r) Affjax.Node.URL
+formatPackageUrl :: forall r. PackageName -> Version -> Run (RESOURCE_ENV + r) URL
 formatPackageUrl name version = do
   { s3ApiUrl } <- Env.askResourceEnv
   pure $ Array.fold [ s3ApiUrl, "/", formatPackagePath name version ]
@@ -245,11 +244,7 @@ downloadS3 name version = do
   packageUrl <- formatPackageUrl name version
 
   Log.debug $ "Downloading " <> package <> " from " <> packageUrl
-  response <- Run.liftAff $ withRetryRequest' $ Affjax.Node.defaultRequest
-    { method = Left GET
-    , responseFormat = ResponseFormat.arrayBuffer
-    , url = packageUrl
-    }
+  response <- Run.liftAff $ Fetch.withRetryRequest packageUrl {}
 
   -- TODO: Rely on the metadata to check the size and hash? Or do we not care
   -- for registry-internal operations?
@@ -257,17 +252,20 @@ downloadS3 name version = do
     Cancelled -> do
       Log.error $ "Failed to download " <> package <> " from " <> packageUrl <> " because of a connection timeout."
       Except.throw $ "Failed to download " <> package <> " from the storage backend."
-    Failed (AffjaxError error) -> do
-      Log.error $ "Failed to download " <> package <> " from " <> packageUrl <> " because of an HTTP error: " <> Affjax.Node.printError error
+    Failed (Fetch.FetchError error) -> do
+      Log.error $ "Failed to download " <> package <> " from " <> packageUrl <> " because of an HTTP error: " <> Exception.message error
       Except.throw $ "Could not download " <> package <> " from the storage backend."
-    Failed (StatusError { status, body }) -> do
-      buffer <- Run.liftEffect $ Buffer.fromArrayBuffer body
+    Failed (Fetch.StatusError { status, arrayBuffer: arrayBufferAff }) -> do
+      arrayBuffer <- Run.liftAff arrayBufferAff
+      buffer <- Run.liftEffect $ Buffer.fromArrayBuffer arrayBuffer
       bodyString <- Run.liftEffect $ Buffer.toString UTF8 (buffer :: Buffer)
       Log.error $ "Failed to download " <> package <> " from " <> packageUrl <> " because of a bad status code (" <> show status <> ") with body " <> bodyString
       Except.throw $ "Could not download " <> package <> " from the storage backend."
-    Succeeded { body } -> do
+    Succeeded { arrayBuffer: arrayBufferAff } -> do
+      arrayBuffer <- Run.liftAff arrayBufferAff
+
       Log.debug $ "Successfully downloaded " <> package <> " into a buffer."
-      buffer :: Buffer <- Run.liftEffect $ Buffer.fromArrayBuffer body
+      buffer :: Buffer <- Run.liftEffect $ Buffer.fromArrayBuffer arrayBuffer
       pure buffer
 
 withRetryListObjects :: S3.Space -> PackageName -> Aff (Either String (Array String))

--- a/app/src/Fetch/Retry.purs
+++ b/app/src/Fetch/Retry.purs
@@ -1,0 +1,74 @@
+module Fetch.Retry
+  ( withRetryRequest
+  , RetryRequestError(..)
+  , module ReExport
+  ) where
+
+import Registry.App.Prelude
+
+import Effect.Aff (Error)
+import Effect.Aff as Aff
+import Fetch (class ToCoreRequestOptions, HighlevelRequestOptions, Response, new)
+import Fetch (Response) as ReExport
+import Fetch.Core as Core
+import Fetch.Core.Request as CoreRequest
+import Fetch.Internal.Request as Request
+import Fetch.Internal.Response as Response
+import Prim.Row (class Union)
+import Promise.Aff as Promise.Aff
+
+data RetryRequestError
+  = FetchError Error
+  | StatusError Response
+
+withRetryRequest
+  :: forall input output thruIn thruOut headers
+   . Union input thruIn (HighlevelRequestOptions headers String)
+  => Union output thruOut CoreRequest.UnsafeRequestOptions
+  => ToCoreRequestOptions input output
+  => String
+  -> { | input }
+  -> Aff (RetryResult RetryRequestError Response)
+withRetryRequest url r =
+  withRetry retry
+    $ (Aff.attempt $ fetch @thruIn url r)
+    <#>
+      ( either
+          (Left <<< FetchError)
+          onFetchResponse
+      )
+  where
+  onFetchResponse :: Response -> Either RetryRequestError Response
+  onFetchResponse response =
+    if response.status >= 400 then Left $ StatusError response
+    else Right response
+
+  retry =
+    { timeout: defaultRetry.timeout
+    , retryOnCancel: defaultRetry.retryOnCancel
+    , retryOnFailure: \attempt -> case _ of
+        FetchError _ -> false
+        StatusError { status } ->
+          -- We retry on 500-level errors in case the server is temporarily
+          -- unresponsive, and fail otherwise.
+          if status >= 500 then
+            attempt < 3
+          else false
+    }
+
+-- | Copied and adapted from fetch source code to allow us to disambiguate type variables.
+-- | The upstream library will soon be updated to use Visible Type Application
+-- | and then we can drop this redefinition:
+-- | https://github.com/rowtype-yoga/purescript-fetch/issues/9
+fetch
+  :: forall input output @thruIn thruOut headers
+   . Union input thruIn (HighlevelRequestOptions headers String)
+  => Union output thruOut CoreRequest.UnsafeRequestOptions
+  => ToCoreRequestOptions input output
+  => String
+  -> { | input }
+  -> Aff Response
+fetch url input = do
+  request <- liftEffect $ new url $ Request.convert input
+  coreResponse <- Promise.Aff.toAffE $ Core.fetch request
+  pure $ Response.convert coreResponse

--- a/foreign/package.json
+++ b/foreign/package.json
@@ -7,6 +7,7 @@
     "@octokit/plugin-throttling": "^3.7.0",
     "@octokit/rest": "^18.12.0",
     "aws-sdk": "^2.1050.0",
+    "better-sqlite3": "^8.5.2",
     "fast-glob": "^3.2.11",
     "fs-extra": "^10.0.0",
     "fuse.js": "^6.6.2",
@@ -14,6 +15,7 @@
     "registry-lib": "file:../lib",
     "semver": "^7.5.2",
     "tar": "^6.1.11",
-    "tmp": "^0.2.1"
+    "tmp": "^0.2.1",
+    "yaml": "^2.3.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "better-sqlite3": "^8.4.0",
         "registry-foreign": "file:../foreign",
         "registry-lib": "file:../lib",
-        "xhr2": "^0.2.1",
         "yaml": "^2.2.2"
       }
     },
@@ -31,6 +30,7 @@
         "@octokit/plugin-throttling": "^3.7.0",
         "@octokit/rest": "^18.12.0",
         "aws-sdk": "^2.1050.0",
+        "better-sqlite3": "^8.5.2",
         "fast-glob": "^3.2.11",
         "fs-extra": "^10.0.0",
         "fuse.js": "^6.6.2",
@@ -38,7 +38,8 @@
         "registry-lib": "file:../lib",
         "semver": "^7.5.2",
         "tar": "^6.1.11",
-        "tmp": "^0.2.1"
+        "tmp": "^0.2.1",
+        "yaml": "^2.3.1"
       }
     },
     "lib": {
@@ -299,9 +300,9 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
     "node_modules/better-sqlite3": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.4.0.tgz",
-      "integrity": "sha512-NmsNW1CQvqMszu/CFAJ3pLct6NEFlNfuGM6vw72KHkjOD1UDnL96XNN1BMQc1hiHo8vE2GbOWQYIpZ+YM5wrZw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.5.2.tgz",
+      "integrity": "sha512-w/EZ/jwuZF+/47mAVC2+rhR2X/gwkZ+fd1pbX7Y90D5NRaRzDQcxrHY10t6ijGiYIonCVsBSF5v1cay07bP5sg==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.5.0",
@@ -1496,14 +1497,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/xhr2": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
-      "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/xml2js": {
       "version": "0.5.0",

--- a/spago.lock
+++ b/spago.lock
@@ -4,8 +4,6 @@ workspace:
       path: app
       dependencies:
         - aff
-        - affjax
-        - affjax-node
         - ansi
         - argonaut-core
         - arrays
@@ -22,6 +20,7 @@ workspace:
         - either
         - exceptions
         - exists
+        - fetch
         - filterable
         - foldable-traversable
         - foreign-object
@@ -31,6 +30,7 @@ workspace:
         - identity
         - integers
         - js-date
+        - js-promise-aff
         - js-uri
         - lists
         - maybe
@@ -195,7 +195,7 @@ workspace:
         - variant
       test_dependencies: []
   package_set:
-    registry: 28.1.1
+    registry: 37.0.0
   extra_packages:
     spago-core:
       git: https://github.com/purescript/spago.git
@@ -231,33 +231,6 @@ packages:
     dependencies:
       - aff
       - foreign
-  affjax:
-    type: registry
-    version: 13.0.0
-    integrity: sha256-blYfaoW4FYIrIdvmT4sB7nN7BathFaEfZuiVLPmHJOo=
-    dependencies:
-      - aff
-      - argonaut-core
-      - arraybuffer-types
-      - foreign
-      - form-urlencoded
-      - http-methods
-      - integers
-      - media-types
-      - nullable
-      - refs
-      - unsafe-coerce
-      - web-xhr
-  affjax-node:
-    type: registry
-    version: 1.0.0
-    integrity: sha256-NcmRTXJxJzgHuKoLh+36yA8UejkfouYcX3uevT+Trjc=
-    dependencies:
-      - aff
-      - affjax
-      - either
-      - maybe
-      - prelude
   ansi:
     type: registry
     version: 7.0.0
@@ -592,6 +565,50 @@ packages:
     integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
     dependencies:
       - unsafe-coerce
+  fetch:
+    type: registry
+    version: 2.0.0
+    integrity: sha256-43ojzk1qxr5EUTuRmL8R4Fnqd0V3uXFhL5lWCytaer0=
+    dependencies:
+      - aff
+      - arraybuffer-types
+      - effect
+      - fetch-core
+      - foreign
+      - http-methods
+      - js-promise-aff
+      - newtype
+      - prelude
+      - record
+      - typelevel-prelude
+      - web-file
+      - web-streams
+  fetch-core:
+    type: registry
+    version: 5.1.0
+    integrity: sha256-mBifgiz5g2QhyCHeYn/A6M6+7FWEw63KxXN+UWFHX/o=
+    dependencies:
+      - arraybuffer-types
+      - arrays
+      - console
+      - effect
+      - foldable-traversable
+      - foreign
+      - foreign-object
+      - functions
+      - http-methods
+      - js-promise
+      - maybe
+      - newtype
+      - nullable
+      - prelude
+      - record
+      - tuples
+      - typelevel-prelude
+      - unfoldable
+      - unsafe-coerce
+      - web-file
+      - web-streams
   filterable:
     type: registry
     version: 5.0.0
@@ -665,18 +682,6 @@ packages:
     integrity: sha256-X7u0SuCvFbLbzuNEKLBNuWjmcroqMqit4xEzpQwAP7E=
     dependencies:
       - aff
-  form-urlencoded:
-    type: registry
-    version: 7.0.0
-    integrity: sha256-WUzk8DTjrbPVHKZ5w7XpPBO6ci6xFhvYguHp6RvX+18=
-    dependencies:
-      - foldable-traversable
-      - js-uri
-      - maybe
-      - newtype
-      - prelude
-      - strings
-      - tuples
   formatters:
     type: registry
     version: 7.0.0
@@ -853,6 +858,25 @@ packages:
       - foreign
       - integers
       - now
+  js-promise:
+    type: registry
+    version: 1.0.0
+    integrity: sha256-kXNo5g9RJgPdrTuKRe5oG2kBIwPp+j5VDPDplqZBJzQ=
+    dependencies:
+      - effect
+      - exceptions
+      - foldable-traversable
+      - functions
+      - maybe
+      - prelude
+  js-promise-aff:
+    type: registry
+    version: 1.0.0
+    integrity: sha256-s9kml9Ei74hKlMMg41yyZp4GkbmYUwaH+gBWWrdhwec=
+    dependencies:
+      - aff
+      - foreign
+      - js-promise
   js-timers:
     type: registry
     version: 6.1.0
@@ -1104,8 +1128,8 @@ packages:
       - unsafe-coerce
   node-fs-aff:
     type: registry
-    version: 9.2.0
-    integrity: sha256-usKEFrLY9zh8o3IP3bwc+jX7Zd4OOmhHvwLFZlxdN8U=
+    version: 9.2.2
+    integrity: sha256-BPcg35n+cnQzAcediaqTf4hJYbiotZEG72e8JjL/nRo=
     dependencies:
       - aff
       - either
@@ -1237,8 +1261,8 @@ packages:
       - tuples
   ordered-collections:
     type: registry
-    version: 3.0.0
-    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
+    version: 3.1.0
+    integrity: sha256-Qs3KjwxhDbemLBzvn5hxagwieOZVcUnPeBENe9NK5fQ=
     dependencies:
       - arrays
       - foldable-traversable
@@ -1260,8 +1284,8 @@ packages:
       - prelude
   parallel:
     type: registry
-    version: 6.0.0
-    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
+    version: 7.0.0
+    integrity: sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=
     dependencies:
       - control
       - effect
@@ -1538,17 +1562,17 @@ packages:
       - tuples
   spec:
     type: registry
-    version: 7.3.0
-    integrity: sha256-YmmRmlHmSHyAM8j5/QVHLgkMhtAkt2FXytVb5j/Zu0s=
+    version: 7.5.4
+    integrity: sha256-o49xJAmAN//ZYVMTz01xeDqdLOiEYoHbaXZYtOXmUZI=
     dependencies:
       - aff
       - ansi
       - arrays
       - avar
       - bifunctors
-      - console
       - control
       - datetime
+      - debug
       - effect
       - either
       - exceptions
@@ -1564,6 +1588,7 @@ packages:
       - parallel
       - pipes
       - prelude
+      - refs
       - strings
       - tailrec
       - transformers
@@ -1759,30 +1784,15 @@ packages:
       - foreign
       - media-types
       - web-dom
-  web-html:
+  web-streams:
     type: registry
-    version: 4.1.0
-    integrity: sha256-ByqS/h1/yG+hjCOnOQp7L1QpIWzQENNKB1kaHtpEhlE=
-    dependencies:
-      - js-date
-      - web-dom
-      - web-file
-      - web-storage
-  web-storage:
-    type: registry
-    version: 5.0.0
-    integrity: sha256-q+6lxcnfWxus0/nDeFVtF1V+tLehZvvXQ0cduYPLksY=
-    dependencies:
-      - nullable
-      - web-events
-  web-xhr:
-    type: registry
-    version: 5.0.1
-    integrity: sha256-3dbIPVG66S+hPrgEVnpD78hrGjE7qlBbsReWOz89Ios=
+    version: 4.0.0
+    integrity: sha256-02HgXIk6R+pU9fWOX42krukAI1QkCbLKcCv3b4Jq6WI=
     dependencies:
       - arraybuffer-types
-      - datetime
-      - http-methods
-      - web-dom
-      - web-file
-      - web-html
+      - effect
+      - exceptions
+      - js-promise
+      - nullable
+      - prelude
+      - tuples

--- a/spago.yaml
+++ b/spago.yaml
@@ -1,7 +1,7 @@
 workspace:
   lock: true
   package_set:
-    registry: 28.1.1
+    registry: 37.0.0
   extra_packages:
     spago-core:
       git: https://github.com/purescript/spago.git

--- a/spago.yaml
+++ b/spago.yaml
@@ -1,7 +1,7 @@
 workspace:
   lock: true
   package_set:
-    registry: 37.0.0
+    registry: 35.1.0
   extra_packages:
     spago-core:
       git: https://github.com/purescript/spago.git


### PR DESCRIPTION
Resolves #643

Replaces Affjax with Fetch.
I recommend reviewing `Fetch.Retry` first, the rest of changes are pretty mechanical. 
There's probably a case to be made for moving some or all of the `Fetch.Retry` module into the actual fetch package.
Just let me know what you want to do.