### PR TITLE
Revert #697: admit unrecognised fields when parsing JSON objects

### DIFF
--- a/lib/src/Manifest.purs
+++ b/lib/src/Manifest.purs
@@ -22,7 +22,6 @@ import Data.Array as Array
 import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Codec.JSON as CJ
 import Data.Codec.JSON.Common as CJ.Common
-import Data.Codec.JSON.Strict as CJS
 import Data.Map (Map)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
@@ -72,14 +71,14 @@ instance Ord Manifest where
 -- | JSON object. The implementation uses explicitly ordered keys instead of
 -- | record sugar.
 codec :: CJ.Codec Manifest
-codec = Profunctor.wrapIso Manifest $ CJ.named "Manifest" $ CJS.objectStrict
-  $ CJS.recordProp @"name" PackageName.codec
-  $ CJS.recordProp @"version" Version.codec
-  $ CJS.recordProp @"license" License.codec
-  $ CJS.recordPropOptional @"description" (Internal.Codec.limitedString 300)
-  $ CJS.recordProp @"location" Location.codec
-  $ CJS.recordPropOptional @"owners" (CJ.Common.nonEmptyArray Owner.codec)
-  $ CJS.recordPropOptional @"includeFiles" (CJ.Common.nonEmptyArray CJ.Common.nonEmptyString)
-  $ CJS.recordPropOptional @"excludeFiles" (CJ.Common.nonEmptyArray CJ.Common.nonEmptyString)
-  $ CJS.recordProp @"dependencies" (Internal.Codec.packageMap Range.codec)
-  $ CJS.record
+codec = Profunctor.wrapIso Manifest $ CJ.named "Manifest" $ CJ.object
+  $ CJ.recordProp @"name" PackageName.codec
+  $ CJ.recordProp @"version" Version.codec
+  $ CJ.recordProp @"license" License.codec
+  $ CJ.recordPropOptional @"description" (Internal.Codec.limitedString 300)
+  $ CJ.recordProp @"location" Location.codec
+  $ CJ.recordPropOptional @"owners" (CJ.Common.nonEmptyArray Owner.codec)
+  $ CJ.recordPropOptional @"includeFiles" (CJ.Common.nonEmptyArray CJ.Common.nonEmptyString)
+  $ CJ.recordPropOptional @"excludeFiles" (CJ.Common.nonEmptyArray CJ.Common.nonEmptyString)
+  $ CJ.recordProp @"dependencies" (Internal.Codec.packageMap Range.codec)
+  $ CJ.record

--- a/lib/src/Metadata.purs
+++ b/lib/src/Metadata.purs
@@ -24,7 +24,6 @@ import Data.Array.NonEmpty (NonEmptyArray)
 import Data.Codec.JSON as CJ
 import Data.Codec.JSON.Common as CJ.Common
 import Data.Codec.JSON.Record as CJ.Record
-import Data.Codec.JSON.Strict as CJS
 import Data.DateTime (DateTime)
 import Data.Map (Map)
 import Data.Maybe (Maybe)
@@ -55,12 +54,12 @@ derive instance Eq Metadata
 -- | A codec for encoding and decoding a `Metadata` value as JSON. Represented
 -- | as a JSON object. Keys are explicitly ordered.
 codec :: CJ.Codec Metadata
-codec = Profunctor.wrapIso Metadata $ CJ.named "Metadata" $ CJS.objectStrict
-  $ CJS.recordProp @"location" Location.codec
-  $ CJS.recordPropOptional @"owners" (CJ.Common.nonEmptyArray Owner.codec)
-  $ CJS.recordProp @"published" (Internal.Codec.versionMap publishedMetadataCodec)
-  $ CJS.recordProp @"unpublished" (Internal.Codec.versionMap unpublishedMetadataCodec)
-  $ CJS.record
+codec = Profunctor.wrapIso Metadata $ CJ.named "Metadata" $ CJ.object
+  $ CJ.recordProp @"location" Location.codec
+  $ CJ.recordPropOptional @"owners" (CJ.Common.nonEmptyArray Owner.codec)
+  $ CJ.recordProp @"published" (Internal.Codec.versionMap publishedMetadataCodec)
+  $ CJ.recordProp @"unpublished" (Internal.Codec.versionMap unpublishedMetadataCodec)
+  $ CJ.record
 
 -- | Metadata about a published package version.
 -- |

--- a/lib/src/PackageSet.purs
+++ b/lib/src/PackageSet.purs
@@ -15,7 +15,6 @@ module Registry.PackageSet
 import Prelude
 
 import Data.Codec.JSON as CJ
-import Data.Codec.JSON.Strict as CJS
 import Data.DateTime (Date)
 import Data.Map (Map)
 import Data.Newtype (class Newtype)
@@ -41,9 +40,9 @@ derive newtype instance Eq PackageSet
 -- | JSON object. We use an explicit ordering instead of record sugar in the
 -- | implementation.
 codec :: CJ.Codec PackageSet
-codec = Profunctor.wrapIso PackageSet $ CJ.named "PackageSet" $ CJS.objectStrict
-  $ CJS.recordProp @"version" Version.codec
-  $ CJS.recordProp @"compiler" Version.codec
-  $ CJS.recordProp @"published" Internal.Codec.iso8601Date
-  $ CJS.recordProp @"packages" (Internal.Codec.packageMap Version.codec)
-  $ CJS.record
+codec = Profunctor.wrapIso PackageSet $ CJ.named "PackageSet" $ CJ.object
+  $ CJ.recordProp @"version" Version.codec
+  $ CJ.recordProp @"compiler" Version.codec
+  $ CJ.recordProp @"published" Internal.Codec.iso8601Date
+  $ CJ.recordProp @"packages" (Internal.Codec.packageMap Version.codec)
+  $ CJ.record


### PR DESCRIPTION
We need to keep `codec-json@2.0.0`, but we remove the strict parsing introduced in #697