### PR TITLE
Add support for purs@0.15.16

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,27 @@ nix run .#daily-importer
 
 The [.env.example](./.env.example) file lists out a number of environment variables that you can set. Scripts that require environment variables will fail at startup if the required env var is not found, so you can add only the ones you need to your .env file.
 
+## Upgrading the PureScript Compiler
+
+When a new compiler release is added to `purescript-overlay`, the registry needs a small set of changes:
+
+```sh
+# Update the Nix input that provides purs and the compiler binaries
+nix flake update purescript-overlay
+
+# Confirm the dev shell now exposes the expected compiler version
+nix develop --command purs --version
+```
+
+If the compiler bump causes source incompatibilities, fix them in the PureScript code and re-run the commands above. Then, update the expected compiler list in [`app/test/App/CLI/PursVersions.purs`](./app/test/App/CLI/PursVersions.purs). Once done, verify with `nix flake check`.
+
+Deploying the updated server is normally enough to start the registry-wide compiler matrix rollout. On server startup, the job executor checks whether the newest compiler known to `purs-versions` is missing from the latest `prelude` metadata; if so, it enqueues matrix jobs for packages without dependencies, and those jobs cascade through the rest of the registry.
+
+In practice this means:
+
+- Push the compiler upgrade to `master` and let the normal deploy workflow roll it out, or deploy manually with `colmena apply`.
+- After deploy, watch `journalctl -u server.service` or the jobs API if you want to confirm the new compiler matrix has started.
+
 ## Testing
 
 The usual PureScript testing workflow applies in the registry — from within a Nix shell, you can execute all tests:

--- a/app/test/App/CLI/PursVersions.purs
+++ b/app/test/App/CLI/PursVersions.purs
@@ -47,6 +47,7 @@ knownCompilers = map (unsafeFromRight <<< Version.parse)
   , "0.15.13"
   , "0.15.14"
   , "0.15.15"
+  , "0.15.16"
   ]
 
 spec :: Spec.Spec Unit

--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769971816,
-        "narHash": "sha256-6WdiHwc7cM07ttMh3JQslHzmwL9+RaDvf2OwZ0bsWu0=",
+        "lastModified": 1773587485,
+        "narHash": "sha256-hgL4SGSg6pBK9EC8RQFEA6Y+dhJU0ZByG+o/PYdkVmY=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "af71d25ea276b03c46e79cf6ef59edd0a938dfd3",
+        "rev": "0a45ee1adbadbda0273b11cd4cc22a68408c73ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The compiler matrix jobs will run on deploy, so we just need to update the shell and list of compilers in tests.