### PR TITLE
Port from codec-argonaut to codec-json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ result
 
 # Keep it secret, keep it safe.
 .env
+.envrc

--- a/app/spago.yaml
+++ b/app/spago.yaml
@@ -8,11 +8,11 @@ package:
   dependencies:
     - aff
     - ansi
-    - argonaut-core
     - arrays
     - b64
     - bifunctors
-    - codec-argonaut
+    - codec
+    - codec-json
     - console
     - const
     - control
@@ -23,22 +23,23 @@ package:
     - either
     - exceptions
     - exists
-    - filterable
     - fetch
+    - filterable
     - foldable-traversable
+    - foreign
     - foreign-object
     - formatters
     - http-methods
     - httpurple
     - identity
     - integers
-    - js-fetch
     - js-date
-    - js-uri
+    - js-fetch
     - js-promise-aff
+    - js-uri
+    - json
     - lists
     - maybe
-    - media-types
     - newtype
     - node-buffer
     - node-child-process
@@ -56,7 +57,6 @@ package:
     - partial
     - prelude
     - profunctor
-    - profunctor-lenses
     - record
     - refs
     - registry-foreign

--- a/app/src/App/Effect/Cache.purs
+++ b/app/src/App/Effect/Cache.purs
@@ -34,8 +34,8 @@ module Registry.App.Effect.Cache
 
 import Registry.App.Prelude
 
-import Data.Argonaut.Parser as Argonaut.Parser
-import Data.Codec.Argonaut as CA
+import Codec.JSON.DecodeError as CJ.DecodeError
+import Data.Codec.JSON as CJ
 import Data.Const (Const(..))
 import Data.Exists (Exists)
 import Data.Exists as Exists
@@ -45,6 +45,7 @@ import Data.String as String
 import Data.Symbol (class IsSymbol)
 import Effect.Aff as Aff
 import Effect.Ref as Ref
+import JSON as JSON
 import JSURI as JSURI
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
@@ -254,7 +255,7 @@ class FsEncodable key where
 -- | cache values as something other than JSON or a raw buffer.
 data FsEncoding :: (Type -> Type -> Type) -> Type -> Type -> Type
 data FsEncoding z b a
-  = AsJson String (JsonCodec a) (z a b)
+  = AsJson String (CJ.Codec a) (z a b)
   | AsBuffer String (z Buffer b)
 
 -- | Handle the Cache effect by caching values on the file system, given a
@@ -286,13 +287,13 @@ getFsImpl cacheDir = case _ of
       Left _ -> do
         Log.debug $ "No cache file found for " <> id <> " at path " <> path
         pure $ reply Nothing
-      Right content -> case Argonaut.Parser.jsonParser content of
+      Right content -> case JSON.parse content of
         Left parseError -> do
           Log.error $ "Found cache file for " <> id <> " at path " <> path <> " but its contents are not valid JSON: " <> parseError
           deletePathById cacheDir id *> pure (reply Nothing)
-        Right jsonContent -> case CA.decode codec jsonContent of
+        Right jsonContent -> case CJ.decode codec jsonContent of
           Left decodeError -> do
-            let error = CA.printJsonDecodeError decodeError
+            let error = CJ.DecodeError.print decodeError
             Log.error $ "Found cache file for " <> id <> " at path " <> path <> " but its contents could not be decoded with the provided codec:\n" <> error
             deletePathById cacheDir id *> pure (reply Nothing)
           Right entry -> do

--- a/app/src/App/Legacy/Manifest.purs
+++ b/app/src/App/Legacy/Manifest.purs
@@ -2,11 +2,13 @@ module Registry.App.Legacy.Manifest where
 
 import Registry.App.Prelude
 
+import Codec.JSON.DecodeError as CJ.DecodeError
 import Data.Array as Array
-import Data.Codec.Argonaut as CA
-import Data.Codec.Argonaut.Common as CA.Common
-import Data.Codec.Argonaut.Record as CA.Record
-import Data.Codec.Argonaut.Variant as CA.Variant
+import Data.Codec as Codec
+import Data.Codec.JSON as CJ
+import Data.Codec.JSON.Common as CJ.Common
+import Data.Codec.JSON.Record as CJ.Record
+import Data.Codec.JSON.Variant as CJ.Variant
 import Data.Either as Either
 import Data.Exists as Exists
 import Data.FunctorWithIndex (mapWithIndex)
@@ -182,18 +184,18 @@ data LegacyManifestError
   | InvalidLicense (Array String)
   | InvalidDependencies (Array { name :: String, range :: String, error :: String })
 
-legacyManifestErrorCodec :: JsonCodec LegacyManifestError
-legacyManifestErrorCodec = Profunctor.dimap toVariant fromVariant $ CA.Variant.variantMatch
+legacyManifestErrorCodec :: CJ.Codec LegacyManifestError
+legacyManifestErrorCodec = Profunctor.dimap toVariant fromVariant $ CJ.Variant.variantMatch
   { noManifests: Left unit
   , missingLicense: Left unit
-  , invalidLicense: Right (CA.array CA.string)
-  , invalidDependencies: Right (CA.array dependencyCodec)
+  , invalidLicense: Right (CJ.array CJ.string)
+  , invalidDependencies: Right (CJ.array dependencyCodec)
   }
   where
