### PR TITLE
Support Windows globs

### DIFF
--- a/foreign/src/Foreign/FastGlob.js
+++ b/foreign/src/Foreign/FastGlob.js
@@ -1,3 +1,5 @@
 import fg from "fast-glob";
 
 export const matchImpl = (entries) => (options) => () => fg(entries, options);
+
+export const convertPathToPattern = (path) => fg.convertPathToPattern(path);


### PR DESCRIPTION
Came across this one while working on https://github.com/purescript/spago/pull/995: it turns out that [fast-glob](https://www.npmjs.com/package/fast-glob) only supports forward slashes, so paths need to be converted for that.

The library exports a `convertPathToPattern` function, which I:
- added to the implementation of `match` so that the generated matches can take Windows paths
- exported from the library so that downstream can use it to fix their paths