### PR TITLE
Compute package set version from successes, reverse-order removals 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,10 @@ import Registry.Operation (AuthenticatedData)
 import Registry.SSH as SSH
 ```
 
+### Syntax
+
+- Never use `let/in` syntax unless in an `ado` block. Prefer `do/let`.
+
 ## Deployment
 
 Continuous deployment via GitHub Actions on master. Manual deploy:

--- a/app/src/App/Legacy/Manifest.purs
+++ b/app/src/App/Legacy/Manifest.purs
@@ -38,12 +38,12 @@ import Registry.App.Legacy.LenientVersion as LenientVersion
 import Registry.App.Legacy.PackageSet as Legacy.PackageSet
 import Registry.App.Legacy.Types (LegacyPackageSet(..), LegacyPackageSetEntry, LegacyPackageSetUnion, RawPackageName(..), RawVersion(..), RawVersionRange(..), legacyPackageSetCodec, legacyPackageSetUnionCodec, rawPackageNameMapCodec, rawVersionCodec, rawVersionRangeCodec)
 import Registry.Foreign.Octokit (Address, GitHubError(..))
-import Registry.Internal.Codec as Internal.Codec
-import Registry.Location as Location
-import Registry.Owner as Owner
 import Registry.Foreign.Octokit as Octokit
 import Registry.Foreign.Tmp as Tmp
+import Registry.Internal.Codec as Internal.Codec
 import Registry.License as License
+import Registry.Location as Location
+import Registry.Owner as Owner
 import Registry.PackageName as PackageName
 import Registry.Range as Range
 import Registry.Sha256 as Sha256


### PR DESCRIPTION
Fixes #716. First, we use success packages only to determine the new package set version. Then, we split package set updates into updates and removals, process updates first in dependency order, and then removals in reverse dependency order.