### PR TITLE
Retry spurious compile error, fail matrix job on bad compile

### DIFF
--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -713,8 +713,8 @@ publish payload = do
       let installedResolutions = Path.concat [ tmp, ".registry" ]
       buildPlan <- MatrixBuilder.resolutionsToBuildPlan validatedResolutions
       MatrixBuilder.installBuildPlan buildPlan installedResolutions
-      compilationResult <- Run.liftAff $ Purs.callCompiler
-        { command: Purs.Compile { globs: [ "src/**/*.purs", Path.concat [ installedResolutions, "*/src/**/*.purs" ] ] }
+      compilationResult <- Purs.compile
+        { globs: [ "src/**/*.purs", Path.concat [ installedResolutions, "*/src/**/*.purs" ] ]
         , version: Just compiler
         , cwd: Just downloadedPackage
         }
@@ -861,8 +861,8 @@ publish payload = do
         Just { result: Right _ } -> do
           Log.debug "Using cached successful compilation, skipping compilation step"
         _ -> do
-          compilationResult <- Run.liftAff $ Purs.callCompiler
-            { command: Purs.Compile { globs: [ Path.concat [ packageSource, "src/**/*.purs" ], Path.concat [ installedResolutions, "*/src/**/*.purs" ] ] }
+          compilationResult <- Purs.compile
+            { globs: [ Path.concat [ packageSource, "src/**/*.purs" ], Path.concat [ installedResolutions, "*/src/**/*.purs" ] ]
             , version: Just compiler
             , cwd: Just tmp
             }
@@ -1018,8 +1018,8 @@ findAllCompilers { source, manifest, compilers } = do
             FS.Extra.ensureDirectory installed
             buildPlanForCompiler <- MatrixBuilder.resolutionsToBuildPlan resolutions
             MatrixBuilder.installBuildPlan buildPlanForCompiler installed
-            result <- Run.liftAff $ Purs.callCompiler
-              { command: Purs.Compile { globs: [ Path.concat [ source, "src/**/*.purs" ], Path.concat [ installed, "*/src/**/*.purs" ] ] }
+            result <- Purs.compile
+              { globs: [ Path.concat [ source, "src/**/*.purs" ], Path.concat [ installed, "*/src/**/*.purs" ] ]
               , version: Just target
               , cwd: Just workdir
               }

--- a/app/src/App/Effect/PackageSets.purs
+++ b/app/src/App/Effect/PackageSets.purs
@@ -234,8 +234,11 @@ handle env = case _ of
   compileInstalledPackages :: Version -> Run _ (Either CompilerFailure String)
   compileInstalledPackages compiler = do
     Log.debug "Compiling installed packages..."
-    let command = Purs.Compile { globs: [ Path.concat [ Path.basename packagesWorkDir, "**/*.purs" ] ] }
-    Run.liftAff $ Purs.callCompiler { command, version: Just compiler, cwd: Just env.workdir }
+    Purs.compile
+      { globs: [ Path.concat [ Path.basename packagesWorkDir, "**/*.purs" ] ]
+      , version: Just compiler
+      , cwd: Just env.workdir
+      }
 
   attemptChanges :: Version -> PackageSet -> ChangeSet -> Run _ (Either CompilerFailure PackageSet)
   attemptChanges compiler (PackageSet set) changes = do


### PR DESCRIPTION
We've noticed occasionally a matrix job fails with this JSON end of input error, and compilation should be retried. Alas these jobs are marked as success even if they failed compilation.