### PR TITLE
Include additional VCS directories to ignore

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -426,7 +426,8 @@ These files are always included in the tarball, if present:
 
 These files are always excluded from the tarball, regardless of what is specified in the `files` key:
 
-- `.psci`, `.psci_modules`, `.spago`, `node_modules`, `bower_components`, `.git`, `CVS`, `.svn`, and `.hg` directories.
+- `.psci`, `.psci_modules`, `.spago`, `node_modules`, and `bower_components` directories.
+- `.git`, `CVS`, `.svn`, `.hg`, `_darcs`, `.fossil`, `.jj`, and `.pijul` <abbr title="version control system">VCS</abbr> directories.
 - `package-lock.json`, `yarn.lock`, and `pnpm-lock.yaml` files.
 - `.swp`, `._*`, and `.DS_Store` files.
 

--- a/lib/src/Constants.purs
+++ b/lib/src/Constants.purs
@@ -41,6 +41,11 @@ ignoredDirectories =
   , "CVS"
   , ".svn"
   , ".hg"
+  -- Additional VCS directories
+  , "_darcs"
+  , ".fossil"
+  , ".jj"
+  , ".pijul"
   ]
 
 ignoredFiles :: Array FilePath


### PR DESCRIPTION
npm’s list is incomplete for VCSs. Since they can sometimes execute scripts without the users knowledge & since only the source, not the entire history, is needed, it should be safe to ignore them. Additionally clarified these as a separate bullet point in the spec.