### PR TITLE
Add 'until' to API routes that list things

### DIFF
--- a/app-e2e/src/Test/E2E/Support/Client.purs
+++ b/app-e2e/src/Test/E2E/Support/Client.purs
@@ -122,7 +122,7 @@ getJobsWith filter = do
     includeCompleted = case filter of
       ActiveOnly -> Just false
       IncludeCompleted -> Just true
-    route = Jobs { since: Nothing, until: Nothing, include_completed: includeCompleted }
+    route = Jobs { since: Nothing, until: Nothing, order: Nothing, include_completed: includeCompleted }
   liftAff $ get (CJ.array V1.jobCodec) clientConfig.baseUrl (printRoute route)
 
 -- | Get the list of jobs (includes completed jobs)
@@ -133,7 +133,7 @@ getJobs = getJobsWith IncludeCompleted
 getJob :: JobId -> Maybe LogLevel -> Maybe DateTime -> E2E Job
 getJob jobId level since = do
   { clientConfig } <- ask
-  let route = Job jobId { level, since, until: Nothing }
+  let route = Job jobId { level, since, until: Nothing, order: Nothing }
   liftAff $ get V1.jobCodec clientConfig.baseUrl (printRoute route)
 
 -- | Try to get a specific job by ID, returning Left on HTTP/parse errors.
@@ -141,7 +141,7 @@ getJob jobId level since = do
 tryGetJob :: JobId -> Maybe LogLevel -> Maybe DateTime -> E2E (Either ClientError Job)
 tryGetJob jobId level since = do
   { clientConfig } <- ask
-  let route = Job jobId { level, since, until: Nothing }
+  let route = Job jobId { level, since, until: Nothing, order: Nothing }
   liftAff $ tryGet V1.jobCodec clientConfig.baseUrl (printRoute route)
 
 -- | Check if the server is healthy

--- a/app-e2e/src/Test/E2E/Support/Client.purs
+++ b/app-e2e/src/Test/E2E/Support/Client.purs
@@ -122,7 +122,7 @@ getJobsWith filter = do
     includeCompleted = case filter of
       ActiveOnly -> Just false
       IncludeCompleted -> Just true
-    route = Jobs { since: Nothing, include_completed: includeCompleted }
+    route = Jobs { since: Nothing, until: Nothing, include_completed: includeCompleted }
   liftAff $ get (CJ.array V1.jobCodec) clientConfig.baseUrl (printRoute route)
 
 -- | Get the list of jobs (includes completed jobs)
@@ -133,7 +133,7 @@ getJobs = getJobsWith IncludeCompleted
 getJob :: JobId -> Maybe LogLevel -> Maybe DateTime -> E2E Job
 getJob jobId level since = do
   { clientConfig } <- ask
-  let route = Job jobId { level, since }
+  let route = Job jobId { level, since, until: Nothing }
   liftAff $ get V1.jobCodec clientConfig.baseUrl (printRoute route)
 
 -- | Try to get a specific job by ID, returning Left on HTTP/parse errors.
@@ -141,7 +141,7 @@ getJob jobId level since = do
 tryGetJob :: JobId -> Maybe LogLevel -> Maybe DateTime -> E2E (Either ClientError Job)
 tryGetJob jobId level since = do
   { clientConfig } <- ask
-  let route = Job jobId { level, since }
+  let route = Job jobId { level, since, until: Nothing }
   liftAff $ tryGet V1.jobCodec clientConfig.baseUrl (printRoute route)
 
 -- | Check if the server is healthy

--- a/app/src/App/SQLite.js
+++ b/app/src/App/SQLite.js
@@ -168,53 +168,44 @@ export const selectPackageSetJobByPayloadImpl = (db, payload) => {
   return stmt.get(payload);
 };
 
