### PR TITLE
Thread through package set errors

### DIFF
--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -204,9 +204,9 @@ packageSetUpdate payload = do
   let changeSet = candidates.accepted <#> maybe Remove Update
   Comment.comment "Attempting to build package set update."
   PackageSets.upgradeAtomic latestPackageSet (fromMaybe prevCompiler payload.compiler) changeSet >>= case _ of
-    Nothing ->
-      Except.throw "The package set produced from this suggested update does not compile."
-    Just packageSet -> do
+    Left error ->
+      Except.throw $ "The package set produced from this suggested update does not compile:\n\n" <> error
+    Right packageSet -> do
       let commitMessage = PackageSets.commitMessage latestPackageSet changeSet (un PackageSet packageSet).version
       Registry.writePackageSet packageSet commitMessage
       Comment.comment "Built and released a new package set! Now mirroring to the package-sets repo..."

--- a/app/test/Test/Assert/Run.purs
+++ b/app/test/Test/Assert/Run.purs
@@ -217,7 +217,7 @@ handlePackageSetsMock :: forall r a. PackageSets a -> Run r a
 handlePackageSetsMock = case _ of
   -- FIXME: Actually reply with a package set with a pure upgrade
   UpgradeAtomic _packageSet _compilerVersion _changeSet reply -> do
-    pure $ reply $ Right Nothing
+    pure $ reply $ Right $ Left ""
   -- FIXME: Actually reply with a package sequential upgrade result
   UpgradeSequential packageSet _compilerVersion changeSet reply ->
     pure $ reply $ Right $ Just { failed: changeSet, succeeded: changeSet, result: packageSet }


### PR DESCRIPTION
Fixes #647 by returning errors in the batch package set update call. This isn't done for sequential updates since those are never user-visible, only run nightly in CI, where they're logged.