### PR TITLE
Read .env.example in pipeline tests and update lockfile

### DIFF
--- a/app/test/App/API.purs
+++ b/app/test/App/API.purs
@@ -13,6 +13,7 @@ import Node.FS.Aff as FS.Aff
 import Node.Path as Path
 import Node.Process as Process
 import Registry.App.API as API
+import Registry.App.Effect.Env as Env
 import Registry.App.Effect.Log as Log
 import Registry.App.Effect.Pursuit as Pursuit
 import Registry.App.Effect.Registry as Registry
@@ -104,6 +105,8 @@ spec = do
     -- the fixtures directory.
     enterCleanEnv :: FilePath -> Aff PipelineEnv
     enterCleanEnv workdir = do
+      Env.loadEnvFile (Path.concat [ "..", ".env.example" ])
+
       -- FIXME: The publish pipeline probably shouldn't require this. But...the
       -- publish pipeline requires that there be a 'types' directory containing
       -- dhall types for the registry in the current working directory.

--- a/spago.lock
+++ b/spago.lock
@@ -195,7 +195,7 @@ workspace:
         - variant
       test_dependencies: []
   package_set:
-    registry: 37.0.0
+    registry: 35.1.0
   extra_packages:
     spago-core:
       git: https://github.com/purescript/spago.git
@@ -1261,8 +1261,8 @@ packages:
       - tuples
   ordered-collections:
     type: registry
-    version: 3.1.0
-    integrity: sha256-Qs3KjwxhDbemLBzvn5hxagwieOZVcUnPeBENe9NK5fQ=
+    version: 3.0.0
+    integrity: sha256-R9WddNBRPkY37gw8XkDCLX2vJ5eI9qdaWDdCp61r2+M=
     dependencies:
       - arrays
       - foldable-traversable
@@ -1284,8 +1284,8 @@ packages:
       - prelude
   parallel:
     type: registry
-    version: 7.0.0
-    integrity: sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=
+    version: 6.0.0
+    integrity: sha256-VJbkGD0rAKX+NUEeBJbYJ78bEKaZbgow+QwQEfPB6ko=
     dependencies:
       - control
       - effect


### PR DESCRIPTION
The main branch right now is a little bit inconsistent in that a) the lockfile has gone out of date and b) running tests locally will fail with a missing HEALTHCHECKS_URL env var for the pipeline, since this isn't set in your shell (normally!) and we never read the env files. This PR fixes those two issues.