### PR TITLE
Update compilers (0.15.11, 0.15.12)

### DIFF
--- a/app/test/App/API.purs
+++ b/app/test/App/API.purs
@@ -105,15 +105,15 @@ spec = do
     -- the fixtures directory.
     enterCleanEnv :: FilePath -> Aff PipelineEnv
     enterCleanEnv workdir = do
-      Env.loadEnvFile (Path.concat [ "..", ".env.example" ])
+      Env.loadEnvFile ".env.example"
 
       -- FIXME: The publish pipeline probably shouldn't require this. But...the
       -- publish pipeline requires that there be a 'types' directory containing
       -- dhall types for the registry in the current working directory.
-      FS.Extra.copy { from: Path.concat [ "..", "types" ], to: Path.concat [ workdir, "types" ], preserveTimestamps: true }
+      FS.Extra.copy { from: "types", to: Path.concat [ workdir, "types" ], preserveTimestamps: true }
 
       testFixtures <- liftAff Tmp.mkTmpDir
-      let copyFixture path = FS.Extra.copy { from: Path.concat [ "fixtures", path ], to: Path.concat [ testFixtures, path ], preserveTimestamps: true }
+      let copyFixture path = FS.Extra.copy { from: Path.concat [ "app", "fixtures", path ], to: Path.concat [ testFixtures, path ], preserveTimestamps: true }
 
       -- Set up a clean fixtures environment.
       liftAff do

--- a/app/test/App/CLI/Licensee.purs
+++ b/app/test/App/CLI/Licensee.purs
@@ -10,7 +10,7 @@ import Test.Spec as Spec
 
 spec :: Spec.Spec Unit
 spec = do
-  let fixtures = Path.concat [ "fixtures", "manifest-files", "halogen-hooks" ]
+  let fixtures = Path.concat [ "app", "fixtures", "manifest-files", "halogen-hooks" ]
 
   Spec.it "Detects from directory" do
     detected <- Licensee.detect fixtures
@@ -62,7 +62,7 @@ readFiles = do
   pure { license, packageJson, spagoDhall, bowerJson }
 
 fixtureFile :: FilePath -> FilePath
-fixtureFile file = Path.concat [ "fixtures", "manifest-files", "halogen-hooks", file ]
+fixtureFile file = Path.concat [ "app", "fixtures", "manifest-files", "halogen-hooks", file ]
 
 readLicense :: Aff String
 readLicense = FS.Aff.readTextFile UTF8 $ fixtureFile "LICENSE"

--- a/app/test/App/CLI/PursVersions.purs
+++ b/app/test/App/CLI/PursVersions.purs
@@ -41,6 +41,8 @@ knownCompilers = map (unsafeFromRight <<< Version.parse)
   , "0.15.8"
   , "0.15.9"
   , "0.15.10"
+  , "0.15.11"
+  , "0.15.12"
   ]
 
 spec :: Spec.Spec Unit

--- a/app/test/App/GitHubIssue.purs
+++ b/app/test/App/GitHubIssue.purs
@@ -7,6 +7,7 @@ import Registry.App.Prelude
 import Data.Argonaut.Parser as Argonaut.Parser
 import Data.Codec.Argonaut as CA
 import Data.Map as Map
+import Node.Path as Path
 import Registry.App.GitHubIssue as GitHubIssue
 import Registry.Foreign.Octokit (IssueNumber(..))
 import Registry.Operation (PackageOperation(..), PackageSetOperation(..))
@@ -35,7 +36,7 @@ decodeEventsToOps = do
         , location: Nothing
         }
 
-    res <- GitHubIssue.readOperation "fixtures/update_issue_comment.json"
+    res <- GitHubIssue.readOperation $ Path.concat [ "app", "fixtures", "update_issue_comment.json" ]
     res `Assert.shouldEqual` GitHubIssue.DecodedOperation issueNumber username (Right operation)
 
   Spec.it "decodes an Addition operation" do
@@ -50,7 +51,7 @@ decodeEventsToOps = do
         , resolutions: Just $ Map.fromFoldable [ Utils.unsafePackageName "prelude" /\ Utils.unsafeVersion "1.0.0" ]
         }
 
-    res <- GitHubIssue.readOperation "fixtures/addition_issue_created.json"
+    res <- GitHubIssue.readOperation $ Path.concat [ "app", "fixtures", "addition_issue_created.json" ]
     res `Assert.shouldEqual` GitHubIssue.DecodedOperation issueNumber username (Right operation)
 
   Spec.it "decodes a Package Set Update operation" do
