### PR TITLE
Only pick up last 24hrs in daily publish job

### DIFF
--- a/app/test/Test/Assert/Run.purs
+++ b/app/test/Test/Assert/Run.purs
@@ -403,6 +403,9 @@ handleGitHubMock env = case _ of
 
     pure $ reply $ Right tags
 
+  ListCommitsSince _address _since reply ->
+    pure $ reply $ Left $ UnexpectedError "Unimplemented"
+
   ListTeamMembers team reply -> pure $ reply $ case team of
     { org: "purescript", team: "packaging" } -> Right [ "pacchettibotti", "f-f", "thomashoneyman" ]
     _ -> Left $ APIError { statusCode: 404, message: "No fixture provided for team " <> team.org <> "/" <> team.team }

--- a/lib/src/Internal/Codec.purs
+++ b/lib/src/Internal/Codec.purs
@@ -1,5 +1,6 @@
 module Registry.Internal.Codec
-  ( iso8601Date
+  ( formatIso8601
+  , iso8601Date
   , iso8601DateTime
   , limitedString
   , packageMap
@@ -39,6 +40,12 @@ import Registry.PackageName (PackageName)
 import Registry.PackageName as PackageName
 import Registry.Version (Version)
 import Registry.Version as Version
+
+-- | INTERNAL
+-- |
+-- | Format a DateTime as an ISO8601 string.
+formatIso8601 :: DateTime -> String
+formatIso8601 = Formatter.DateTime.format Internal.Format.iso8601DateTime
 
 -- | INTERNAL
 -- |

--- a/nix/test/config.nix
+++ b/nix/test/config.nix
@@ -309,6 +309,33 @@ let
         ];
       };
     }
+    # Commits endpoint for prelude - return empty (no recent commits)
+    {
+      request = {
+        method = "GET";
+        urlPattern = "/repos/purescript/purescript-prelude/commits\\?since=.*";
+      };
+      response = {
+        status = 200;
+        headers."Content-Type" = "application/json";
+        jsonBody = [ ];
+      };
+    }
+    # Commits endpoint for type-equality - return the v4.0.2 commit sha
+    # This makes the DailyImporter detect that v4.0.2 is a recent commit
+    {
+      request = {
+        method = "GET";
+        urlPattern = "/repos/purescript/purescript-type-equality/commits\\?since=.*";
+      };
+      response = {
+        status = 200;
+        headers."Content-Type" = "application/json";
+        jsonBody = [
+          { sha = "type-eq-sha-402"; }
+        ];
+      };
+    }
     # Tags for type-equality package (used by two scheduler tests):
     # 1. Transfer detection: metadata says purescript, commit URLs point to new-owner
     # 2. Legacy imports: v4.0.2 is a new version not yet published

--- a/scripts/src/VerifyIntegrity.purs
+++ b/scripts/src/VerifyIntegrity.purs
@@ -12,9 +12,9 @@ import Data.Either (isLeft)
 import Data.Foldable (class Foldable, foldM, intercalate)
 import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Map as Map
-import Effect.Aff as Aff
 import Data.Set as Set
 import Data.String as String
+import Effect.Aff as Aff
 import Effect.Class.Console (log)
 import Effect.Class.Console as Console
 import Node.FS.Aff as FS.Aff


### PR DESCRIPTION
The current implementation will attempt to publish all tags which are not listed in publish/unpublished, but we only want to pick up tags created within the last 24hrs.