### PR TITLE
Add systemd dep on network for startup

### DIFF
--- a/nix/registry-server.nix
+++ b/nix/registry-server.nix
@@ -117,6 +117,8 @@ in
         "multi-user.target"
         "nginx.service"
       ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
       serviceConfig = {
         ExecStart = "${serverInit}/bin/registry-server-init";
         Type = "simple";


### PR DESCRIPTION
Noticed that on startup when pulling metadata the server will print an error connecting to `github.com` – we need to ensure we've got the network ready before starting the server.