### PR TITLE
Make repo locks exception safe

### DIFF
--- a/app-e2e/src/Test/E2E/Endpoint/Startup.purs
+++ b/app-e2e/src/Test/E2E/Endpoint/Startup.purs
@@ -83,7 +83,7 @@ spec = do
 
   Spec.describe "scheduleTransfers" do
     Spec.it "enqueues transfer jobs when package location changes" do
-      -- type-equality metadata says old-owner, but tags point to purescript
+      -- type-equality metadata says purescript, but tags point to new-owner
       jobs <- Client.getJobs
       let
         isTypeEqualityTransferJob :: Job -> Boolean
@@ -101,8 +101,8 @@ spec = do
             Transfer { newLocation } ->
               case newLocation of
                 GitHub { owner } ->
-                  when (owner /= "purescript") do
-                    Assert.fail $ "Expected owner 'purescript' but got '" <> owner <> "'"
+                  when (owner /= "new-owner") do
+                    Assert.fail $ "Expected owner 'new-owner' but got '" <> owner <> "'"
                 _ -> Assert.fail "Expected GitHub location"
             _ -> Assert.fail "Expected Transfer payload"
         Just _ -> Assert.fail "Expected TransferJob but got different job type"

--- a/app/fixtures/registry/metadata/type-equality.json
+++ b/app/fixtures/registry/metadata/type-equality.json
@@ -1,6 +1,6 @@
 {
   "location": {
-    "githubOwner": "old-owner",
+    "githubOwner": "purescript",
     "githubRepo": "purescript-type-equality"
   },
   "published": {

--- a/app/src/App/Effect/Registry.purs
+++ b/app/src/App/Effect/Registry.purs
@@ -256,9 +256,9 @@ withRepoLockTimeout timeout process locks key action = do
   case outcome of
     Nothing -> do
       Log.warn $ "Repo lock timed out for " <> printProcess process
-      Run.liftAff $ Aff.throwError $ Aff.error "Repo lock timed out."
+      Except.throw "Repo lock timed out."
     Just (Left err) ->
-      Run.liftAff $ Aff.throwError err
+      Except.throw $ "Repo action failed: " <> Aff.message err
     Just (Right value) ->
       pure value
   where

--- a/app/src/App/Server/Scheduler.purs
+++ b/app/src/App/Server/Scheduler.purs
@@ -257,12 +257,14 @@ enqueuePublishJob allMetadata name (Metadata metadata) version ref = do
               -- Find the highest published version of each dependency within its range
               let
                 depVersions :: Map PackageName Version
-                depVersions = Map.mapMaybeWithKey (\depName range ->
-                  case Map.lookup depName allMetadata of
-                    Just (Metadata depMeta) ->
-                      Array.last $ Array.filter (Range.includes range) $ Array.sort $ Array.fromFoldable $ Map.keys depMeta.published
-                    Nothing -> Nothing
-                ) manifest.dependencies
+                depVersions = Map.mapMaybeWithKey
+                  ( \depName range ->
+                      case Map.lookup depName allMetadata of
+                        Just (Metadata depMeta) ->
+                          Array.last $ Array.filter (Range.includes range) $ Array.sort $ Array.fromFoldable $ Map.keys depMeta.published
+                        Nothing -> Nothing
+                  )
+                  manifest.dependencies
 
               case compatibleCompilers allMetadata depVersions of
                 Just compilerSet -> pure $ NonEmptySet.min compilerSet

--- a/app/test/App/API.purs
+++ b/app/test/App/API.purs
@@ -142,7 +142,9 @@ spec = do
           Nothing -> Except.throw $ "Expected " <> formatPackageVersion name version <> " to be in metadata."
           Just published -> do
             let many' = NonEmptyArray.toArray published.compilers
-            let expected = map Utils.unsafeVersion [ "0.15.10", "0.15.11" ]
+            -- Only 0.15.10 is expected because prelude only has 0.15.10 in metadata,
+            -- so the solver cannot find a solution for 0.15.11
+            let expected = map Utils.unsafeVersion [ "0.15.10" ]
             unless (many' == expected) do
               Except.throw $ "Expected " <> formatPackageVersion name version <> " to have a compiler matrix of " <> Utils.unsafeStringify (map Version.print expected) <> " but got " <> Utils.unsafeStringify (map Version.print many')
 
@@ -191,7 +193,8 @@ spec = do
           Nothing -> Except.throw $ "Expected " <> formatPackageVersion transitive.name transitive.version <> " to be in metadata."
           Just published -> do
             let many' = NonEmptyArray.toArray published.compilers
-            let expected = map Utils.unsafeVersion [ "0.15.10", "0.15.11" ]
+            -- Only 0.15.10 is expected because prelude only has 0.15.10 in metadata
+            let expected = map Utils.unsafeVersion [ "0.15.10" ]
             unless (many' == expected) do
               Except.throw $ "Expected " <> formatPackageVersion transitive.name transitive.version <> " to have a compiler matrix of " <> Utils.unsafeStringify (map Version.print expected) <> " but got " <> Utils.unsafeStringify (map Version.print many')
 

--- a/app/test/App/Effect/Registry.purs
+++ b/app/test/App/Effect/Registry.purs
@@ -16,23 +16,134 @@ import Run.Except as Except
 import Test.Spec as Spec
 
 spec :: Spec.Spec Unit
-spec = Spec.it "Releases repo lock on exception" do
-  locks <- Registry.newRepoLocks
-  repoLock <- Registry.getOrCreateLock locks Registry.RegistryRepo
+spec = do
+  Spec.it "Releases repo lock on exception" do
+    locks <- Registry.newRepoLocks
+    repoLock <- Registry.getOrCreateLock locks Registry.RegistryRepo
 
-  result <- Aff.attempt $ runBase do
-    Registry.withRepoLock Registry.API locks Registry.RegistryRepo do
-      Log.info "Acquiring lock"
-      Except.throw "boom"
+    result <- Aff.attempt $ runBase do
+      Registry.withRepoLock Registry.API locks Registry.RegistryRepo do
+        Log.info "Acquiring lock"
+        Except.throw "boom"
 
-  case result of
-    Left _ -> do
-      owner <- liftEffect $ Ref.read repoLock.owner
-      available <- AVar.tryRead repoLock.lock
-      Assert.shouldEqual Nothing owner
-      Assert.shouldEqual (Just unit) available
-    Right _ ->
-      Assert.fail "Expected lock action to throw"
+    case result of
+      Left _ -> do
+        owner <- liftEffect $ Ref.read repoLock.owner
+        available <- AVar.tryRead repoLock.lock
+        Assert.shouldEqual Nothing owner
+        Assert.shouldEqual (Just unit) available
+      Right _ ->
+        Assert.fail "Expected lock action to throw"
+
+  Spec.it "Tracks lock owner while held" do
+    locks <- Registry.newRepoLocks
+    repoLock <- Registry.getOrCreateLock locks Registry.RegistryRepo
+    entered <- AVar.empty
+    release <- AVar.empty
+
+    fiber <- Aff.forkAff $ runBase do
+      Registry.withRepoLock Registry.Scheduler locks Registry.RegistryRepo do
+        Run.liftAff $ AVar.put unit entered
+        Run.liftAff $ AVar.take release
+
+    _ <- AVar.take entered
+    ownerWhile <- liftEffect $ Ref.read repoLock.owner
+    Assert.shouldEqual (Just Registry.Scheduler) ownerWhile
+
+    _ <- AVar.put unit release
+    _ <- Aff.joinFiber fiber
+
+    ownerAfter <- liftEffect $ Ref.read repoLock.owner
+    Assert.shouldEqual Nothing ownerAfter
+
+  Spec.it "Serializes work for same repo" do
+    locks <- Registry.newRepoLocks
+    entered <- AVar.empty
+    release <- AVar.empty
+    secondEntered <- liftEffect $ Ref.new false
+
+    let
+      action = Registry.withRepoLock Registry.API locks Registry.RegistryRepo
+      buildWorker = runBase <<< action
+
+      worker1 = buildWorker do
+        Run.liftAff $ AVar.put unit entered
+        Run.liftAff $ AVar.take release
+
+      worker2 = buildWorker do
+        Run.liftEffect $ Ref.write true secondEntered
+
+    fiber1 <- Aff.forkAff worker1
+    _ <- AVar.take entered
+    fiber2 <- Aff.forkAff worker2
+
+    _ <- Aff.delay (Aff.Milliseconds 50.0)
+    enteredBefore <- liftEffect $ Ref.read secondEntered
+    Assert.shouldEqual false enteredBefore
+
+    _ <- AVar.put unit release
+    _ <- Aff.joinFiber fiber1
+    _ <- Aff.joinFiber fiber2
+
+    enteredAfter <- liftEffect $ Ref.read secondEntered
+    Assert.shouldEqual true enteredAfter
+
+  Spec.it "Allows concurrent work for different repos" do
+    locks <- Registry.newRepoLocks
+    enteredA <- AVar.empty
+    enteredB <- AVar.empty
+    releaseA <- AVar.empty
+    releaseB <- AVar.empty
+    doneA <- liftEffect $ Ref.new false
+    doneB <- liftEffect $ Ref.new false
+
+    let
+      action repo entered release flag = runBase do
+        Registry.withRepoLock Registry.API locks repo do
+          Run.liftAff $ AVar.put unit entered
+          Run.liftAff $ AVar.take release
+          Run.liftEffect $ Ref.write true flag
+
+      workerA = action Registry.RegistryRepo enteredA releaseA doneA
+      workerB = action Registry.ManifestIndexRepo enteredB releaseB doneB
+
+    _ <- Aff.forkAff workerA
+    _ <- AVar.take enteredA
+
+    _ <- Aff.forkAff workerB
+    _ <- Aff.delay (Aff.Milliseconds 50.0)
+    enteredBStatus <- AVar.tryRead enteredB
+    Assert.shouldEqual (Just unit) enteredBStatus
+
+    _ <- AVar.put unit releaseA
+    _ <- AVar.put unit releaseB
+
+    gotA <- liftEffect $ Ref.read doneA
+    gotB <- liftEffect $ Ref.read doneB
+    Assert.shouldEqual true gotA
+    Assert.shouldEqual true gotB
+
+  Spec.it "Releases lock after timeout" do
+    locks <- Registry.newRepoLocks
+    repoLock <- Registry.getOrCreateLock locks Registry.RegistryRepo
+
+    result <- Aff.attempt $ runBase do
+      Registry.withRepoLockTimeout (Aff.Milliseconds 10.0) Registry.API locks Registry.RegistryRepo do
+        Run.liftAff $ Aff.delay (Aff.Milliseconds 50.0)
+
+    case result of
+      Left _ -> do
+        owner <- liftEffect $ Ref.read repoLock.owner
+        available <- AVar.tryRead repoLock.lock
+        Assert.shouldEqual Nothing owner
+        Assert.shouldEqual (Just unit) available
+
+        followUp <- Aff.attempt $ runBase do
+          Registry.withRepoLock Registry.API locks Registry.RegistryRepo do
+            pure unit
+        Assert.shouldEqual true (isRight followUp)
+      Right _ ->
+        Assert.fail "Expected timeout"
   where
   runBase :: forall a. Run (LOG + EXCEPT String + AFF + EFFECT + ()) a -> Aff a
   runBase =

--- a/app/test/App/Effect/Registry.purs
+++ b/app/test/App/Effect/Registry.purs
@@ -1,0 +1,41 @@
+module Test.Registry.App.Effect.Registry (spec) where
+
+import Registry.App.Prelude
+
+import Effect.Aff as Aff
+import Effect.Aff.AVar as AVar
+import Effect.Ref as Ref
+import Registry.App.Effect.Log (LOG)
+import Registry.App.Effect.Log as Log
+import Registry.App.Effect.Registry as Registry
+import Registry.Test.Assert as Assert
+import Run (AFF, EFFECT, Run)
+import Run as Run
+import Run.Except (EXCEPT)
+import Run.Except as Except
+import Test.Spec as Spec
+
+spec :: Spec.Spec Unit
+spec = Spec.it "Releases repo lock on exception" do
+  locks <- Registry.newRepoLocks
+  repoLock <- Registry.getOrCreateLock locks Registry.RegistryRepo
+
+  result <- Aff.attempt $ runBase do
+    Registry.withRepoLock Registry.API locks Registry.RegistryRepo do
+      Log.info "Acquiring lock"
+      Except.throw "boom"
+
+  case result of
+    Left _ -> do
+      owner <- liftEffect $ Ref.read repoLock.owner
+      available <- AVar.tryRead repoLock.lock
+      Assert.shouldEqual Nothing owner
+      Assert.shouldEqual (Just unit) available
+    Right _ ->
+      Assert.fail "Expected lock action to throw"
+  where
+  runBase :: forall a. Run (LOG + EXCEPT String + AFF + EFFECT + ()) a -> Aff a
+  runBase =
+    Log.interpret (\(Log.Log _ _ next) -> pure next)
+      >>> Except.catch (\err -> Run.liftAff (Aff.throwError (Aff.error err)))
+      >>> Run.runBaseAff'

--- a/app/test/Main.purs
+++ b/app/test/Main.purs
@@ -10,6 +10,7 @@ import Test.Registry.App.CLI.Purs as Test.CLI.Purs
 import Test.Registry.App.CLI.PursVersions as Test.CLI.PursVersions
 import Test.Registry.App.CLI.Tar as Test.CLI.Tar
 import Test.Registry.App.Effect.PackageSets as Test.Effect.PackageSets
+import Test.Registry.App.Effect.Registry as Test.Effect.Registry
 import Test.Registry.App.GitHubIssue as Test.GitHubIssue
 import Test.Registry.App.Legacy.LenientRange as Test.Legacy.LenientRange
 import Test.Registry.App.Legacy.LenientVersion as Test.Legacy.LenientVersion
@@ -37,6 +38,7 @@ main = runSpecAndExitProcess' config [ consoleReporter ] do
 
   Spec.describe "Registry.App.Effect" do
     Test.Effect.PackageSets.spec
+    Test.Effect.Registry.spec
 
   Spec.describe "Registry.App.GitHubIssue" do
     Test.GitHubIssue.spec

--- a/nix/test/config.nix
+++ b/nix/test/config.nix
@@ -289,12 +289,12 @@ let
       };
     }
     # Tags for type-equality package (used by two scheduler tests):
-    # 1. Transfer detection: metadata says old-owner, commit URLs point to purescript
+    # 1. Transfer detection: metadata says purescript, commit URLs point to new-owner
     # 2. Legacy imports: v4.0.2 is a new version not yet published
     {
       request = {
         method = "GET";
-        url = "/repos/old-owner/purescript-type-equality/tags";
+        url = "/repos/purescript/purescript-type-equality/tags";
       };
       response = {
         status = 200;
@@ -304,8 +304,8 @@ let
             name = "v4.0.1";
             commit = {
               sha = "type-eq-sha-401";
-              # Points to actual owner - scheduler detects this transfer
-              url = "https://api.github.com/repos/purescript/purescript-type-equality/commits/type-eq-sha-401";
+              # Points to new owner - scheduler detects this transfer
+              url = "https://api.github.com/repos/new-owner/purescript-type-equality/commits/type-eq-sha-401";
             };
           }
           {
@@ -313,7 +313,7 @@ let
             commit = {
               sha = "type-eq-sha-402";
               # New version not yet published - scheduler detects for legacy import
-              url = "https://api.github.com/repos/purescript/purescript-type-equality/commits/type-eq-sha-402";
+              url = "https://api.github.com/repos/new-owner/purescript-type-equality/commits/type-eq-sha-402";
             };
           }
         ];
@@ -401,14 +401,15 @@ let
 
   # Parse metadata files to get the actual published versions (not just package names)
   # Returns a set like { "prelude-6.0.1" = true; "type-equality-4.0.1" = true; }
-  publishedVersions = lib.foldl' (acc: fileName:
+  publishedVersions = lib.foldl' (
+    acc: fileName:
     let
       packageName = lib.removeSuffix ".json" fileName;
       metadata = builtins.fromJSON (builtins.readFile (metadataFixturesDir + "/${fileName}"));
-      versions = builtins.attrNames (metadata.published or {});
+      versions = builtins.attrNames (metadata.published or { });
     in
     acc // lib.genAttrs (map (v: "${packageName}-${v}") versions) (_: true)
-  ) {} metadataFiles;
+  ) { } metadataFiles;
 
   # ============================================================================
   # UNIFIED STORAGE MAPPINGS WITH WIREMOCK SCENARIOS


### PR DESCRIPTION
The repo-locking flow in #715 has a couple issues, namely:

- There isn't a guarantee that locks are released when exceptions are thrown in `Aff` (though it does catch run exceptions)
- A stuck git operation can hold the lock forever

All along we wanted to use `Aff.bracket`, which is the typical approach to this kind of design. But this doesn't work with `Run`. In this change I've made a change to lower the action to `Aff`, capture `LOG` effects into a `Ref`, then replay them after the lock is released to preserve logging behavior. This lets us remove the orphan-cleanup `clearOwnLocks`, which was only compensating for the previous non–exception-safe path.

The new helper (`runWithLogs`) uses `Run.runCont` to interpret `LOG`, `AFF`, `EFFECT`, and `EXCEPT String`, not supporting any other effects, and the change is localized to the registry module. Logs are replayed afterwards, and we still throw exceptions if needed, but the lock will be released. The lock timeout currently produces an `Aff` error and a warning log with the owning process name.

I also added a new `Test.Registry.App.Effect.Registry` module which acquires a lock, throws an exception, and makes sure everything's still clean. Might add a couple more tests.