@@ -65,7 +66,7 @@ decodeEventsToOps = do
             ]
         }
 
-    res <- GitHubIssue.readOperation "fixtures/package-set-update_issue_created.json"
+    res <- GitHubIssue.readOperation $ Path.concat [ "app", "fixtures", "package-set-update_issue_created.json" ]
     res `Assert.shouldEqual` GitHubIssue.DecodedOperation issueNumber username (Left operation)
 
   Spec.it "decodes lenient JSON" do

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690996119,
-        "narHash": "sha256-VrRHVSMgnx/bF1RYose0/prp4AxTWmylkiXApgQ9yow=",
+        "lastModified": 1696815342,
+        "narHash": "sha256-MHA0Ye0PaFF6pay6tP9yMgwWvuqRraa9bH45U88RwC4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "333c06d0affd30db1a70f2658102597b92bad593",
+        "rev": "8be69c1764f58e07099e4a24b926f49bbada8c7f",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
         "slimlock": "slimlock"
       },
       "locked": {
-        "lastModified": 1690938891,
-        "narHash": "sha256-GHLvi3J0mp0hArCKjDr1+TzecVjbbWIfphwvnfn30Sc=",
+        "lastModified": 1696754599,
+        "narHash": "sha256-qS5DTaPdMi5I6fZqRcguCjH1gznN/IfeasqzGJAaBlg=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "339dc45f5f883644ce59bd95d23753c93845093e",
+        "rev": "31ce998c770647a8f732dbb51ecc09abda3beb38",
         "type": "github"
       },
       "original": {

--- a/lib/test/Registry/Manifest.purs
+++ b/lib/test/Registry/Manifest.purs
@@ -15,7 +15,7 @@ import Test.Spec as Spec
 spec :: Spec Unit
 spec = do
   Spec.it "Round-trips manifest fixtures" do
-    let manifestFixturesPath = Path.concat [ "fixtures", "manifests" ]
+    let manifestFixturesPath = Path.concat [ "lib", "fixtures", "manifests" ]
     fixturePaths <- FS.Aff.readdir manifestFixturesPath
     fixtures <- for fixturePaths \path -> do
       rawManifest <- FS.Aff.readTextFile UTF8 $ Path.concat [ manifestFixturesPath, path ]

--- a/lib/test/Registry/Sha256.purs
+++ b/lib/test/Registry/Sha256.purs
@@ -47,7 +47,7 @@ hooksSpagoHash :: Sha256.Sha256
 hooksSpagoHash = Utils.fromRight "Failed to parse Sha256" $ Sha256.parse "sha256-fN9RUAzN21ZY4Y0UwqUSxwUPVz1g7/pcqoDvbJZoT04="
 
 hooksSpago :: FilePath
-hooksSpago = Path.concat [ "fixtures", "packages", "halogen-hooks-0.5.0", "spago.dhall" ]
+hooksSpago = Path.concat [ "lib", "fixtures", "packages", "halogen-hooks-0.5.0", "spago.dhall" ]
 
 -- Test hash produced by `openssl`:
 -- openssl dgst -sha256 -binary < fixtures/packages/halogen-hooks-0.5.0/LICENSE | openssl base64 -A
@@ -55,7 +55,7 @@ hooksLicenseHash :: Sha256.Sha256
 hooksLicenseHash = Utils.fromRight "Failed to parse Sha256" $ Sha256.parse "sha256-wOzNcCq20TAL/LMT1lYIiaoEIFGDBw+yp14bj7qK9v4="
 
 hooksLicense :: FilePath
-hooksLicense = Path.concat [ "fixtures", "packages", "halogen-hooks-0.5.0", "LICENSE" ]
+hooksLicense = Path.concat [ "lib", "fixtures", "packages", "halogen-hooks-0.5.0", "LICENSE" ]
 
 sha256Nix :: FilePath -> ExceptT String Aff Sha256.Sha256
 sha256Nix path = ExceptT do


### PR DESCRIPTION
New compilers have come out, so this updates the flake to add support for them via purescript-overlay.

```console
❯ nix develop --command 'purs-versions'
0.13.0 0.13.2 0.13.3 0.13.4 0.13.5 0.13.6 0.13.8 0.14.0 0.14.1 0.14.2 0.14.3 0.14.4 0.14.5 0.14.6 0.14.7 0.14.8 0.14.9 0.15.0 0.15.10 0.15.11 0.15.12 0.15.2 0.15.3 0.15.4 0.15.5 0.15.6 0.15.7 0.15.8 0.15.9
```