-const _selectJobs = (db, { table, since, until, includeCompleted }) => {
+const _selectJobs = (db, { table, since, until, includeCompleted, order }) => {
   let query = `
     SELECT job.*, info.*
     FROM ${table} job
     JOIN ${JOB_INFO_TABLE} info ON job.jobId = info.jobId
-    WHERE 1=1
+    WHERE info.createdAt >= ? AND info.createdAt < ?
   `;
-  let params = [];
-
-  if (since != null) {
-    query += ` AND info.createdAt >= ?`;
-    params.push(since);
-  }
-
-  if (until != null) {
-    query += ` AND info.createdAt <= ?`;
-    params.push(until);
-  }
+  const params = [since, until];
 
   if (includeCompleted === false) {
     query += ` AND info.finishedAt IS NULL`;
   }
 
-  query += ` ORDER BY info.createdAt ASC LIMIT 100`;
+  const dir = order === 'DESC' ? 'DESC' : 'ASC';
+  query += ` ORDER BY info.createdAt ${dir} LIMIT 100`;
   const stmt = db.prepare(query);
 
   return stmt.all(...params);
 }
 
-export const selectPublishJobsImpl = (db, since, until, includeCompleted) => {
-  return _selectJobs(db, { table: PUBLISH_JOBS_TABLE, since, until, includeCompleted });
+export const selectPublishJobsImpl = (db, since, until, includeCompleted, order) => {
+  return _selectJobs(db, { table: PUBLISH_JOBS_TABLE, since, until, includeCompleted, order });
 };
 
-export const selectUnpublishJobsImpl = (db, since, until, includeCompleted) => {
-  return _selectJobs(db, { table: UNPUBLISH_JOBS_TABLE, since, until, includeCompleted });
+export const selectUnpublishJobsImpl = (db, since, until, includeCompleted, order) => {
+  return _selectJobs(db, { table: UNPUBLISH_JOBS_TABLE, since, until, includeCompleted, order });
 };
 
-export const selectTransferJobsImpl = (db, since, until, includeCompleted) => {
-  return _selectJobs(db, { table: TRANSFER_JOBS_TABLE, since, until, includeCompleted });
+export const selectTransferJobsImpl = (db, since, until, includeCompleted, order) => {
+  return _selectJobs(db, { table: TRANSFER_JOBS_TABLE, since, until, includeCompleted, order });
 };
 
-export const selectMatrixJobsImpl = (db, since, until, includeCompleted) => {
-  return _selectJobs(db, { table: MATRIX_JOBS_TABLE, since, until, includeCompleted });
+export const selectMatrixJobsImpl = (db, since, until, includeCompleted, order) => {
+  return _selectJobs(db, { table: MATRIX_JOBS_TABLE, since, until, includeCompleted, order });
 };
 
-export const selectPackageSetJobsImpl = (db, since, until, includeCompleted) => {
-  return _selectJobs(db, { table: PACKAGE_SET_JOBS_TABLE, since, until, includeCompleted });
+export const selectPackageSetJobsImpl = (db, since, until, includeCompleted, order) => {
+  return _selectJobs(db, { table: PACKAGE_SET_JOBS_TABLE, since, until, includeCompleted, order });
 };
 
 export const startJobImpl = (db, args) => {
@@ -268,24 +259,12 @@ export const insertLogLineImpl = (db, logLine) => {
   return stmt.run(logLine);
 };
 
-export const selectLogsByJobImpl = (db, jobId, logLevel, since, until) => {
-  let query = `
+export const selectLogsByJobImpl = (db, jobId, logLevel, since, until, order) => {
+  const dir = order === 'DESC' ? 'DESC' : 'ASC';
+  const stmt = db.prepare(`
     SELECT * FROM ${LOGS_TABLE}
-    WHERE jobId = ? AND level >= ?
-  `;
-  let params = [jobId, logLevel];
-
-  if (since != null) {
-    query += ` AND timestamp >= ?`;
-    params.push(since);
-  }
-
-  if (until != null) {
-    query += ` AND timestamp <= ?`;
-    params.push(until);
-  }
-
-  query += ` ORDER BY timestamp ASC LIMIT 100`;
-  const stmt = db.prepare(query);
-  return stmt.all(...params);
+    WHERE jobId = ? AND level >= ? AND timestamp >= ? AND timestamp < ?
+    ORDER BY timestamp ${dir} LIMIT 100
+  `);
+  return stmt.all(jobId, logLevel, since, until);
 };

--- a/app/src/App/SQLite.purs
+++ b/app/src/App/SQLite.purs
@@ -57,7 +57,7 @@ import Data.Function (on)
 import Data.Nullable (notNull, null)
 import Data.Nullable as Nullable
 import Data.UUID.Random as UUID
-import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn3, EffectFn4)
+import Effect.Uncurried (EffectFn1, EffectFn2, EffectFn4, EffectFn5)
 import Effect.Uncurried as Uncurried
 import Record as Record
 import Registry.API.V1 (Job(..), JobId(..), LogLevel(..), LogLine)
@@ -192,14 +192,15 @@ toSuccess success = case success of
 
 type SelectJobRequest =
   { level :: Maybe LogLevel
-  , since :: DateTime
+  , since :: Maybe DateTime
+  , until :: Maybe DateTime
   , jobId :: JobId
   }
 
 selectJob :: SQLite -> SelectJobRequest -> Effect { unreadableLogs :: Array String, job :: Either String (Maybe Job) }
-selectJob db { level: maybeLogLevel, since, jobId: JobId jobId } = do
+selectJob db { level: maybeLogLevel, since, until, jobId: JobId jobId } = do
   let logLevel = fromMaybe Info maybeLogLevel
-  { fail: unreadableLogs, success: logs } <- selectLogsByJob db (JobId jobId) logLevel since
+  { fail: unreadableLogs, success: logs } <- selectLogsByJob db (JobId jobId) logLevel since until
   -- Failing to decode a log should not prevent us from returning a job, so we pass
   -- failures through to be handled by application code
   job <- runExceptT $ firstJust
@@ -262,12 +263,13 @@ selectJob db { level: maybeLogLevel, since, jobId: JobId jobId } = do
       maybeJobDetails
 
 type SelectJobsRequest =
-  { since :: DateTime
+  { since :: Maybe DateTime
+  , until :: Maybe DateTime
   , includeCompleted :: Boolean
   }
 
 selectJobs :: SQLite -> SelectJobsRequest -> Effect { failed :: Array String, jobs :: Array Job }
-selectJobs db { since, includeCompleted } = do
+selectJobs db { since, until, includeCompleted } = do
   publishJobs <- selectPublishJobs
   unpublishJobs <- selectUnpublishJobs
   transferJobs <- selectTransferJobs
@@ -279,24 +281,27 @@ selectJobs db { since, includeCompleted } = do
   pure { failed: failedJobs, jobs: take 100 $ sortBy (compare `on` (V1.jobInfo >>> _.createdAt)) allJobs }
 
   where
+  sinceStr = Nullable.toNullable $ map (DateTime.format Internal.Format.iso8601DateTime) since
+  untilStr = Nullable.toNullable $ map (DateTime.format Internal.Format.iso8601DateTime) until
+
   selectPublishJobs = do
-    jobs <- Uncurried.runEffectFn3 selectPublishJobsImpl db (DateTime.format Internal.Format.iso8601DateTime since) includeCompleted
+    jobs <- Uncurried.runEffectFn4 selectPublishJobsImpl db sinceStr untilStr includeCompleted
     pure $ map (map (PublishJob <<< Record.merge { logs: [], jobType: Proxy :: _ "publish" }) <<< publishJobDetailsFromJSRep) jobs
 
   selectUnpublishJobs = do
-    jobs <- Uncurried.runEffectFn3 selectUnpublishJobsImpl db (DateTime.format Internal.Format.iso8601DateTime since) includeCompleted
+    jobs <- Uncurried.runEffectFn4 selectUnpublishJobsImpl db sinceStr untilStr includeCompleted
     pure $ map (map (UnpublishJob <<< Record.merge { logs: [], jobType: Proxy :: _ "unpublish" }) <<< unpublishJobDetailsFromJSRep) jobs
 
   selectTransferJobs = do
-    jobs <- Uncurried.runEffectFn3 selectTransferJobsImpl db (DateTime.format Internal.Format.iso8601DateTime since) includeCompleted
+    jobs <- Uncurried.runEffectFn4 selectTransferJobsImpl db sinceStr untilStr includeCompleted
     pure $ map (map (TransferJob <<< Record.merge { logs: [], jobType: Proxy :: _ "transfer" }) <<< transferJobDetailsFromJSRep) jobs
 
   selectMatrixJobs = do
-    jobs <- Uncurried.runEffectFn3 selectMatrixJobsImpl db (DateTime.format Internal.Format.iso8601DateTime since) includeCompleted
+    jobs <- Uncurried.runEffectFn4 selectMatrixJobsImpl db sinceStr untilStr includeCompleted
     pure $ map (map (MatrixJob <<< Record.merge { logs: [], jobType: Proxy :: _ "matrix" }) <<< matrixJobDetailsFromJSRep) jobs
 
   selectPackageSetJobs = do
-    jobs <- Uncurried.runEffectFn3 selectPackageSetJobsImpl db (DateTime.format Internal.Format.iso8601DateTime since) includeCompleted
+    jobs <- Uncurried.runEffectFn4 selectPackageSetJobsImpl db sinceStr untilStr includeCompleted
     pure $ map (map (PackageSetJob <<< Record.merge { logs: [], jobType: Proxy :: _ "packageset" }) <<< packageSetJobDetailsFromJSRep) jobs
 
 --------------------------------------------------------------------------------
@@ -352,7 +357,7 @@ type SelectPublishParams =
 
 foreign import selectPublishJobImpl :: EffectFn2 SQLite SelectPublishParams (Nullable JSPublishJobDetails)
 
-foreign import selectPublishJobsImpl :: EffectFn3 SQLite String Boolean (Array JSPublishJobDetails)
+foreign import selectPublishJobsImpl :: EffectFn4 SQLite (Nullable String) (Nullable String) Boolean (Array JSPublishJobDetails)
 
 selectNextPublishJob :: SQLite -> Effect (Either String (Maybe PublishJobDetails))
 selectNextPublishJob db = do
@@ -452,7 +457,7 @@ type SelectUnpublishParams =
 
 foreign import selectUnpublishJobImpl :: EffectFn2 SQLite SelectUnpublishParams (Nullable JSUnpublishJobDetails)
 
-foreign import selectUnpublishJobsImpl :: EffectFn3 SQLite String Boolean (Array JSUnpublishJobDetails)
+foreign import selectUnpublishJobsImpl :: EffectFn4 SQLite (Nullable String) (Nullable String) Boolean (Array JSUnpublishJobDetails)
 
 selectNextUnpublishJob :: SQLite -> Effect (Either String (Maybe UnpublishJobDetails))
 selectNextUnpublishJob db = do
@@ -550,7 +555,7 @@ type SelectTransferParams = { jobId :: Nullable String, packageName :: Nullable 
 
 foreign import selectTransferJobImpl :: EffectFn2 SQLite SelectTransferParams (Nullable JSTransferJobDetails)
 
-foreign import selectTransferJobsImpl :: EffectFn3 SQLite String Boolean (Array JSTransferJobDetails)
+foreign import selectTransferJobsImpl :: EffectFn4 SQLite (Nullable String) (Nullable String) Boolean (Array JSTransferJobDetails)
 
 selectNextTransferJob :: SQLite -> Effect (Either String (Maybe TransferJobDetails))
 selectNextTransferJob db = do
@@ -686,7 +691,7 @@ matrixJobDetailsFromJSRep { jobId, packageName, packageVersion, compilerVersion,
 
 foreign import selectMatrixJobImpl :: EffectFn2 SQLite (Nullable String) (Nullable JSMatrixJobDetails)
 
-foreign import selectMatrixJobsImpl :: EffectFn3 SQLite String Boolean (Array JSMatrixJobDetails)
+foreign import selectMatrixJobsImpl :: EffectFn4 SQLite (Nullable String) (Nullable String) Boolean (Array JSMatrixJobDetails)
 
 selectNextMatrixJob :: SQLite -> Effect (Either String (Maybe MatrixJobDetails))
 selectNextMatrixJob db = do
@@ -734,7 +739,7 @@ foreign import selectPackageSetJobImpl :: EffectFn2 SQLite (Nullable String) (Nu
 
 foreign import selectPackageSetJobByPayloadImpl :: EffectFn2 SQLite String (Nullable JSPackageSetJobDetails)
 
-foreign import selectPackageSetJobsImpl :: EffectFn3 SQLite String Boolean (Array JSPackageSetJobDetails)
+foreign import selectPackageSetJobsImpl :: EffectFn4 SQLite (Nullable String) (Nullable String) Boolean (Array JSPackageSetJobDetails)
 
 selectNextPackageSetJob :: SQLite -> Effect (Either String (Maybe PackageSetJobDetails))
 selectNextPackageSetJob db = do
@@ -814,18 +819,21 @@ foreign import insertLogLineImpl :: EffectFn2 SQLite JSLogLine Unit
 insertLogLine :: SQLite -> LogLine -> Effect Unit
 insertLogLine db = Uncurried.runEffectFn2 insertLogLineImpl db <<< logLineToJSRep
 
-foreign import selectLogsByJobImpl :: EffectFn4 SQLite String Int String (Array JSLogLine)
+foreign import selectLogsByJobImpl :: EffectFn5 SQLite String Int (Nullable String) (Nullable String) (Array JSLogLine)
 
 -- | Select all logs for a given job at or above the indicated log level. To get all
--- | logs, pass the DEBUG log level.
-selectLogsByJob :: SQLite -> JobId -> LogLevel -> DateTime -> Effect { fail :: Array String, success :: Array LogLine }
-selectLogsByJob db jobId level since = do
-  let timestamp = DateTime.format Internal.Format.iso8601DateTime since
+-- | logs, pass the DEBUG log level. Both since and until are optional; when provided
+-- | they create a half-open [since, until) time window.
+selectLogsByJob :: SQLite -> JobId -> LogLevel -> Maybe DateTime -> Maybe DateTime -> Effect { fail :: Array String, success :: Array LogLine }
+selectLogsByJob db jobId level since until = do
+  let sinceTimestamp = Nullable.toNullable $ map (DateTime.format Internal.Format.iso8601DateTime) since
+  let untilTimestamp = Nullable.toNullable $ map (DateTime.format Internal.Format.iso8601DateTime) until
   jsLogLines <-
-    Uncurried.runEffectFn4
+    Uncurried.runEffectFn5
       selectLogsByJobImpl
       db
       (un JobId jobId)
       (API.V1.logLevelToPriority level)
-      timestamp
+      sinceTimestamp
+      untilTimestamp
   pure $ partitionEithers $ map logLineFromJSRep jsLogLines

--- a/lib/src/API/V1.purs
+++ b/lib/src/API/V1.purs
@@ -1,3 +1,4 @@
+-- | Types, codecs, and routes for the Registry HTTP API (v1).
 module Registry.API.V1
   ( JobCreatedResponse
   , JobId(..)
@@ -10,6 +11,7 @@ module Registry.API.V1
   , PackageSetJobData
   , PublishJobData
   , Route(..)
+  , SortOrder(..)
   , TransferJobData
   , UnpublishJobData
   , jobInfo
@@ -19,6 +21,7 @@ module Registry.API.V1
   , logLevelToPriority
   , printJobType
   , printLogLevel
+  , printSortOrder
   , routes
   ) where
 
@@ -62,8 +65,8 @@ data Route
   | Unpublish
   | Transfer
   | PackageSets
-  | Jobs { since :: Maybe DateTime, until :: Maybe DateTime, include_completed :: Maybe Boolean }
-  | Job JobId { level :: Maybe LogLevel, since :: Maybe DateTime, until :: Maybe DateTime }
+  | Jobs { since :: Maybe DateTime, until :: Maybe DateTime, order :: Maybe SortOrder, include_completed :: Maybe Boolean }
+  | Job JobId { level :: Maybe LogLevel, since :: Maybe DateTime, until :: Maybe DateTime, order :: Maybe SortOrder }
   | Status
 
 derive instance Generic Route _
@@ -77,6 +80,7 @@ routes = Routing.root $ Routing.prefix "api" $ Routing.prefix "v1" $ RoutingG.su
   , "Jobs": "jobs" ?
       { since: Routing.optional <<< timestampP <<< Routing.string
       , until: Routing.optional <<< timestampP <<< Routing.string
+      , order: Routing.optional <<< sortOrderP <<< Routing.string
       , include_completed: Routing.optional <<< Routing.boolean
       }
   , "Job": "jobs" /
@@ -84,6 +88,7 @@ routes = Routing.root $ Routing.prefix "api" $ Routing.prefix "v1" $ RoutingG.su
           { level: Routing.optional <<< logLevelP <<< Routing.string
           , since: Routing.optional <<< timestampP <<< Routing.string
           , until: Routing.optional <<< timestampP <<< Routing.string
+          , order: Routing.optional <<< sortOrderP <<< Routing.string
           }
       )
   , "Status": "status" / RoutingG.noArgs
@@ -100,6 +105,24 @@ timestampP = Routing.as printTimestamp parseTimestamp
   where
   printTimestamp t = DateTime.format Internal.Format.iso8601DateTime t
   parseTimestamp s = DateTime.unformat Internal.Format.iso8601DateTime s
+
+data SortOrder = ASC | DESC
+
+derive instance Eq SortOrder
+
+printSortOrder :: SortOrder -> String
+printSortOrder = case _ of
+  ASC -> "ASC"
+  DESC -> "DESC"
+
+parseSortOrder :: String -> Either String SortOrder
+parseSortOrder = case _ of
+  "ASC" -> Right ASC
+  "DESC" -> Right DESC
+  other -> Left $ "Invalid sort order: " <> other
+
+sortOrderP :: RouteDuplex' String -> RouteDuplex' SortOrder
+sortOrderP = Routing.as printSortOrder parseSortOrder
 
 type JobCreatedResponse = { jobId :: JobId }
 

--- a/lib/src/API/V1.purs
+++ b/lib/src/API/V1.purs
@@ -62,8 +62,8 @@ data Route
   | Unpublish
   | Transfer
   | PackageSets
-  | Jobs { since :: Maybe DateTime, include_completed :: Maybe Boolean }
-  | Job JobId { level :: Maybe LogLevel, since :: Maybe DateTime }
+  | Jobs { since :: Maybe DateTime, until :: Maybe DateTime, include_completed :: Maybe Boolean }
+  | Job JobId { level :: Maybe LogLevel, since :: Maybe DateTime, until :: Maybe DateTime }
   | Status
 
 derive instance Generic Route _
@@ -76,12 +76,14 @@ routes = Routing.root $ Routing.prefix "api" $ Routing.prefix "v1" $ RoutingG.su
   , "PackageSets": "package-sets" / RoutingG.noArgs
   , "Jobs": "jobs" ?
       { since: Routing.optional <<< timestampP <<< Routing.string
+      , until: Routing.optional <<< timestampP <<< Routing.string
       , include_completed: Routing.optional <<< Routing.boolean
       }
   , "Job": "jobs" /
       ( jobIdS ?
           { level: Routing.optional <<< logLevelP <<< Routing.string
           , since: Routing.optional <<< timestampP <<< Routing.string
+          , until: Routing.optional <<< timestampP <<< Routing.string
           }
       )
   , "Status": "status" / RoutingG.noArgs


### PR DESCRIPTION
The fact that having only the `since` parameter in the API routes was not very ergonomic already came up in previous discussions with @thomashoneyman, but trying to put together a dashboard for the logs (as per #742) cemented this idea.

Here we add an `until` parameter, so that the default when neither `since` nor `until` are provided is that we fetch the last items until now, which I think is a sensible default.

Bonus: we add a CORS middleware as well here, also needed for the dashboard. 