### PR TITLE
`instance Show` for `PackageName`

### DIFF
--- a/lib/src/PackageName.purs
+++ b/lib/src/PackageName.purs
@@ -50,6 +50,7 @@ stripPureScriptPrefix pkg =
 -- | A Registry-compliant package name
 newtype PackageName = PackageName String
 
+derive newtype instance Show PackageName
 derive newtype instance Eq PackageName
 derive newtype instance Ord PackageName
 


### PR DESCRIPTION
I think this will assist with any debugging that uses `PackageName`, for instance in Spago: https://github.com/purescript/spago/pull/1253