-  dependencyCodec = CA.Record.object "Dependency"
-    { name: CA.string
-    , range: CA.string
-    , error: CA.string
+  dependencyCodec = CJ.named "Dependency" $ CJ.Record.object
+    { name: CJ.string
+    , range: CJ.string
+    , error: CJ.string
     }
 
   toVariant = case _ of
@@ -305,15 +307,15 @@ newtype SpagoDhallJson = SpagoDhallJson
 
 derive instance Newtype SpagoDhallJson _
 
-spagoDhallJsonCodec :: JsonCodec SpagoDhallJson
-spagoDhallJsonCodec = Profunctor.dimap toRep fromRep $ CA.Record.object "SpagoDhallJson"
-  { license: CA.Record.optional CA.Common.nonEmptyString
-  , dependencies: CA.Record.optional (CA.array (Profunctor.wrapIso RawPackageName CA.string))
-  , packages: CA.Record.optional packageVersionMapCodec
+spagoDhallJsonCodec :: CJ.Codec SpagoDhallJson
+spagoDhallJsonCodec = Profunctor.dimap toRep fromRep $ CJ.named "SpagoDhallJson" $ CJ.Record.object
+  { license: CJ.Record.optional CJ.Common.nonEmptyString
+  , dependencies: CJ.Record.optional (CJ.array (Profunctor.wrapIso RawPackageName CJ.string))
+  , packages: CJ.Record.optional packageVersionMapCodec
   }
   where
-  packageVersionMapCodec :: JsonCodec (Map RawPackageName { version :: RawVersion })
-  packageVersionMapCodec = rawPackageNameMapCodec $ CA.Record.object "VersionObject" { version: rawVersionCodec }
+  packageVersionMapCodec :: CJ.Codec (Map RawPackageName { version :: RawVersion })
+  packageVersionMapCodec = rawPackageNameMapCodec $ CJ.named "VersionObject" $ CJ.Record.object { version: rawVersionCodec }
 
   toRep (SpagoDhallJson fields) = fields
     { dependencies = if Array.null fields.dependencies then Nothing else Just fields.dependencies
@@ -346,8 +348,8 @@ fetchSpagoDhallJson address ref = Run.Except.runExceptAt _spagoDhallError do
   dhallJson <- Run.liftAff $ dhallToJson { dhall: spagoDhall, cwd: Just tmp }
   Run.Except.rethrowAt _spagoDhallError $ case dhallJson of
     Left err -> Left $ Octokit.DecodeError err
-    Right json -> case CA.decode spagoDhallJsonCodec json of
-      Left err -> Left $ Octokit.DecodeError $ CA.printJsonDecodeError err
+    Right json -> case CJ.decode spagoDhallJsonCodec json of
+      Left err -> Left $ Octokit.DecodeError $ CJ.DecodeError.print err
       Right value -> pure value
   where
   _spagoDhallError :: Proxy "spagoDhallError"
@@ -355,7 +357,7 @@ fetchSpagoDhallJson address ref = Run.Except.runExceptAt _spagoDhallError do
 
   -- | Convert a string representing a Dhall expression into JSON using the
   -- | `dhall-to-json` CLI.
-  dhallToJson :: { dhall :: String, cwd :: Maybe FilePath } -> Aff (Either String Json)
+  dhallToJson :: { dhall :: String, cwd :: Maybe FilePath } -> Aff (Either String JSON)
   dhallToJson { dhall, cwd } = do
     let cmd = "dhall-to-json"
     let args = []
@@ -363,7 +365,7 @@ fetchSpagoDhallJson address ref = Run.Except.runExceptAt _spagoDhallError do
     for_ process.stdin \{ writeUtf8End } -> writeUtf8End dhall
     result <- process.getResult
     pure case result.exit of
-      Normally 0 -> lmap CA.printJsonDecodeError $ parseJson CA.json result.stdout
+      Normally 0 -> lmap CJ.DecodeError.print $ parseJson CJ.json result.stdout
       _ -> Left result.stderr
 
 newtype Bowerfile = Bowerfile
@@ -375,24 +377,25 @@ newtype Bowerfile = Bowerfile
 derive instance Newtype Bowerfile _
 derive newtype instance Eq Bowerfile
 
-bowerfileCodec :: JsonCodec Bowerfile
-bowerfileCodec = Profunctor.dimap toRep fromRep $ CA.Record.object "Bowerfile"
-  { description: CA.Record.optional CA.string
-  , dependencies: CA.Record.optional dependenciesCodec
-  , license: CA.Record.optional licenseCodec
+bowerfileCodec :: CJ.Codec Bowerfile
+bowerfileCodec = Profunctor.dimap toRep fromRep $ CJ.named "Bowerfile" $ CJ.Record.object
+  { description: CJ.Record.optional CJ.string
+  , dependencies: CJ.Record.optional dependenciesCodec
+  , license: CJ.Record.optional licenseCodec
   }
   where
   toRep (Bowerfile fields) = fields { dependencies = Just fields.dependencies, license = Just fields.license }
   fromRep fields = Bowerfile $ fields { dependencies = fromMaybe Map.empty fields.dependencies, license = fromMaybe [] fields.license }
 
-  dependenciesCodec :: JsonCodec (Map RawPackageName RawVersionRange)
+  dependenciesCodec :: CJ.Codec (Map RawPackageName RawVersionRange)
   dependenciesCodec = rawPackageNameMapCodec rawVersionRangeCodec
 
-  licenseCodec :: JsonCodec (Array String)
-  licenseCodec = CA.codec' decode encode
+  licenseCodec :: CJ.Codec (Array String)
+  licenseCodec = Codec.codec' decode encode
     where
-    decode json = CA.decode (CA.array CA.string) json <|> map Array.singleton (CA.decode CA.string json)
-    encode = CA.encode (CA.array CA.string)
+    encode = CJ.encode (CJ.array CJ.string)
+    decode json = Codec.decode (CJ.array CJ.string) json
+      <|> map Array.singleton (Codec.decode CJ.string json)
 
 -- | Attempt to construct a Bowerfile from a bower.json file located in a
 -- | remote repository at the given ref.
@@ -491,7 +494,7 @@ instance MemoryEncodable LegacyCache where
 instance FsEncodable LegacyCache where
   encodeFs = case _ of
     LegacySet (RawVersion ref) next ->
-      Exists.mkExists $ AsJson ("LegacySet__" <> ref) (CA.Common.either Octokit.githubErrorCodec legacyPackageSetCodec) next
+      Exists.mkExists $ AsJson ("LegacySet__" <> ref) (CJ.Common.either Octokit.githubErrorCodec legacyPackageSetCodec) next
     LegacyUnion hash next ->
       Exists.mkExists $ AsJson ("LegacyUnion" <> Sha256.print hash) legacyPackageSetUnionCodec next
 

--- a/app/src/App/Legacy/Types.purs
+++ b/app/src/App/Legacy/Types.purs
@@ -2,8 +2,8 @@ module Registry.App.Legacy.Types where
 
 import Registry.App.Prelude
 
-import Data.Codec.Argonaut as CA
-import Data.Codec.Argonaut.Record as CA.Record
+import Data.Codec.JSON as CJ
+import Data.Codec.JSON.Record as CJ.Record
 import Data.Profunctor as Profunctor
 import Registry.Internal.Codec as Internal.Codec
 import Registry.PackageName as PackageName
@@ -14,7 +14,7 @@ newtype LegacyPackageSet = LegacyPackageSet (Map PackageName LegacyPackageSetEnt
 derive instance Newtype LegacyPackageSet _
 derive newtype instance Eq LegacyPackageSet
 
-legacyPackageSetCodec :: JsonCodec LegacyPackageSet
+legacyPackageSetCodec :: CJ.Codec LegacyPackageSet
 legacyPackageSetCodec =
   Profunctor.wrapIso LegacyPackageSet
     $ Internal.Codec.packageMap legacyPackageSetEntryCodec
@@ -23,12 +23,13 @@ legacyPackageSetCodec =
 -- | versions they have in the package sets.
 type LegacyPackageSetUnion = Map PackageName (Map RawVersion (Map PackageName { min :: RawVersion, max :: RawVersion }))
 
-legacyPackageSetUnionCodec :: JsonCodec LegacyPackageSetUnion
-legacyPackageSetUnionCodec = Internal.Codec.packageMap $ rawVersionMapCodec $ Internal.Codec.packageMap $
-  CA.Record.object "LenientBounds"
-    { min: rawVersionCodec
-    , max: rawVersionCodec
-    }
+legacyPackageSetUnionCodec :: CJ.Codec LegacyPackageSetUnion
+legacyPackageSetUnionCodec = Internal.Codec.packageMap $ rawVersionMapCodec $ Internal.Codec.packageMap
+  $ CJ.named "LenientBounds"
+  $ CJ.Record.object
+      { min: rawVersionCodec
+      , max: rawVersionCodec
+      }
 
 -- | The format of a legacy packages.json package set entry for an individual
 -- | package.
@@ -38,11 +39,11 @@ type LegacyPackageSetEntry =
   , version :: RawVersion
   }
 
-legacyPackageSetEntryCodec :: JsonCodec LegacyPackageSetEntry
-legacyPackageSetEntryCodec = CA.Record.object "LegacyPackageSetEntry"
-  { dependencies: CA.array PackageName.codec
-  , repo: CA.string
-  , version: Profunctor.wrapIso RawVersion CA.string
+legacyPackageSetEntryCodec :: CJ.Codec LegacyPackageSetEntry
+legacyPackageSetEntryCodec = CJ.named "LegacyPackageSetEntry" $ CJ.Record.object
+  { dependencies: CJ.array PackageName.codec
+  , repo: CJ.string
+  , version: Profunctor.wrapIso RawVersion CJ.string
   }
 
 -- | An unprocessed package name, which may possibly be malformed.
@@ -52,11 +53,11 @@ derive instance Newtype RawPackageName _
 derive newtype instance Eq RawPackageName
 derive newtype instance Ord RawPackageName
 
-rawPackageNameCodec :: JsonCodec RawPackageName
-rawPackageNameCodec = Profunctor.wrapIso RawPackageName CA.string
+rawPackageNameCodec :: CJ.Codec RawPackageName
+rawPackageNameCodec = Profunctor.wrapIso RawPackageName CJ.string
 
-rawPackageNameMapCodec :: forall a. JsonCodec a -> JsonCodec (Map RawPackageName a)
-rawPackageNameMapCodec = Internal.Codec.strMap "RawPackageMap" (Just <<< RawPackageName) (un RawPackageName)
+rawPackageNameMapCodec :: forall a. CJ.Codec a -> CJ.Codec (Map RawPackageName a)
+rawPackageNameMapCodec = Internal.Codec.strMap "RawPackageMap" (Right <<< RawPackageName) (un RawPackageName)
 
 -- | An unprocessed version
 newtype RawVersion = RawVersion String
@@ -65,11 +66,11 @@ derive instance Newtype RawVersion _
 derive newtype instance Eq RawVersion
 derive newtype instance Ord RawVersion
 
-rawVersionCodec :: JsonCodec RawVersion
-rawVersionCodec = Profunctor.wrapIso RawVersion CA.string
+rawVersionCodec :: CJ.Codec RawVersion
+rawVersionCodec = Profunctor.wrapIso RawVersion CJ.string
 
-rawVersionMapCodec :: forall a. JsonCodec a -> JsonCodec (Map RawVersion a)
-rawVersionMapCodec = Internal.Codec.strMap "RawVersionMap" (Just <<< RawVersion) (un RawVersion)
+rawVersionMapCodec :: forall a. CJ.Codec a -> CJ.Codec (Map RawVersion a)
+rawVersionMapCodec = Internal.Codec.strMap "RawVersionMap" (Right <<< RawVersion) (un RawVersion)
 
 -- | An unprocessed version range
 newtype RawVersionRange = RawVersionRange String
@@ -78,5 +79,5 @@ derive instance Newtype RawVersionRange _
 derive newtype instance Eq RawVersionRange
 derive newtype instance Ord RawVersionRange
 
-rawVersionRangeCodec :: JsonCodec RawVersionRange
-rawVersionRangeCodec = Profunctor.wrapIso RawVersionRange CA.string
+rawVersionRangeCodec :: CJ.Codec RawVersionRange
+rawVersionRangeCodec = Profunctor.wrapIso RawVersionRange CJ.string

--- a/app/src/App/Prelude.purs
+++ b/app/src/App/Prelude.purs
@@ -39,20 +39,17 @@ module Registry.App.Prelude
 
 import Prelude
 
+import Codec.JSON.DecodeError as CJ.DecodeError
 import Control.Alt ((<|>)) as Extra
 import Control.Alternative (guard) as Extra
-import Control.Monad.Except (ExceptT(..)) as Extra
+import Control.Monad.Except (Except, ExceptT(..), except) as Extra
 import Control.Monad.Trans.Class (lift) as Extra
 import Control.Parallel.Class as Parallel
-import Data.Argonaut.Core (Json) as Extra
-import Data.Argonaut.Core as Argonaut
-import Data.Argonaut.Parser as Argonaut.Parser
 import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray) as Extra
 import Data.Bifunctor (bimap, lmap) as Extra
 import Data.Bitraversable (ltraverse) as Extra
-import Data.Codec.Argonaut (JsonCodec, JsonDecodeError) as Extra
-import Data.Codec.Argonaut as CA
+import Data.Codec.JSON as CJ
 import Data.DateTime (DateTime)
 import Data.DateTime as DateTime
 import Data.Either (Either(..), either, fromLeft, fromRight', hush, isRight, note) as Either
@@ -83,6 +80,8 @@ import Effect.Class (class MonadEffect, liftEffect) as Extra
 import Effect.Now as Now
 import Effect.Ref (Ref) as Extra
 import Foreign.Object (Object) as Extra
+import JSON (JSON) as Extra
+import JSON as JSON
 import Node.Buffer (Buffer) as Extra
 import Node.Encoding (Encoding(..)) as Extra
 import Node.FS.Aff as FS.Aff
@@ -114,35 +113,35 @@ pacchettibottiKeyType :: String
 pacchettibottiKeyType = "ssh-ed25519"
 
 -- | Print a type as a formatted JSON string
-printJson :: forall a. Extra.JsonCodec a -> a -> String
-printJson codec = Argonaut.stringifyWithIndent 2 <<< CA.encode codec
+printJson :: forall a. CJ.Codec a -> a -> String
+printJson codec = JSON.printIndented <<< CJ.encode codec
 
 -- | Print a type as a JSON string without formatting
-stringifyJson :: forall a. Extra.JsonCodec a -> a -> String
-stringifyJson codec = Argonaut.stringify <<< CA.encode codec
+stringifyJson :: forall a. CJ.Codec a -> a -> String
+stringifyJson codec = JSON.print <<< CJ.encode codec
 
 -- | Parse a type from a string of JSON data.
-parseJson :: forall a. Extra.JsonCodec a -> String -> Either.Either Extra.JsonDecodeError a
-parseJson codec = CA.decode codec <=< Extra.lmap (\err -> CA.TypeMismatch ("JSON: " <> err)) <<< Argonaut.Parser.jsonParser
+parseJson :: forall a. CJ.Codec a -> String -> Either.Either CJ.DecodeError a
+parseJson codec = CJ.decode codec <=< Extra.lmap (CJ.DecodeError.basic <<< append "JSON: ") <<< JSON.parse
 
 -- | Encode data as formatted JSON and write it to the provided filepath
-writeJsonFile :: forall a. Extra.JsonCodec a -> Extra.FilePath -> a -> Extra.Aff Unit
+writeJsonFile :: forall a. CJ.Codec a -> Extra.FilePath -> a -> Extra.Aff Unit
 writeJsonFile codec path = FS.Aff.writeTextFile Extra.UTF8 path <<< (_ <> "\n") <<< printJson codec
 
 -- | Decode data from a JSON file at the provided filepath
-readJsonFile :: forall a. Extra.JsonCodec a -> Extra.FilePath -> Extra.Aff (Either.Either String a)
+readJsonFile :: forall a. CJ.Codec a -> Extra.FilePath -> Extra.Aff (Either.Either String a)
 readJsonFile codec path = do
   result <- Aff.attempt $ FS.Aff.readTextFile Extra.UTF8 path
-  pure (Extra.lmap Aff.message result >>= parseJson codec >>> Extra.lmap CA.printJsonDecodeError)
+  pure (Extra.lmap Aff.message result >>= parseJson codec >>> Extra.lmap CJ.DecodeError.print)
 
 -- | Parse a type from a string of YAML data after converting it to JSON.
-parseYaml :: forall a. Extra.JsonCodec a -> String -> Either.Either String a
+parseYaml :: forall a. CJ.Codec a -> String -> Either.Either String a
 parseYaml codec yaml = do
   json <- Extra.lmap (append "YAML: ") (Yaml.yamlParser yaml)
-  Extra.lmap CA.printJsonDecodeError (CA.decode codec json)
+  Extra.lmap CJ.DecodeError.print (CJ.decode codec json)
 
 -- | Decode data from a YAML file at the provided filepath
-readYamlFile :: forall a. Extra.JsonCodec a -> Extra.FilePath -> Extra.Aff (Either.Either String a)
+readYamlFile :: forall a. CJ.Codec a -> Extra.FilePath -> Extra.Aff (Either.Either String a)
 readYamlFile codec path = do
   result <- Aff.attempt $ FS.Aff.readTextFile Extra.UTF8 path
   pure (Extra.lmap Aff.message result >>= parseYaml codec)

--- a/app/src/App/Server.purs
+++ b/app/src/App/Server.purs
@@ -3,7 +3,7 @@ module Registry.App.Server where
 import Registry.App.Prelude hiding ((/))
 
 import Control.Monad.Cont (ContT)
-import Data.Codec.Argonaut as CA
+import Data.Codec.JSON as CJ
 import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Newtype (unwrap)
 import Data.String as String
@@ -91,7 +91,7 @@ router env { route, method, body } = HTTPurple.usingCont case route, method of
         HTTPurple.badRequest "Expected transfer operation."
 
   Jobs, Get -> do
-    jsonOk (CA.array V1.jobCodec) []
+    jsonOk (CJ.array V1.jobCodec) []
 
   Job jobId { level: maybeLogLevel, since }, Get -> do
     let logLevel = fromMaybe Error maybeLogLevel
@@ -291,13 +291,13 @@ main = do
       , " └───────────────────────────────────────────┘"
       ]
 
-jsonDecoder :: forall a. JsonCodec a -> JsonDecoder JsonDecodeError a
+jsonDecoder :: forall a. CJ.Codec a -> JsonDecoder CJ.DecodeError a
 jsonDecoder codec = JsonDecoder (parseJson codec)
 
-jsonEncoder :: forall a. JsonCodec a -> JsonEncoder a
+jsonEncoder :: forall a. CJ.Codec a -> JsonEncoder a
 jsonEncoder codec = JsonEncoder (stringifyJson codec)
 
-jsonOk :: forall m a. MonadAff m => JsonCodec a -> a -> m Response
+jsonOk :: forall m a. MonadAff m => CJ.Codec a -> a -> m Response
 jsonOk codec datum = HTTPurple.ok' HTTPurple.jsonHeaders $ HTTPurple.toJson (jsonEncoder codec) datum
 
 runEffects :: forall a. ServerEnv -> Run ServerEffects a -> Aff (Either Aff.Error a)

--- a/app/test/App/CLI/Purs.purs
+++ b/app/test/App/CLI/Purs.purs
@@ -2,10 +2,11 @@ module Test.Registry.App.CLI.Purs (spec) where
 
 import Registry.App.Prelude
 
-import Data.Argonaut.Parser as Argonaut.Parser
-import Data.Codec.Argonaut as CA
+import Codec.JSON.DecodeError as CJ.DecodeError
+import Data.Codec.JSON as CJ
 import Data.Foldable (traverse_)
 import Data.Map as Map
+import JSON as JSON
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
 import Registry.App.CLI.Purs (CompilerFailure(..))
@@ -69,10 +70,10 @@ spec = do
           CompilationError errs -> Purs.printCompilerErrors errs
           UnknownError str -> str
           MissingCompiler -> "MissingCompiler"
-        Right str -> case Argonaut.Parser.jsonParser str of
+        Right str -> case JSON.parse str of
           Left parseErr -> Assert.fail $ "Failed to parse output as JSON: " <> parseErr
-          Right json -> case CA.decode PursGraph.pursGraphCodec json of
-            Left decodeErr -> Assert.fail $ "Failed to decode JSON: " <> CA.printJsonDecodeError decodeErr
+          Right json -> case CJ.decode PursGraph.pursGraphCodec json of
+            Left decodeErr -> Assert.fail $ "Failed to decode JSON: " <> CJ.DecodeError.print decodeErr
             Right graph -> do
               let
                 expected = Map.fromFoldable

--- a/app/test/App/GitHubIssue.purs
+++ b/app/test/App/GitHubIssue.purs
@@ -91,7 +91,7 @@ decodeEventsToOps = do
       rawOperation = packageNameTooLongString
 
       parseJson = bimap CJ.DecodeError.print Publish <<< CJ.decode Operation.publishCodec <=< JSON.parse
-    
+
     parseJson (GitHubIssue.firstObject rawOperation) `Assert.shouldEqual` (Left "$.name: Could not decode Publish:\n  Could not decode PackageName:\n    Package name cannot be longer than 150 characters")
 
 preludeAdditionString :: String

--- a/app/test/App/GitHubIssue.purs
+++ b/app/test/App/GitHubIssue.purs
@@ -86,6 +86,14 @@ decodeEventsToOps = do
 
     parseJson (GitHubIssue.firstObject rawOperation) `Assert.shouldEqual` (Right operation)
 
+  Spec.it "returns a sensible error message when the JSON fails to parse" do
+    let
+      rawOperation = packageNameTooLongString
+
+      parseJson = bimap CJ.DecodeError.print Publish <<< CJ.decode Operation.publishCodec <=< JSON.parse
+    
+    parseJson (GitHubIssue.firstObject rawOperation) `Assert.shouldEqual` (Left "$.name: Could not decode Publish:\n  Could not decode PackageName:\n    Package name cannot be longer than 150 characters")
+
 preludeAdditionString :: String
 preludeAdditionString =
   """
@@ -104,4 +112,20 @@ preludeAdditionString =
   ```
 
   Thanks!
+  """
+
+packageNameTooLongString :: String
+packageNameTooLongString =
+  """
+  ```
+  {
+    "name": "packagenamewayyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyytoolong",
+    "ref": "v5.0.0",
+    "location": {
+      "githubOwner": "purescript",
+      "githubRepo": "purescript-prelude"
+    },
+    "compiler": "0.15.0"
+  }
+  ```
   """

--- a/app/test/App/GitHubIssue.purs
+++ b/app/test/App/GitHubIssue.purs
@@ -4,9 +4,10 @@ module Test.Registry.App.GitHubIssue
 
 import Registry.App.Prelude
 
-import Data.Argonaut.Parser as Argonaut.Parser
-import Data.Codec.Argonaut as CA
+import Codec.JSON.DecodeError as CJ.DecodeError
+import Data.Codec.JSON as CJ
 import Data.Map as Map
+import JSON as JSON
 import Node.Path as Path
 import Registry.App.GitHubIssue as GitHubIssue
 import Registry.Foreign.Octokit (IssueNumber(..))
@@ -81,7 +82,7 @@ decodeEventsToOps = do
 
       rawOperation = preludeAdditionString
 
-      parseJson = bimap CA.printJsonDecodeError Publish <<< CA.decode Operation.publishCodec <=< Argonaut.Parser.jsonParser
+      parseJson = bimap CJ.DecodeError.print Publish <<< CJ.decode Operation.publishCodec <=< JSON.parse
 
     parseJson (GitHubIssue.firstObject rawOperation) `Assert.shouldEqual` (Right operation)
 

--- a/app/test/App/Legacy/Manifest.purs
+++ b/app/test/App/Legacy/Manifest.purs
@@ -2,8 +2,8 @@ module Test.Registry.App.Legacy.Manifest (spec) where
 
 import Registry.App.Prelude
 
+import Codec.JSON.DecodeError as CJ.DecodeError
 import Data.Array as Array
-import Data.Codec.Argonaut as CA
 import Registry.App.Legacy.Manifest as Legacy.Manifest
 import Registry.Test.Assert as Assert
 import Test.Spec (Spec)
@@ -24,7 +24,7 @@ bowerfileSpec = do
             [ "Failed to parse:\n"
             , input
             , "due to an error:\n"
-            , CA.printJsonDecodeError err
+            , CJ.DecodeError.print err
             ]
           Right _ -> pure unit
 

--- a/foreign/spago.yaml
+++ b/foreign/spago.yaml
@@ -6,15 +6,16 @@ package:
   dependencies:
     - aff
     - aff-promise
-    - argonaut-core
     - arrays
     - b64
     - bifunctors
-    - codec-argonaut
+    - codec
+    - codec-json
     - convertable-options
     - datetime
     - effect
     - either
+    - exceptions
     - fetch
     - filterable
     - foldable-traversable
@@ -23,6 +24,8 @@ package:
     - http-methods
     - integers
     - js-date
+    - js-fetch
+    - json
     - maybe
     - newtype
     - node-buffer
@@ -33,12 +36,15 @@ package:
     - profunctor
     - registry-lib
     - strings
+    - transformers
     - tuples
     - unsafe-coerce
     - variant
   test:
     main: Test.Foreign
     dependencies:
+      - node-child-process
+      - node-execa
       - node-fs
       - node-process
       - spec

--- a/foreign/src/Foreign/Yaml.purs
+++ b/foreign/src/Foreign/Yaml.purs
@@ -2,13 +2,13 @@ module Registry.Foreign.Yaml
   ( yamlParser
   ) where
 
-import Data.Argonaut.Core as Core
 import Data.Either (Either(..))
 import Data.Function.Uncurried (Fn3, runFn3)
+import JSON (JSON)
 
 -- | Parse a JSON string, constructing the `Toml` value described by the string.
 -- | To convert a string into a `Toml` string, see `fromString`.
-yamlParser :: String -> Either String Core.Json
+yamlParser :: String -> Either String JSON
 yamlParser j = runFn3 yamlDocParserImpl Left Right j
 
-foreign import yamlDocParserImpl :: forall a. Fn3 (String -> a) (Core.Json -> a) String a
+foreign import yamlDocParserImpl :: forall a. Fn3 (String -> a) (JSON -> a) String a

--- a/foreign/test/Foreign/JsonRepair.purs
+++ b/foreign/test/Foreign/JsonRepair.purs
@@ -2,15 +2,14 @@ module Test.Registry.Foreign.JsonRepair (spec) where
 
 import Prelude
 
-import Data.Argonaut.Core (Json)
-import Data.Argonaut.Core as Argonaut
-import Data.Argonaut.Parser as Argonaut.Parser
+import Codec.JSON.DecodeError as CJ.DecodeError
 import Data.Bifunctor (lmap)
-import Data.Codec.Argonaut (JsonCodec)
-import Data.Codec.Argonaut as CA
-import Data.Codec.Argonaut.Record as CA.Record
+import Data.Codec.JSON as CJ
+import Data.Codec.JSON.Record as CJ.Record
 import Data.Either (Either)
 import Data.Either as Either
+import JSON (JSON)
+import JSON as JSON
 import Registry.Foreign.JsonRepair as JsonRepair
 import Registry.Test.Assert as Assert
 import Test.Spec as Spec
@@ -18,40 +17,40 @@ import Test.Spec as Spec
 spec :: Spec.Spec Unit
 spec = do
   Spec.describe "Valid JSON" do
-    let arrayCodec = CA.array CA.int
-    parseTest arrayCodec "[1,2,3]" $ CA.encode arrayCodec [ 1, 2, 3 ]
+    let arrayCodec = CJ.array CJ.int
+    parseTest arrayCodec "[1,2,3]" $ CJ.encode arrayCodec [ 1, 2, 3 ]
 
-    let objectCodec = CA.Record.object "Test" { name: CA.string }
-    parseTest objectCodec """{ "name": "test" }""" $ CA.encode objectCodec { name: "test" }
+    let objectCodec = CJ.named "Test" $ CJ.Record.object { name: CJ.string }
+    parseTest objectCodec """{ "name": "test" }""" $ CJ.encode objectCodec { name: "test" }
 
     let
-      complexCodec = CA.Record.object "Complex" { complex: CA.Record.object "Nested" { nested: CA.string, bool: CA.boolean } }
+      complexCodec = CJ.named "Complex" $ CJ.Record.object { complex: CJ.Record.object { nested: CJ.string, bool: CJ.boolean } }
       complexJson = { complex: { nested: "json", bool: true } }
 
-    parseTest complexCodec (Argonaut.stringify $ CA.encode complexCodec complexJson) (CA.encode complexCodec complexJson)
+    parseTest complexCodec (JSON.print $ CJ.encode complexCodec complexJson) (CJ.encode complexCodec complexJson)
 
   Spec.describe "Fixable JSON" do
-    let testObjectCodec = CA.Record.object "Test" { trailing: CA.string }
-    parseTest testObjectCodec """{ "trailing": "comma", }""" $ CA.encode testObjectCodec { trailing: "comma" }
+    let testObjectCodec = CJ.named "Test" $ CJ.Record.object { trailing: CJ.string }
+    parseTest testObjectCodec """{ "trailing": "comma", }""" $ CJ.encode testObjectCodec { trailing: "comma" }
 
-    let testArrayCodec = CA.array CA.string
-    parseTest testArrayCodec """[ "trailing comma", ]""" $ CA.encode testArrayCodec [ "trailing comma" ]
+    let testArrayCodec = CJ.array CJ.string
+    parseTest testArrayCodec """[ "trailing comma", ]""" $ CJ.encode testArrayCodec [ "trailing comma" ]
 
   Spec.describe "Unfixable JSON" do
     let
-      failParse :: forall a. JsonCodec a -> String -> Spec.Spec Unit
+      failParse :: forall a. CJ.Codec a -> String -> Spec.Spec Unit
       failParse codec str = Spec.it str do
         parseString codec str `Assert.shouldSatisfy` Either.isLeft
 
-    failParse (CA.Record.object "Test" { name: CA.string }) "name: test"
-    failParse (CA.Record.object "Test" { key: CA.string }) """{ "horrendously invalid json" }"""
+    failParse (CJ.named "Test" $ CJ.Record.object { name: CJ.string }) "name: test"
+    failParse (CJ.named "Test" $ CJ.Record.object { key: CJ.string }) """{ "horrendously invalid json" }"""
 
-parseString :: forall a. JsonCodec a -> String -> Either String String
+parseString :: forall a. CJ.Codec a -> String -> Either String String
 parseString codec input = do
-  parsed <- Argonaut.Parser.jsonParser (JsonRepair.tryRepair input)
-  decoded <- lmap CA.printJsonDecodeError $ CA.decode codec parsed
-  pure $ Argonaut.stringify $ CA.encode codec decoded
+  parsed <- JSON.parse (JsonRepair.tryRepair input)
+  decoded <- lmap CJ.DecodeError.print $ CJ.decode codec parsed
+  pure $ JSON.print $ CJ.encode codec decoded
 
-parseTest :: forall a. JsonCodec a -> String -> Json -> Spec.Spec Unit
+parseTest :: forall a. CJ.Codec a -> String -> JSON -> Spec.Spec Unit
 parseTest codec str json = Spec.it str do
-  parseString codec str `Assert.shouldContain` Argonaut.stringify json
+  parseString codec str `Assert.shouldContain` JSON.print json

--- a/lib/spago.yaml
+++ b/lib/spago.yaml
@@ -3,12 +3,14 @@ package:
   publish:
     license: BSD-3-Clause
     version: 0.0.1
+  build:
+    pedanticPackages: true
   dependencies:
     - aff
-    - argonaut-core
     - arrays
     - bifunctors
-    - codec-argonaut
+    - codec
+    - codec-json
     - control
     - datetime
     - effect
@@ -21,6 +23,7 @@ package:
     - functors
     - graphs
     - integers
+    - json
     - language-cst-parser
     - lists
     - maybe
@@ -37,14 +40,15 @@ package:
     - profunctor-lenses
     - routing-duplex
     - safe-coerce
+    - st
     - strings
     - transformers
     - tuples
   test:
     main: Test.Registry
     dependencies:
-      - argonaut-core
       - exceptions
+      - json
       - node-child-process
       - node-execa
       - spec

--- a/lib/src/Internal/Codec.purs
+++ b/lib/src/Internal/Codec.purs
@@ -10,26 +10,28 @@ module Registry.Internal.Codec
 
 import Prelude
 
-import Data.Argonaut.Core (Json)
+import Codec.JSON.DecodeError as CJ.DecodeError
+import Control.Monad.Except (Except, except, withExcept)
 import Data.Bifunctor (lmap)
-import Data.Codec.Argonaut (JsonCodec)
-import Data.Codec.Argonaut as CA
+import Data.Codec as Codec
+import Data.Codec.JSON as CJ
 import Data.DateTime (Date, DateTime)
 import Data.DateTime as DateTime
 import Data.Either (Either(..))
-import Data.Either as Either
 import Data.FoldableWithIndex (forWithIndex_)
 import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Formatter.DateTime as Formatter.Datetime
 import Data.Int as Int
 import Data.Map (Map)
 import Data.Map as Map
-import Data.Maybe (Maybe)
 import Data.String as String
 import Data.Traversable (for)
 import Data.Tuple (Tuple(..))
 import Foreign.Object as Object
 import Foreign.Object.ST as Object.ST
+import JSON (JSON)
+import JSON.Object as JSON.Object
+import JSON.Path as JSON.Path
 import Parsing (Parser)
 import Parsing as Parsing
 import Registry.Internal.Format as Internal.Format
@@ -48,55 +50,55 @@ import Registry.Version as Version
 -- | be a valid simple ISO8601 string (ie. it may be an outdated metadata file
 -- | using the RFC3339String format). The string will be modified if you read
 -- | and then write.
-iso8601DateTime :: JsonCodec DateTime
-iso8601DateTime = CA.codec' decode encode
+iso8601DateTime :: CJ.Codec DateTime
+iso8601DateTime = Codec.codec' decode encode
   where
-  encode :: DateTime -> Json
+  encode :: DateTime -> JSON
   encode =
     Formatter.DateTime.format Internal.Format.iso8601DateTime
-      >>> CA.encode CA.string
+      >>> CJ.encode CJ.string
 
-  decode :: Json -> Either CA.JsonDecodeError DateTime
+  decode :: JSON -> Except CJ.DecodeError DateTime
   decode json = do
-    string <- CA.decode CA.string json
-    case Internal.Format.rfc3339ToISO8601 string of
-      Left err -> Left $ CA.TypeMismatch $ "Unable to parse input as ISO8601: " <> err
+    string <- Codec.decode CJ.string json
+    except case Internal.Format.rfc3339ToISO8601 string of
+      Left err -> Left $ CJ.DecodeError.basic $ "Unable to parse input as ISO8601: " <> err
       Right fixed ->
-        lmap (CA.TypeMismatch <<< append "ISO8601: ") (Formatter.Datetime.unformat Internal.Format.iso8601DateTime fixed)
+        lmap (CJ.DecodeError.basic <<< append "ISO8601: ") (Formatter.Datetime.unformat Internal.Format.iso8601DateTime fixed)
 
 -- | INTERNAL
 -- |
 -- | A codec for date times that encode as JSON strings in the ISO8601 date
 -- | format, ie. YYYY-MM-DD
-iso8601Date :: JsonCodec Date
-iso8601Date = CA.codec' decode encode
+iso8601Date :: CJ.Codec Date
+iso8601Date = Codec.codec' decode encode
   where
-  encode :: Date -> Json
+  encode :: Date -> JSON
   encode =
     flip DateTime.DateTime bottom
       >>> Formatter.DateTime.format Internal.Format.iso8601Date
-      >>> CA.encode CA.string
+      >>> CJ.encode CJ.string
 
-  decode :: Json -> Either CA.JsonDecodeError Date
+  decode :: JSON -> Except CJ.DecodeError Date
   decode json = do
-    string <- CA.decode CA.string json
-    dateTime <- lmap (CA.TypeMismatch <<< append "YYYY-MM-DD: ") (Formatter.DateTime.unformat Internal.Format.iso8601Date string)
+    string <- Codec.decode CJ.string json
+    dateTime <- except $ lmap (CJ.DecodeError.basic <<< append "YYYY-MM-DD: ") (Formatter.DateTime.unformat Internal.Format.iso8601Date string)
     pure $ DateTime.date dateTime
 
 -- | INTERNAL
 -- |
 -- | A codec for `String` values with an explicit limited length.
-limitedString :: Int -> JsonCodec String
-limitedString limit = CA.codec' decode encode
+limitedString :: Int -> CJ.Codec String
+limitedString limit = Codec.codec' decode encode
   where
-  encode :: String -> Json
-  encode = CA.encode CA.string
+  encode :: String -> JSON
+  encode = CJ.encode CJ.string
 
-  decode :: Json -> Either CA.JsonDecodeError String
-  decode json = do
-    string <- CA.decode CA.string json
+  decode :: JSON -> Except CJ.DecodeError String
+  decode json = except do
+    string <- CJ.decode CJ.string json
     if String.length string > limit then
-      Left $ CA.TypeMismatch $ "LimitedString: Exceeds limit of " <> Int.toStringAs Int.decimal limit <> " characters."
+      Left $ CJ.DecodeError.basic $ "LimitedString: Exceeds limit of " <> Int.toStringAs Int.decimal limit <> " characters."
     else
       Right string
 
@@ -104,51 +106,55 @@ limitedString limit = CA.codec' decode encode
 -- |
 -- | A codec for `String` values that can be parsed into a `String`, failing
 -- | with the parse error message if invalid.
-parsedString :: String -> Parser String String -> JsonCodec String
-parsedString label parser = CA.codec' decode encode
+parsedString :: Parser String String -> CJ.Codec String
+parsedString parser = Codec.codec' decode encode
   where
-  encode :: String -> Json
-  encode = CA.encode CA.string
+  encode :: String -> JSON
+  encode = CJ.encode CJ.string
 
-  decode :: Json -> Either CA.JsonDecodeError String
-  decode json = do
-    string <- CA.decode CA.string json
+  decode :: JSON -> Except CJ.DecodeError String
+  decode json = except do
+    string <- CJ.decode CJ.string json
     case Parsing.runParser string parser of
-      Left error -> Left $ CA.TypeMismatch $ label <> ": " <> Parsing.parseErrorMessage error
+      Left error -> Left $ CJ.DecodeError.basic $ Parsing.parseErrorMessage error
       Right value -> pure value
 
 -- | INTERNAL
 -- |
 -- | A codec for `Map` structures that have `PackageName`s as keys. Encodes as
 -- | a JSON object, ie. `{ "aff": <value>, "argonaut": <value> }`
-packageMap :: forall a. JsonCodec a -> JsonCodec (Map PackageName a)
-packageMap = strMap "PackageName" (Either.hush <<< PackageName.parse) PackageName.print
+packageMap :: forall a. CJ.Codec a -> CJ.Codec (Map PackageName a)
+packageMap = strMap "PackageName" PackageName.parse PackageName.print
 
 -- | INTERNAL
 -- |
 -- | A codec for `Map` structures that have `Version`s as keys. Encodes as a
 -- | JSON object, ie. `{ "1.0.0": <value>, "2.0.0": <value> }`
-versionMap :: forall a. JsonCodec a -> JsonCodec (Map Version a)
-versionMap = strMap "Version" (Either.hush <<< Version.parse) Version.print
+versionMap :: forall a. CJ.Codec a -> CJ.Codec (Map Version a)
+versionMap = strMap "Version" Version.parse Version.print
 
 -- | INTERNAL
 -- |
 -- | A codec for `Map` structures that have keys that can be encoded as strings.
 -- | Represented as an object in JSON.
-strMap :: forall k a. Ord k => String -> (String -> Maybe k) -> (k -> String) -> JsonCodec a -> JsonCodec (Map k a)
-strMap type_ parse print valueCodec = CA.codec' decode encode
+strMap :: forall k a. Ord k => String -> (String -> Either String k) -> (k -> String) -> CJ.Codec a -> CJ.Codec (Map k a)
+strMap typeName parse print valueCodec = Codec.codec' decode encode
   where
-  encode :: Map k a -> Json
-  encode m = CA.encode CA.jobject $ Object.runST do
+  encode :: Map k a -> JSON
+  encode m = CJ.encode CJ.jobject $ JSON.Object.fromFoldableWithIndex $ Object.runST do
     obj <- Object.ST.new
-    forWithIndex_ m \k v -> Object.ST.poke (print k) (CA.encode valueCodec v) obj
+    forWithIndex_ m \k v -> Object.ST.poke (print k) (CJ.encode valueCodec v) obj
     pure obj
 
-  decode :: Json -> Either CA.JsonDecodeError (Map k a)
+  decode :: JSON -> Except CJ.DecodeError (Map k a)
   decode json = do
-    array :: Array _ <- Object.toUnfoldable <$> CA.decode CA.jobject json
+    array :: Array _ <- JSON.Object.toUnfoldable <$> Codec.decode CJ.jobject json
     parsed <- for array \(Tuple k v) -> do
-      key <- Either.note (CA.AtKey k (CA.TypeMismatch type_)) (parse k)
-      val <- lmap (CA.AtKey k) (CA.decode valueCodec v)
+      key <- except $ lmap
+        (CJ.DecodeError.error (JSON.Path.AtKey k JSON.Path.Tip) <<< append (typeName <> ": "))
+        (parse k)
+      val <- withExcept
+        (CJ.DecodeError.withPath (\p -> JSON.Path.extend p (JSON.Path.AtKey k JSON.Path.Tip)))
+        (Codec.decode valueCodec v)
       pure $ Tuple key val
     pure $ Map.fromFoldable parsed

--- a/lib/src/Manifest.purs
+++ b/lib/src/Manifest.purs
@@ -20,9 +20,8 @@ import Prelude
 
 import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray)
-import Data.Codec.Argonaut (JsonCodec)
-import Data.Codec.Argonaut as CA
-import Data.Codec.Argonaut.Common as CA.Common
+import Data.Codec.JSON as CJ
+import Data.Codec.JSON.Common as CJ.Common
 import Data.Map (Map)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
@@ -72,15 +71,15 @@ instance Ord Manifest where
 -- | A codec for encoding and decoding a `Manifest` as JSON. Represented as a
 -- | JSON object. The implementation uses explicitly ordered keys instead of
 -- | record sugar.
-codec :: JsonCodec Manifest
-codec = Profunctor.wrapIso Manifest $ CA.object "Manifest"
-  $ CA.recordProp (Proxy :: _ "name") PackageName.codec
-  $ CA.recordProp (Proxy :: _ "version") Version.codec
-  $ CA.recordProp (Proxy :: _ "license") License.codec
-  $ CA.recordPropOptional (Proxy :: _ "description") (Internal.Codec.limitedString 300)
-  $ CA.recordProp (Proxy :: _ "location") Location.codec
-  $ CA.recordPropOptional (Proxy :: _ "owners") (CA.Common.nonEmptyArray Owner.codec)
-  $ CA.recordPropOptional (Proxy :: _ "includeFiles") (CA.Common.nonEmptyArray CA.Common.nonEmptyString)
-  $ CA.recordPropOptional (Proxy :: _ "excludeFiles") (CA.Common.nonEmptyArray CA.Common.nonEmptyString)
-  $ CA.recordProp (Proxy :: _ "dependencies") (Internal.Codec.packageMap Range.codec)
-  $ CA.record
+codec :: CJ.Codec Manifest
+codec = Profunctor.wrapIso Manifest $ CJ.named "Manifest" $ CJ.object
+  $ CJ.recordProp (Proxy :: _ "name") PackageName.codec
+  $ CJ.recordProp (Proxy :: _ "version") Version.codec
+  $ CJ.recordProp (Proxy :: _ "license") License.codec
+  $ CJ.recordPropOptional (Proxy :: _ "description") (Internal.Codec.limitedString 300)
+  $ CJ.recordProp (Proxy :: _ "location") Location.codec
+  $ CJ.recordPropOptional (Proxy :: _ "owners") (CJ.Common.nonEmptyArray Owner.codec)
+  $ CJ.recordPropOptional (Proxy :: _ "includeFiles") (CJ.Common.nonEmptyArray CJ.Common.nonEmptyString)
+  $ CJ.recordPropOptional (Proxy :: _ "excludeFiles") (CJ.Common.nonEmptyArray CJ.Common.nonEmptyString)
+  $ CJ.recordProp (Proxy :: _ "dependencies") (Internal.Codec.packageMap Range.codec)
+  $ CJ.record

--- a/lib/src/Metadata.purs
+++ b/lib/src/Metadata.purs
@@ -21,10 +21,9 @@ module Registry.Metadata
 import Prelude
 
 import Data.Array.NonEmpty (NonEmptyArray)
-import Data.Codec.Argonaut (JsonCodec)
-import Data.Codec.Argonaut as CA
-import Data.Codec.Argonaut.Common as CA.Common
-import Data.Codec.Argonaut.Record as CA.Record
+import Data.Codec.JSON as CJ
+import Data.Codec.JSON.Common as CJ.Common
+import Data.Codec.JSON.Record as CJ.Record
 import Data.DateTime (DateTime)
 import Data.Map (Map)
 import Data.Maybe (Maybe)
@@ -55,13 +54,13 @@ derive instance Eq Metadata
 
 -- | A codec for encoding and decoding a `Metadata` value as JSON. Represented
 -- | as a JSON object. Keys are explicitly ordered.
-codec :: JsonCodec Metadata
-codec = Profunctor.wrapIso Metadata $ CA.object "Metadata"
-  $ CA.recordProp (Proxy :: _ "location") Location.codec
-  $ CA.recordPropOptional (Proxy :: _ "owners") (CA.Common.nonEmptyArray Owner.codec)
-  $ CA.recordProp (Proxy :: _ "published") (Internal.Codec.versionMap publishedMetadataCodec)
-  $ CA.recordProp (Proxy :: _ "unpublished") (Internal.Codec.versionMap unpublishedMetadataCodec)
-  $ CA.record
+codec :: CJ.Codec Metadata
+codec = Profunctor.wrapIso Metadata $ CJ.named "Metadata" $ CJ.object
+  $ CJ.recordProp (Proxy :: _ "location") Location.codec
+  $ CJ.recordPropOptional (Proxy :: _ "owners") (CJ.Common.nonEmptyArray Owner.codec)
+  $ CJ.recordProp (Proxy :: _ "published") (Internal.Codec.versionMap publishedMetadataCodec)
+  $ CJ.recordProp (Proxy :: _ "unpublished") (Internal.Codec.versionMap unpublishedMetadataCodec)
+  $ CJ.record
 
 -- | Metadata about a published package version.
 -- |
@@ -74,12 +73,12 @@ type PublishedMetadata =
   , ref :: String
   }
 
-publishedMetadataCodec :: JsonCodec PublishedMetadata
-publishedMetadataCodec = CA.Record.object "PublishedMetadata"
-  { bytes: CA.number
+publishedMetadataCodec :: CJ.Codec PublishedMetadata
+publishedMetadataCodec = CJ.named "PublishedMetadata" $ CJ.Record.object
+  { bytes: CJ.number
   , hash: Sha256.codec
   , publishedTime: Internal.Codec.iso8601DateTime
-  , ref: CA.string
+  , ref: CJ.string
   }
 
 -- | Metadata about an unpublished package version.
@@ -89,8 +88,8 @@ type UnpublishedMetadata =
   , unpublishedTime :: DateTime
   }
 
-unpublishedMetadataCodec :: JsonCodec UnpublishedMetadata
-unpublishedMetadataCodec = CA.Record.object "UnpublishedMetadata"
+unpublishedMetadataCodec :: CJ.Codec UnpublishedMetadata
+unpublishedMetadataCodec = CJ.named "UnpublishedMetadata" $ CJ.Record.object
   { publishedTime: Internal.Codec.iso8601DateTime
   , reason: Internal.Codec.limitedString 300
   , unpublishedTime: Internal.Codec.iso8601DateTime

--- a/lib/src/Owner.purs
+++ b/lib/src/Owner.purs
@@ -11,9 +11,8 @@ module Registry.Owner
 
 import Prelude
 
-import Data.Codec.Argonaut (JsonCodec)
-import Data.Codec.Argonaut as CA
-import Data.Codec.Argonaut.Record as CA.Record
+import Data.Codec.JSON as CJ
+import Data.Codec.JSON.Record as CJ.Record
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Data.Profunctor as Profunctor
@@ -30,9 +29,9 @@ derive newtype instance Eq Owner
 
 -- | A codec for encoding and decoding an `Owner` as JSON. Represented as a JSON
 -- | object.
-codec :: JsonCodec Owner
-codec = Profunctor.wrapIso Owner $ CA.Record.object "Owner"
-  { id: CA.Record.optional CA.string
-  , keytype: CA.string
-  , public: CA.string
+codec :: CJ.Codec Owner
+codec = Profunctor.wrapIso Owner $ CJ.named "Owner" $ CJ.Record.object
+  { id: CJ.Record.optional CJ.string
+  , keytype: CJ.string
+  , public: CJ.string
   }

--- a/lib/src/PackageSet.purs
+++ b/lib/src/PackageSet.purs
@@ -14,8 +14,7 @@ module Registry.PackageSet
 
 import Prelude
 
-import Data.Codec.Argonaut (JsonCodec)
-import Data.Codec.Argonaut as CA
+import Data.Codec.JSON as CJ
 import Data.DateTime (Date)
 import Data.Map (Map)
 import Data.Newtype (class Newtype)
@@ -41,10 +40,10 @@ derive newtype instance Eq PackageSet
 -- | A codec for encoding and decoding a `PackageSet` as JSON. Represented as a
 -- | JSON object. We use an explicit ordering instead of record sugar in the
 -- | implementation.
-codec :: JsonCodec PackageSet
-codec = Profunctor.wrapIso PackageSet $ CA.object "PackageSet"
-  $ CA.recordProp (Proxy :: _ "version") Version.codec
-  $ CA.recordProp (Proxy :: _ "compiler") Version.codec
-  $ CA.recordProp (Proxy :: _ "published") Internal.Codec.iso8601Date
-  $ CA.recordProp (Proxy :: _ "packages") (Internal.Codec.packageMap Version.codec)
-  $ CA.record
+codec :: CJ.Codec PackageSet
+codec = Profunctor.wrapIso PackageSet $ CJ.named "PackageSet" $ CJ.object
+  $ CJ.recordProp (Proxy :: _ "version") Version.codec
+  $ CJ.recordProp (Proxy :: _ "compiler") Version.codec
+  $ CJ.recordProp (Proxy :: _ "published") Internal.Codec.iso8601Date
+  $ CJ.recordProp (Proxy :: _ "packages") (Internal.Codec.packageMap Version.codec)
+  $ CJ.record

--- a/lib/src/PursGraph.purs
+++ b/lib/src/PursGraph.purs
@@ -10,9 +10,8 @@ import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Array.ST as Array.ST
 import Data.Bifunctor (bimap)
-import Data.Codec.Argonaut (JsonCodec)
-import Data.Codec.Argonaut as CA
-import Data.Codec.Argonaut.Record as CA.Record
+import Data.Codec.JSON as CJ
+import Data.Codec.JSON.Record as CJ.Record
 import Data.Either (Either(..))
 import Data.Map (Map)
 import Data.Map as Map
@@ -33,18 +32,18 @@ import Safe.Coerce (coerce)
 -- | compiler from a set of source files.
 type PursGraph = Map ModuleName PursGraphNode
 
-pursGraphCodec :: JsonCodec PursGraph
-pursGraphCodec = Internal.Codec.strMap "PursGraph" (Just <<< ModuleName) (un ModuleName) pursGraphNodeCodec
+pursGraphCodec :: CJ.Codec PursGraph
+pursGraphCodec = Internal.Codec.strMap "PursGraph" (Right <<< ModuleName) (un ModuleName) pursGraphNodeCodec
 
 type PursGraphNode =
   { depends :: Array ModuleName
   , path :: FilePath
   }
 
-pursGraphNodeCodec :: JsonCodec PursGraphNode
-pursGraphNodeCodec = CA.Record.object "PursGraphNode"
-  { depends: CA.array moduleNameCodec
-  , path: CA.string
+pursGraphNodeCodec :: CJ.Codec PursGraphNode
+pursGraphNodeCodec = CJ.named "PursGraphNode" $ CJ.Record.object
+  { depends: CJ.array moduleNameCodec
+  , path: CJ.string
   }
 
 -- | A module name string from a 'purs graph' invocation.
@@ -54,8 +53,8 @@ derive instance Newtype ModuleName _
 derive instance Eq ModuleName
 derive instance Ord ModuleName
 
-moduleNameCodec :: JsonCodec ModuleName
-moduleNameCodec = Profunctor.wrapIso ModuleName CA.string
+moduleNameCodec :: CJ.Codec ModuleName
+moduleNameCodec = Profunctor.wrapIso ModuleName CJ.string
 
 type AssociatedError = { module :: ModuleName, path :: FilePath, error :: String }
 

--- a/lib/test/Registry/PursGraph.purs
+++ b/lib/test/Registry/PursGraph.purs
@@ -2,10 +2,10 @@ module Test.Registry.PursGraph (spec) where
 
 import Prelude
 
-import Data.Argonaut.Parser as Argonaut.Parser
+import Codec.JSON.DecodeError as CJ.DecodeError
 import Data.Array as Array
 import Data.Array.NonEmpty as NonEmptyArray
-import Data.Codec.Argonaut as CA
+import Data.Codec.JSON as CJ
 import Data.Either (Either(..))
 import Data.Foldable (for_)
 import Data.Foldable as Foldable
@@ -15,6 +15,7 @@ import Data.Maybe as Maybe
 import Data.Set (Set)
 import Data.Set as Set
 import Data.String as String
+import JSON as JSON
 import Node.Encoding (Encoding(..))
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
@@ -29,10 +30,10 @@ import Test.Spec as Spec
 spec :: Spec.Spec Unit
 spec = do
   let
-    parse raw = case Argonaut.Parser.jsonParser raw of
+    parse raw = case JSON.parse raw of
       Left err -> Left $ "Failed to parse graph as JSON:\n\n" <> raw <> "\n\n  due to an error:\n\n" <> err
-      Right json -> case CA.decode PursGraph.pursGraphCodec json of
-        Left err -> Left $ "Failed to decode graph JSON:\n\n" <> CA.printJsonDecodeError err
+      Right json -> case CJ.decode PursGraph.pursGraphCodec json of
+        Left err -> Left $ "Failed to decode graph JSON:\n\n" <> CJ.DecodeError.print err
         Right result -> pure result
 
   Spec.it "type-equality (no deps)" do

--- a/lib/test/Registry/Test/Utils.purs
+++ b/lib/test/Registry/Test/Utils.purs
@@ -2,7 +2,6 @@ module Registry.Test.Utils where
 
 import Prelude
 
-import Data.Argonaut.Core as Argonaut
 import Data.Array as Array
 import Data.Array.NonEmpty as NonEmptyArray
 import Data.Bifunctor (bimap)
@@ -14,6 +13,8 @@ import Data.Formatter.DateTime as DateTime.Formatters
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Tuple (Tuple)
+import JSON (JSON)
+import JSON as JSON
 import Partial.Unsafe (unsafeCrashWith)
 import Partial.Unsafe as Partial
 import Registry.Internal.Format as Internal.Format
@@ -44,7 +45,7 @@ fromRight msg = Either.fromRight' (\_ -> Partial.unsafeCrashWith msg)
 
 -- | Unsafely stringify a value by coercing it to `Json` and stringifying it.
 unsafeStringify :: forall a. a -> String
-unsafeStringify a = Argonaut.stringify (unsafeCoerce a :: Argonaut.Json)
+unsafeStringify a = JSON.print (unsafeCoerce a :: JSON)
 
 -- | Partition an array of `Either` values into failure and success  values
 partitionEithers :: forall e a. Array (Either e a) -> { fail :: Array e, success :: Array a }

--- a/scripts/spago.yaml
+++ b/scripts/spago.yaml
@@ -5,12 +5,10 @@ package:
     version: 0.0.1
   dependencies:
     - aff
-    - argonaut-core
     - argparse-basic
     - arrays
-    - codec-argonaut
+    - codec-json
     - console
-    - control
     - datetime
     - either
     - exceptions
@@ -18,8 +16,10 @@ package:
     - filterable
     - foldable-traversable
     - formatters
+    - json
     - lists
     - newtype
+    - node-fs
     - node-path
     - node-process
     - now

--- a/scripts/src/PackageDeleter.purs
+++ b/scripts/src/PackageDeleter.purs
@@ -6,7 +6,7 @@ import ArgParse.Basic (ArgParser)
 import ArgParse.Basic as Arg
 import Control.Apply (lift2)
 import Data.Array as Array
-import Data.Codec.Argonaut as CA
+import Data.Codec.JSON as CJ
 import Data.FoldableWithIndex (foldMapWithIndex)
 import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Map as Map
@@ -52,8 +52,8 @@ derive instance Eq InputMode
 
 type DeletePackages = Map PackageName (Array Version)
 
-deletePackagesCodec :: JsonCodec DeletePackages
-deletePackagesCodec = Internal.Codec.packageMap (CA.array Version.codec)
+deletePackagesCodec :: CJ.Codec DeletePackages
+deletePackagesCodec = Internal.Codec.packageMap (CJ.array Version.codec)
 
 parser :: ArgParser Arguments
 parser = Arg.fromRecord

--- a/scripts/src/PackageTransferrer.purs
+++ b/scripts/src/PackageTransferrer.purs
@@ -3,8 +3,9 @@ module Registry.Scripts.PackageTransferrer where
 import Registry.App.Prelude
 
 import Data.Array as Array
-import Data.Codec.Argonaut.Common as CA.Common
-import Data.Codec.Argonaut.Record as CA.Record
+import Data.Codec.JSON as CJ
+import Data.Codec.JSON.Common as CJ.Common
+import Data.Codec.JSON.Record as CJ.Record
 import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Map as Map
 import Data.String as String
@@ -104,7 +105,7 @@ transfer = do
   case Map.size needsTransfer of
     0 -> Log.info "No packages require transferring."
     n -> do
-      Log.info $ Array.fold [ show n, " packages need transferring: ", printJson (CA.Common.strMap packageLocationsCodec) needsTransfer ]
+      Log.info $ Array.fold [ show n, " packages need transferring: ", printJson (CJ.Common.strMap packageLocationsCodec) needsTransfer ]
       _ <- transferAll packages needsTransfer
       Log.info "Completed transfers!"
 
@@ -145,8 +146,8 @@ type PackageLocations =
   , tagLocation :: Location
   }
 
-packageLocationsCodec :: JsonCodec PackageLocations
-packageLocationsCodec = CA.Record.object "PackageLocations"
+packageLocationsCodec :: CJ.Codec PackageLocations
+packageLocationsCodec = CJ.named "PackageLocations" $ CJ.Record.object
   { registeredLocation: Location.codec
   , tagLocation: Location.codec
   }

--- a/scripts/src/VerifyIntegrity.purs
+++ b/scripts/src/VerifyIntegrity.purs
@@ -7,7 +7,7 @@ import ArgParse.Basic (ArgParser)
 import ArgParse.Basic as Arg
 import Control.Apply (lift2)
 import Data.Array as Array
-import Data.Codec.Argonaut as CA
+import Data.Codec.JSON as CJ
 import Data.Either (isLeft)
 import Data.Foldable (class Foldable, foldMap, intercalate)
 import Data.Formatter.DateTime as Formatter.DateTime
@@ -102,7 +102,7 @@ main = launchAff_ do
     -- --package name@version
     Package name -> pure (Just [ name ])
     -- --file packagesversions.json
-    File path -> liftAff (readJsonFile (CA.array PackageName.codec) path) >>= case _ of
+    File path -> liftAff (readJsonFile (CJ.array PackageName.codec) path) >>= case _ of
       Left err -> Console.log err *> liftEffect (Process.exit' 1)
       Right values -> pure (Just values)
     All -> pure Nothing

--- a/spago.lock
+++ b/spago.lock
@@ -5,11 +5,11 @@ workspace:
       dependencies:
         - aff
         - ansi
-        - argonaut-core
         - arrays
         - b64
         - bifunctors
-        - codec-argonaut
+        - codec
+        - codec-json
         - console
         - const
         - control
@@ -23,6 +23,7 @@ workspace:
         - fetch
         - filterable
         - foldable-traversable
+        - foreign
         - foreign-object
         - formatters
         - http-methods
@@ -33,9 +34,9 @@ workspace:
         - js-fetch
         - js-promise-aff
         - js-uri
+        - json
         - lists
         - maybe
-        - media-types
         - newtype
         - node-buffer
         - node-child-process
@@ -53,7 +54,6 @@ workspace:
         - partial
         - prelude
         - profunctor
-        - profunctor-lenses
         - record
         - refs
         - registry-foreign
@@ -76,15 +76,16 @@ workspace:
       dependencies:
         - aff
         - aff-promise
-        - argonaut-core
         - arrays
         - b64
         - bifunctors
-        - codec-argonaut
+        - codec
+        - codec-json
         - convertable-options
         - datetime
         - effect
         - either
+        - exceptions
         - fetch
         - filterable
         - foldable-traversable
@@ -93,6 +94,8 @@ workspace:
         - http-methods
         - integers
         - js-date
+        - js-fetch
+        - json
         - maybe
         - newtype
         - node-buffer
@@ -103,10 +106,13 @@ workspace:
         - profunctor
         - registry-lib
         - strings
+        - transformers
         - tuples
         - unsafe-coerce
         - variant
       test_dependencies:
+        - node-child-process
+        - node-execa
         - node-fs
         - node-process
         - spec
@@ -114,10 +120,10 @@ workspace:
       path: lib
       dependencies:
         - aff
-        - argonaut-core
         - arrays
         - bifunctors
-        - codec-argonaut
+        - codec
+        - codec-json
         - control
         - datetime
         - effect
@@ -130,6 +136,7 @@ workspace:
         - functors
         - graphs
         - integers
+        - json
         - language-cst-parser
         - lists
         - maybe
@@ -146,12 +153,13 @@ workspace:
         - profunctor-lenses
         - routing-duplex
         - safe-coerce
+        - st
         - strings
         - transformers
         - tuples
       test_dependencies:
-        - argonaut-core
         - exceptions
+        - json
         - node-child-process
         - node-execa
         - spec
@@ -160,12 +168,10 @@ workspace:
       path: scripts
       dependencies:
         - aff
-        - argonaut-core
         - argparse-basic
         - arrays
-        - codec-argonaut
+        - codec-json
         - console
-        - control
         - datetime
         - either
         - exceptions
@@ -173,8 +179,10 @@ workspace:
         - filterable
         - foldable-traversable
         - formatters
+        - json
         - lists
         - newtype
+        - node-fs
         - node-path
         - node-process
         - now
@@ -195,6 +203,7 @@ workspace:
   package_set:
     registry: 46.0.0
   extra_packages:
+    codec-json: 1.2.0
     dodo-printer:
       repo: https://github.com/natefaubion/purescript-dodo-printer.git
       version: v2.2.1
@@ -290,22 +299,6 @@ packages:
       - foldable-traversable
       - lists
       - strings
-  argonaut-core:
-    type: registry
-    version: 7.0.0
-    integrity: sha256-RC82GfAjItydxrO24cdX373KHVZiLqybu19b5X8u7B4=
-    dependencies:
-      - arrays
-      - control
-      - either
-      - foreign-object
-      - functions
-      - gen
-      - maybe
-      - nonempty
-      - prelude
-      - strings
-      - tailrec
   argparse-basic:
     type: registry
     version: 2.0.0
@@ -412,15 +405,16 @@ packages:
     dependencies:
       - bifunctors
       - profunctor
-  codec-argonaut:
+  codec-json:
     type: registry
-    version: 10.0.0
-    integrity: sha256-n80U8KiBk333qfQwDobSZWiyNg9BA3CL/EwFznIdRwI=
+    version: 1.2.0
+    integrity: sha256-59+uYYe/5uTFa/Q6EqF8ekvP/Y4SOjUNfwIqIYtNiGI=
     dependencies:
-      - argonaut-core
       - codec
       - foreign-object
+      - json
       - ordered-collections
+      - transformers
       - type-equality
       - variant
   console:
@@ -941,6 +935,21 @@ packages:
     dependencies:
       - functions
       - maybe
+  json:
+    type: registry
+    version: 1.0.0
+    integrity: sha256-UCHdePAoOD19UyCPLU97oZjcdxLlQZQneWFsfoUNNpE=
+    dependencies:
+      - either
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - maybe
+      - prelude
+      - strings
+      - tuples
+      - unfoldable
   justifill:
     type: registry
     version: 0.5.0

--- a/spago.yaml
+++ b/spago.yaml
@@ -3,6 +3,7 @@ workspace:
   package_set:
     registry: 46.0.0
   extra_packages:
+    codec-json: 1.2.0
     dodo-printer:
       repo: https://github.com/natefaubion/purescript-dodo-printer.git
       version: v2.2.1


### PR DESCRIPTION
Not sure if we are tracking this in this repo, but we talked about doing this in the past, and we need it for https://github.com/purescript/spago/issues/1090

Maybe the most important detail here is that we are propagating the errors from the parsers into the `DecodeError`s, so that they get through to the user when parsing things like PackageNames that are too long.