### PR TITLE
Fix manifest description length validation

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -389,7 +389,7 @@ All packages in the registry contain a `purs.json` manifest file in their root d
 - `location`: a valid [`Location`](#location)
 - `ref`: a `string` representing the reference (e.g., a Git commit or Git tag) at the `location` that was used to fetch this version's source code
 - `owners` (optional): a non-empty array of [`Owner`](#owner)
-- `description` (optional): a description of your library as a plain text string, not markdown, up to 300 characters
+- `description` (optional): a description of your library as a plain text string, not markdown, up to 500 characters
 - `includeFiles` (optional): a non-empty array of globs, where globs are used to match file paths (in addition to the `src` directory and other [always-included files](#always-included-files)) that you want included in your package tarball
 - `excludeFiles` (optional): a non-empty array of globs, where globs are used to match file paths in your package source to exclude them (in addition to the [always-ignored files](#always-ignored-files)) from your package tarball.
 - `dependencies`: dependencies of your package as key-value pairs where the keys are [`PackageName`](#packagename)s and values are [`Range`](#range)s; this is a required field, but if you have no dependencies you can provide an empty object.

--- a/app-e2e/src/Test/E2E/Endpoint/Unpublish.purs
+++ b/app-e2e/src/Test/E2E/Endpoint/Unpublish.purs
@@ -6,6 +6,7 @@ import Data.Array as Array
 import Data.Map as Map
 import Data.String as String
 import Registry.API.V1 as V1
+import Registry.LimitedString as LimitedString
 import Registry.Metadata (Metadata(..))
 import Registry.Test.Assert as Assert
 import Test.E2E.Support.Client as Client
@@ -37,7 +38,7 @@ spec = do
         Nothing ->
           Assert.fail "Expected version 4.0.0 to be in 'unpublished' metadata"
         Just unpublishedInfo ->
-          Assert.shouldSatisfy unpublishedInfo.reason (not <<< String.null)
+          Assert.shouldSatisfy (LimitedString.print unpublishedInfo.reason) (not <<< String.null)
 
       when (Map.member Fixtures.effect.version metadata.published) do
         Assert.fail "Version 4.0.0 should not be in 'published' metadata after unpublish"

--- a/app-e2e/src/Test/E2E/Support/Fixtures.purs
+++ b/app-e2e/src/Test/E2E/Support/Fixtures.purs
@@ -145,7 +145,7 @@ effectUnpublishData :: UnpublishData
 effectUnpublishData =
   { name: effect.name
   , version: effect.version
-  , reason: "Testing unpublish flow"
+  , reason: Utils.unsafeLimitedString "Testing unpublish flow"
   }
 
 -- | Transfer data for effect, used for transfer tests.
@@ -166,7 +166,7 @@ nonexistentUnpublishData :: UnpublishData
 nonexistentUnpublishData =
   { name: Utils.unsafePackageName "nonexistent-package"
   , version: Utils.unsafeVersion "1.0.0"
-  , reason: "Testing error handling for unknown package"
+  , reason: Utils.unsafeLimitedString "Testing error handling for unknown package"
   }
 
 -- | Unpublish data for prelude@6.0.1.
@@ -176,7 +176,7 @@ preludeUnpublishData :: UnpublishData
 preludeUnpublishData =
   { name: prelude.name
   , version: prelude.version
-  , reason: "Testing 48-hour limit enforcement"
+  , reason: Utils.unsafeLimitedString "Testing 48-hour limit enforcement"
   }
 
 -- | Sign an unpublish operation using the given private key.
@@ -228,7 +228,7 @@ trusteeAuthenticatedData = do
     unpublishPayload =
       { name: prelude.name
       , version: prelude.version
-      , reason: "Testing trustee re-signing"
+      , reason: Utils.unsafeLimitedString "Testing trustee re-signing"
       }
     rawPayload = JSON.print $ CJ.encode Operation.unpublishCodec unpublishPayload
 

--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -95,6 +95,7 @@ import Registry.Foreign.Tmp as Tmp
 import Registry.Internal.Codec as Internal.Codec
 import Registry.Internal.Path as Internal.Path
 import Registry.License as License
+import Registry.LimitedString as LimitedString
 import Registry.Location as Location
 import Registry.Manifest as Manifest
 import Registry.Metadata as Metadata
@@ -492,6 +493,9 @@ parseSourceManifest { packageDir, name, version, ref, location } = do
           Left err ->
             Except.throw $ "Could not convert bower.json to purs.json manifest: " <> err
           Right { license, description, dependencies } -> do
+            parsedDescription <- case traverse LimitedString.parse description of
+              Left err -> Except.throw err
+              Right result -> pure result
             let
               manifest = Manifest
                 { name
@@ -499,7 +503,7 @@ parseSourceManifest { packageDir, name, version, ref, location } = do
                 , license
                 , location
                 , ref
-                , description
+                , description: parsedDescription
                 , dependencies
                 , includeFiles: Nothing
                 , excludeFiles: Nothing
@@ -530,6 +534,9 @@ parseSourceManifest { packageDir, name, version, ref, location } = do
             Left err ->
               Except.throw $ "Could not convert spago.dhall to purs.json manifest: " <> err
             Right { license, description, dependencies } -> do
+              parsedDescription <- case traverse LimitedString.parse description of
+                Left err -> Except.throw err
+                Right result -> pure result
               let
                 manifest = Manifest
                   { name
@@ -537,7 +544,7 @@ parseSourceManifest { packageDir, name, version, ref, location } = do
                   , license
                   , location
                   , ref
-                  , description
+                  , description: parsedDescription
                   , dependencies
                   , includeFiles: Nothing
                   , excludeFiles: Nothing

--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -95,7 +95,6 @@ import Registry.Foreign.Tmp as Tmp
 import Registry.Internal.Codec as Internal.Codec
 import Registry.Internal.Path as Internal.Path
 import Registry.License as License
-import Registry.LimitedString as LimitedString
 import Registry.Location as Location
 import Registry.Manifest as Manifest
 import Registry.Metadata as Metadata
@@ -493,9 +492,6 @@ parseSourceManifest { packageDir, name, version, ref, location } = do
           Left err ->
             Except.throw $ "Could not convert bower.json to purs.json manifest: " <> err
           Right { license, description, dependencies } -> do
-            parsedDescription <- case traverse LimitedString.parse description of
-              Left err -> Except.throw err
-              Right result -> pure result
             let
               manifest = Manifest
                 { name
@@ -503,7 +499,7 @@ parseSourceManifest { packageDir, name, version, ref, location } = do
                 , license
                 , location
                 , ref
-                , description: parsedDescription
+                , description
                 , dependencies
                 , includeFiles: Nothing
                 , excludeFiles: Nothing
@@ -534,9 +530,6 @@ parseSourceManifest { packageDir, name, version, ref, location } = do
             Left err ->
               Except.throw $ "Could not convert spago.dhall to purs.json manifest: " <> err
             Right { license, description, dependencies } -> do
-              parsedDescription <- case traverse LimitedString.parse description of
-                Left err -> Except.throw err
-                Right result -> pure result
               let
                 manifest = Manifest
                   { name
@@ -544,7 +537,7 @@ parseSourceManifest { packageDir, name, version, ref, location } = do
                   , license
                   , location
                   , ref
-                  , description: parsedDescription
+                  , description
                   , dependencies
                   , includeFiles: Nothing
                   , excludeFiles: Nothing

--- a/app/src/App/Legacy/Manifest.purs
+++ b/app/src/App/Legacy/Manifest.purs
@@ -31,6 +31,7 @@ import Registry.App.Legacy.LenientVersion as LenientVersion
 import Registry.App.Legacy.Types (RawPackageName(..), RawVersion(..), RawVersionRange(..), rawPackageNameMapCodec, rawVersionCodec, rawVersionRangeCodec)
 import Registry.Internal.Codec as Internal.Codec
 import Registry.License as License
+import Registry.LimitedString as LimitedString
 import Registry.Location as Location
 import Registry.Owner as Owner
 import Registry.PackageName as PackageName
@@ -194,7 +195,7 @@ legacyManifestCodec fallbackRef = Profunctor.dimap toRep fromRep $ CJ.named "Man
   $ CJ.recordProp @"name" PackageName.codec
   $ CJ.recordProp @"version" Version.codec
   $ CJ.recordProp @"license" License.codec
-  $ CJ.recordPropOptional @"description" (Internal.Codec.limitedString 300)
+  $ CJ.recordPropOptional @"description" LimitedString.codec
   $ CJ.recordProp @"location" Location.codec
   $ CJ.recordPropOptional @"ref" CJ.string
   $ CJ.recordPropOptional @"owners" (CJ.Common.nonEmptyArray Owner.codec)

--- a/app/src/App/Legacy/Manifest.purs
+++ b/app/src/App/Legacy/Manifest.purs
@@ -33,6 +33,7 @@ import Registry.Internal.Codec as Internal.Codec
 import Registry.License as License
 import Registry.LimitedString as LimitedString
 import Registry.Location as Location
+import Registry.Manifest (ManifestDescription)
 import Registry.Owner as Owner
 import Registry.PackageName as PackageName
 import Registry.Range (Range)
@@ -74,8 +75,8 @@ bowerfileCodec = Profunctor.dimap toRep fromRep $ CJ.named "Bowerfile" $ CJ.Reco
 -- | Returns an error message if the conversion fails.
 bowerfileToPursJson
   :: Bowerfile
-  -> Either String { license :: License, description :: Maybe String, dependencies :: Map PackageName Range }
-bowerfileToPursJson (Bowerfile { description, dependencies, license }) = do
+  -> Either String { license :: License, description :: Maybe ManifestDescription, dependencies :: Map PackageName Range }
+bowerfileToPursJson (Bowerfile { description: bowerDescription, dependencies, license }) = do
   let
     -- Best effort: keep any licenses that parse cleanly and drop the rest.
     validLicenses = Array.mapMaybe (hush <<< License.parseCanonical) license
@@ -86,6 +87,7 @@ bowerfileToPursJson (Bowerfile { description, dependencies, license }) = do
       Just multiple -> Right $ License.joinWith License.And multiple
 
   parsedDeps <- parseDependencies dependencies
+  description <- traverse LimitedString.parse bowerDescription
 
   Right { license: parsedLicense, description, dependencies: parsedDeps }
 
@@ -137,7 +139,7 @@ spagoDhallJsonCodec = Profunctor.dimap toRep fromRep $ CJ.named "SpagoDhallJson"
 -- | Returns an error message if the conversion fails.
 spagoDhallToPursJson
   :: SpagoDhallJson
-  -> Either String { license :: License, description :: Maybe String, dependencies :: Map PackageName Range }
+  -> Either String { license :: License, description :: Maybe ManifestDescription, dependencies :: Map PackageName Range }
 spagoDhallToPursJson (SpagoDhallJson { license, dependencies, packages }) = do
   parsedLicense <- case license of
     Nothing -> Left "No license found in spago.dhall"

--- a/app/src/App/Manifest/SpagoYaml.purs
+++ b/app/src/App/Manifest/SpagoYaml.purs
@@ -18,6 +18,7 @@ import Data.String as String
 import Data.String.NonEmpty as NonEmptyString
 import Registry.Internal.Codec as Internal.Codec
 import Registry.License as License
+import Registry.LimitedString as LimitedString
 import Registry.Location as Location
 import Registry.Manifest (Manifest(..))
 import Registry.Owner as Owner
@@ -31,13 +32,14 @@ import Registry.Version as Version
 -- | the Git reference (tag or commit) used to fetch this version's source.
 spagoYamlToManifest :: String -> SpagoYaml -> Either String Manifest
 spagoYamlToManifest ref config = do
-  package@{ name, description, dependencies: spagoDependencies } <- note "No 'package' key found in config." config.package
+  package@{ name, description: spagoDescription, dependencies: spagoDependencies } <- note "No 'package' key found in config." config.package
   publish@{ version, license, owners } <- note "No 'publish' key found under the 'package' key in config." package.publish
   location <- note "No 'location' key found under the 'publish' key in config." publish.location
   let includeFiles = NonEmptyArray.fromArray =<< (Array.mapMaybe NonEmptyString.fromString <$> publish.include)
   let excludeFiles = NonEmptyArray.fromArray =<< (Array.mapMaybe NonEmptyString.fromString <$> publish.exclude)
   let printRangeError packages = "The following packages did not have their ranges specified: " <> String.joinWith ", " (map PackageName.print (Set.toUnfoldable packages))
   dependencies <- lmap printRangeError $ convertSpagoDependencies spagoDependencies
+  description <- traverse LimitedString.parse spagoDescription
   pure $ Manifest
     { name
     , version

--- a/app/test/App/Auth.purs
+++ b/app/test/App/Auth.purs
@@ -5,6 +5,7 @@ import Registry.App.Prelude
 import Data.Newtype (over)
 import Data.String as String
 import Registry.App.Auth as Auth
+import Registry.LimitedString as LimitedString
 import Registry.Operation (AuthenticatedData, AuthenticatedPackageOperation(..))
 import Registry.PackageName as PackageName
 import Registry.SSH (Signature(..))
@@ -74,7 +75,7 @@ validPayload =
   , payload: Unpublish
       { name
       , version
-      , reason: "Committed bad credentials"
+      , reason: unsafeFromRight $ LimitedString.parse "Committed bad credentials"
       }
   , rawPayload
   }

--- a/app/test/App/Auth.purs
+++ b/app/test/App/Auth.purs
@@ -5,6 +5,7 @@ import Registry.App.Prelude
 import Data.Newtype (over)
 import Data.String as String
 import Registry.App.Auth as Auth
+import Registry.LimitedString (LimitedString)
 import Registry.LimitedString as LimitedString
 import Registry.Operation (AuthenticatedData, AuthenticatedPackageOperation(..))
 import Registry.PackageName as PackageName
@@ -75,7 +76,7 @@ validPayload =
   , payload: Unpublish
       { name
       , version
-      , reason: unsafeFromRight $ LimitedString.parse "Committed bad credentials"
+      , reason
       }
   , rawPayload
   }
@@ -85,6 +86,9 @@ name = unsafeFromRight $ PackageName.parse "foo"
 
 version :: Version
 version = unsafeFromRight $ Version.parse "1.2.3"
+
+reason :: LimitedString 300
+reason = unsafeFromRight $ LimitedString.parse "Committed bad credentials"
 
 keytype :: String
 keytype = "ssh-ed25519"

--- a/app/test/App/Legacy/Manifest.purs
+++ b/app/test/App/Legacy/Manifest.purs
@@ -164,6 +164,16 @@ bowerfileToPursJsonSpec = do
           Left _ -> pure unit
           Right _ -> Assert.fail "Expected conversion to fail for missing license"
 
+    Spec.it "Fails when the description exceeds the manifest limit" do
+      let
+        description = Array.fold $ Array.replicate 501 "a"
+        input = "{ \"license\": \"MIT\", \"description\": \"" <> description <> "\" }"
+      case parseJson Legacy.Manifest.bowerfileCodec input of
+        Left err -> Assert.fail $ "Failed to parse bowerfile:\n" <> CJ.DecodeError.print err
+        Right bowerfile -> case Legacy.Manifest.bowerfileToPursJson bowerfile of
+          Left _ -> pure unit
+          Right _ -> Assert.fail "Expected conversion to fail for an overlong description"
+
 spagoDhallToPursJsonSpec :: Spec Unit
 spagoDhallToPursJsonSpec = do
   Spec.describe "Converts valid SpagoDhallJson" do

--- a/app/test/App/Manifest/SpagoYaml.purs
+++ b/app/test/App/Manifest/SpagoYaml.purs
@@ -2,7 +2,9 @@ module Test.Registry.App.Manifest.SpagoYaml where
 
 import Registry.App.Prelude
 
+import Data.Array as Array
 import Data.Either (isLeft)
+import Data.String as String
 import Effect.Aff as Aff
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
@@ -44,6 +46,28 @@ spec = do
         """
 
     parseYaml SpagoYaml.spagoYamlCodec input `Assert.shouldSatisfy` isLeft
+
+  Spec.it "Rejects descriptions over the manifest limit" do
+    let
+      description = String.joinWith "" $ Array.replicate 501 "a"
+      input = String.joinWith "\n"
+        [ "package:"
+        , "  name: registry-lib"
+        , "  description: " <> description
+        , "  publish:"
+        , "    version: 0.0.1"
+        , "    license: BSD-3-Clause"
+        , "    location:"
+        , "      githubOwner: purescript"
+        , "      githubRepo: registry-dev"
+        , "  dependencies:"
+        , "    - prelude: \">=1.0.0 <2.0.0\""
+        ]
+
+    case parseYaml SpagoYaml.spagoYamlCodec input of
+      Left err -> Assert.fail err
+      Right config ->
+        SpagoYaml.spagoYamlToManifest "v1.0.0" config `Assert.shouldSatisfy` isLeft
 
   Spec.describe "parseSpagoRange" do
     Spec.it "parses unbounded range '*'" do

--- a/lib/src/Internal/Codec.purs
+++ b/lib/src/Internal/Codec.purs
@@ -2,7 +2,6 @@ module Registry.Internal.Codec
   ( formatIso8601
   , iso8601Date
   , iso8601DateTime
-  , limitedString
   , packageMap
   , parsedString
   , versionMap
@@ -22,10 +21,8 @@ import Data.Either (Either(..))
 import Data.FoldableWithIndex (forWithIndex_)
 import Data.Formatter.DateTime as Formatter.DateTime
 import Data.Formatter.DateTime as Formatter.Datetime
-import Data.Int as Int
 import Data.Map (Map)
 import Data.Map as Map
-import Data.String as String
 import Data.Traversable (for)
 import Data.Tuple (Tuple(..))
 import Foreign.Object as Object
@@ -91,23 +88,6 @@ iso8601Date = Codec.codec' decode encode
     string <- Codec.decode CJ.string json
     dateTime <- except $ lmap (CJ.DecodeError.basic <<< append "YYYY-MM-DD: ") (Formatter.DateTime.unformat Internal.Format.iso8601Date string)
     pure $ DateTime.date dateTime
-
--- | INTERNAL
--- |
--- | A codec for `String` values with an explicit limited length.
-limitedString :: Int -> CJ.Codec String
-limitedString limit = Codec.codec' decode encode
-  where
-  encode :: String -> JSON
-  encode = CJ.encode CJ.string
-
-  decode :: JSON -> Except CJ.DecodeError String
-  decode json = except do
-    string <- CJ.decode CJ.string json
-    if String.length string > limit then
-      Left $ CJ.DecodeError.basic $ "LimitedString: Exceeds limit of " <> Int.toStringAs Int.decimal limit <> " characters."
-    else
-      Right string
 
 -- | INTERNAL
 -- |

--- a/lib/src/LimitedString.purs
+++ b/lib/src/LimitedString.purs
@@ -1,0 +1,49 @@
+-- | A string whose maximum length is tracked at the type level.
+module Registry.LimitedString
+  ( LimitedString
+  , codec
+  , parse
+  , print
+  ) where
+
+import Prelude
+
+import Codec.JSON.DecodeError as CJ.DecodeError
+import Control.Monad.Except (Except, except)
+import Data.Bifunctor (lmap)
+import Data.Codec as Codec
+import Data.Codec.JSON as CJ
+import Data.Either (Either(..))
+import Data.Reflectable (class Reflectable, reflectType)
+import Data.String as String
+import JSON (JSON)
+import Type.Proxy (Proxy(..))
+
+-- | A string that cannot exceed the given number of characters.
+newtype LimitedString (limit :: Int) = LimitedString String
+
+derive newtype instance Eq (LimitedString limit)
+derive newtype instance Ord (LimitedString limit)
+
+-- | A codec for encoding and decoding a limited string as a JSON string.
+codec :: forall limit. Reflectable limit Int => CJ.Codec (LimitedString limit)
+codec = CJ.named "LimitedString" $ Codec.codec' decode encode
+  where
+  decode :: JSON -> Except CJ.DecodeError (LimitedString limit)
+  decode = except <<< lmap CJ.DecodeError.basic <<< parse <=< Codec.decode CJ.string
+
+  encode :: LimitedString limit -> JSON
+  encode = print >>> CJ.encode CJ.string
+
+-- | Parse a string, rejecting values that exceed the type-level limit.
+parse :: forall limit. Reflectable limit Int => String -> Either String (LimitedString limit)
+parse string = do
+  let limit = reflectType (Proxy @limit)
+  if String.length string > limit then
+    Left $ "LimitedString: Exceeds limit of " <> show limit <> " characters."
+  else
+    Right $ LimitedString string
+
+-- | Print a limited string as a plain string.
+print :: forall limit. LimitedString limit -> String
+print (LimitedString string) = string

--- a/lib/src/LimitedString.purs
+++ b/lib/src/LimitedString.purs
@@ -14,6 +14,7 @@ import Data.Bifunctor (lmap)
 import Data.Codec as Codec
 import Data.Codec.JSON as CJ
 import Data.Either (Either(..))
+import Data.Int as Int
 import Data.Reflectable (class Reflectable, reflectType)
 import Data.String as String
 import JSON (JSON)
@@ -40,7 +41,7 @@ parse :: forall limit. Reflectable limit Int => String -> Either String (Limited
 parse string = do
   let limit = reflectType (Proxy @limit)
   if String.length string > limit then
-    Left $ "LimitedString: Exceeds limit of " <> show limit <> " characters."
+    Left $ "LimitedString: Exceeds limit of " <> Int.toStringAs Int.decimal limit <> " characters."
   else
     Right $ LimitedString string
 

--- a/lib/src/Manifest.purs
+++ b/lib/src/Manifest.purs
@@ -13,6 +13,7 @@
 -- | https://github.com/purescript/registry-index
 module Registry.Manifest
   ( Manifest(..)
+  , ManifestDescription
   , codec
   ) where
 
@@ -43,6 +44,10 @@ import Registry.Range as Range
 import Registry.Version (Version)
 import Registry.Version as Version
 
+-- | A plain-text package description with the maximum length permitted by the
+-- | registry specification.
+type ManifestDescription = LimitedString 500
+
 -- | The manifest for a package version, which records critical information for
 -- | the registry, pursuit, and package managers to use.
 newtype Manifest = Manifest
@@ -52,7 +57,7 @@ newtype Manifest = Manifest
   , location :: Location
   , ref :: String
   , owners :: Maybe (NonEmptyArray Owner)
-  , description :: Maybe (LimitedString 500)
+  , description :: Maybe ManifestDescription
   , includeFiles :: Maybe (NonEmptyArray NonEmptyString)
   , excludeFiles :: Maybe (NonEmptyArray NonEmptyString)
   , dependencies :: Map PackageName Range

--- a/lib/src/Manifest.purs
+++ b/lib/src/Manifest.purs
@@ -30,6 +30,8 @@ import Data.String.NonEmpty (NonEmptyString)
 import Registry.Internal.Codec as Internal.Codec
 import Registry.License (License)
 import Registry.License as License
+import Registry.LimitedString (LimitedString)
+import Registry.LimitedString as LimitedString
 import Registry.Location (Location)
 import Registry.Location as Location
 import Registry.Owner (Owner)
@@ -50,7 +52,7 @@ newtype Manifest = Manifest
   , location :: Location
   , ref :: String
   , owners :: Maybe (NonEmptyArray Owner)
-  , description :: Maybe String
+  , description :: Maybe (LimitedString 500)
   , includeFiles :: Maybe (NonEmptyArray NonEmptyString)
   , excludeFiles :: Maybe (NonEmptyArray NonEmptyString)
   , dependencies :: Map PackageName Range
@@ -77,7 +79,7 @@ codec = Profunctor.wrapIso Manifest $ CJ.named "Manifest" $ CJ.object
   $ CJ.recordProp @"name" PackageName.codec
   $ CJ.recordProp @"version" Version.codec
   $ CJ.recordProp @"license" License.codec
-  $ CJ.recordPropOptional @"description" (Internal.Codec.limitedString 300)
+  $ CJ.recordPropOptional @"description" LimitedString.codec
   $ CJ.recordProp @"location" Location.codec
   $ CJ.recordProp @"ref" CJ.string
   $ CJ.recordPropOptional @"owners" (CJ.Common.nonEmptyArray Owner.codec)

--- a/lib/src/Metadata.purs
+++ b/lib/src/Metadata.purs
@@ -30,6 +30,8 @@ import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
 import Data.Profunctor as Profunctor
 import Registry.Internal.Codec as Internal.Codec
+import Registry.LimitedString (LimitedString)
+import Registry.LimitedString as LimitedString
 import Registry.Location (Location)
 import Registry.Location as Location
 import Registry.Owner (Owner)
@@ -87,13 +89,13 @@ publishedMetadataCodec = CJ.named "PublishedMetadata" $ CJ.Record.object
 -- | Metadata about an unpublished package version.
 type UnpublishedMetadata =
   { publishedTime :: DateTime
-  , reason :: String
+  , reason :: LimitedString 300
   , unpublishedTime :: DateTime
   }
 
 unpublishedMetadataCodec :: CJ.Codec UnpublishedMetadata
 unpublishedMetadataCodec = CJ.named "UnpublishedMetadata" $ CJ.Record.object
   { publishedTime: Internal.Codec.iso8601DateTime
-  , reason: Internal.Codec.limitedString 300
+  , reason: LimitedString.codec
   , unpublishedTime: Internal.Codec.iso8601DateTime
   }

--- a/lib/src/Operation.purs
+++ b/lib/src/Operation.purs
@@ -48,6 +48,8 @@ import Data.Map (Map)
 import Data.Maybe (Maybe)
 import JSON as JSON
 import Registry.Internal.Codec as Internal.Codec
+import Registry.LimitedString (LimitedString)
+import Registry.LimitedString as LimitedString
 import Registry.Location (Location)
 import Registry.Location as Location
 import Registry.PackageName (PackageName)
@@ -171,7 +173,7 @@ authenticatedCodec = topLevelCodec
 type UnpublishData =
   { name :: PackageName
   , version :: Version
-  , reason :: String
+  , reason :: LimitedString 300
   }
 
 -- | A codec for encoding and decoding an `Unpublish` operation as JSON.
@@ -179,7 +181,7 @@ unpublishCodec :: CJ.Codec UnpublishData
 unpublishCodec = CJ.named "Unpublish" $ CJ.Record.object
   { name: PackageName.codec
   , version: Version.codec
-  , reason: Internal.Codec.limitedString 300
+  , reason: LimitedString.codec
   }
 
 -- | Transfer a package from one location to another. This operation must be

--- a/lib/test/Registry.purs
+++ b/lib/test/Registry.purs
@@ -5,6 +5,7 @@ import Prelude
 import Effect (Effect)
 import Test.Registry.Internal as Test.Internal
 import Test.Registry.License as Test.License
+import Test.Registry.LimitedString as Test.LimitedString
 import Test.Registry.Manifest as Test.Manifest
 import Test.Registry.ManifestIndex as Test.ManifestIndex
 import Test.Registry.Metadata as Test.Metadata
@@ -33,6 +34,7 @@ main = runSpecAndExitProcess [ Spec.Reporter.consoleReporter ] do
     Spec.describe "Version" Test.Version.spec
     Spec.describe "Range" Test.Range.spec
     Spec.describe "License" Test.License.spec
+    Spec.describe "LimitedString" Test.LimitedString.spec
     Spec.describe "Manifest" Test.Manifest.spec
     Spec.describe "Metadata" Test.Metadata.spec
     Spec.describe "Package Set" Test.PackageSet.spec

--- a/lib/test/Registry/LimitedString.purs
+++ b/lib/test/Registry/LimitedString.purs
@@ -1,0 +1,18 @@
+module Test.Registry.LimitedString (spec) where
+
+import Prelude
+
+import Data.Either (Either, isLeft, isRight)
+import Registry.LimitedString (LimitedString)
+import Registry.LimitedString as LimitedString
+import Registry.Test.Assert as Assert
+import Test.Spec (Spec)
+import Test.Spec as Spec
+
+spec :: Spec Unit
+spec = do
+  Spec.it "Parses strings up to the type-level limit" do
+    (LimitedString.parse "abc" :: Either String (LimitedString 3)) `Assert.shouldSatisfy` isRight
+
+  Spec.it "Rejects strings over the type-level limit" do
+    (LimitedString.parse "abcd" :: Either String (LimitedString 3)) `Assert.shouldSatisfy` isLeft

--- a/lib/test/Registry/ManifestIndex.purs
+++ b/lib/test/Registry/ManifestIndex.purs
@@ -24,6 +24,7 @@ import Effect.Exception (Error)
 import JSON as JSON
 import Node.Path as Path
 import Registry.Internal.Codec as Internal.Codec
+import Registry.LimitedString as LimitedString
 import Registry.Location (Location(..))
 import Registry.Manifest (Manifest(..))
 import Registry.ManifestIndex (ManifestIndex)
@@ -72,7 +73,8 @@ spec = do
   Spec.it "Prefers second manifest in the case of duplicate insertion." do
     let
       manifest1 = unsafeManifest "prelude" "1.0.0" []
-      manifest2 = Newtype.over Manifest (_ { description = Just "My prelude description." }) manifest1
+      expectedDescription = Utils.fromRight "Failed to parse manifest description" $ LimitedString.parse "My prelude description."
+      manifest2 = Newtype.over Manifest (_ { description = Just expectedDescription }) manifest1
       index =
         ManifestIndex.insert ManifestIndex.ConsiderRanges manifest1 ManifestIndex.empty
           >>= ManifestIndex.insert ManifestIndex.ConsiderRanges manifest2

--- a/lib/test/Registry/Operation/Validation.purs
+++ b/lib/test/Registry/Operation/Validation.purs
@@ -16,7 +16,7 @@ import Registry.Metadata (Metadata(..))
 import Registry.Operation.Validation (UnpublishError(..), forbiddenModules, getUnresolvedDependencies, validatePursModule, validateUnpublish)
 import Registry.Test.Assert as Assert
 import Registry.Test.Fixtures (defaultHash, defaultLocation)
-import Registry.Test.Utils (fromJust, unsafeDateTime, unsafeManifest, unsafePackageName, unsafeVersion)
+import Registry.Test.Utils (fromJust, unsafeDateTime, unsafeLimitedString, unsafeManifest, unsafePackageName, unsafeVersion)
 import Test.Spec (Spec)
 import Test.Spec as Spec
 
@@ -73,7 +73,7 @@ spec = do
         { location: defaultLocation
         , owners: Nothing
         , published: Map.fromFoldable [ Tuple (unsafeVersion "1.0.0") publishedMetadata ]
-        , unpublished: Map.fromFoldable [ Tuple (unsafeVersion "2.0.0") { publishedTime: outOfRange, unpublishedTime: inRange, reason: "" } ]
+        , unpublished: Map.fromFoldable [ Tuple (unsafeVersion "2.0.0") { publishedTime: outOfRange, unpublishedTime: inRange, reason: unsafeLimitedString "" } ]
         }
 
     Spec.it "Rejects when not yet published" do

--- a/test-utils/src/Registry/Test/Utils.purs
+++ b/test-utils/src/Registry/Test/Utils.purs
@@ -12,6 +12,7 @@ import Data.Either as Either
 import Data.Formatter.DateTime as DateTime.Formatters
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
+import Data.Reflectable (class Reflectable)
 import Data.Tuple (Tuple(..))
 import JSON (JSON)
 import JSON as JSON
@@ -19,6 +20,8 @@ import Partial.Unsafe (unsafeCrashWith)
 import Partial.Unsafe as Partial
 import Registry.Internal.Format as Internal.Format
 import Registry.License as License
+import Registry.LimitedString (LimitedString)
+import Registry.LimitedString as LimitedString
 import Registry.Location (Location(..))
 import Registry.Manifest (Manifest(..))
 import Registry.Metadata (Metadata(..))
@@ -87,6 +90,10 @@ fromJust msg = case _ of
 -- | if the value is a `Left`.
 fromRight :: forall a b. String -> Either a b -> b
 fromRight msg = Either.fromRight' (\_ -> Partial.unsafeCrashWith msg)
+
+-- | Unsafely parse a string with a type-level length limit.
+unsafeLimitedString :: forall limit. Reflectable limit Int => String -> LimitedString limit
+unsafeLimitedString string = fromRight ("Failed to parse LimitedString: " <> string) (LimitedString.parse string)
 
 -- | Unsafely stringify a value by coercing it to `Json` and stringifying it.
 unsafeStringify :: forall a. a -> String


### PR DESCRIPTION
Fixes #773. Manifest descriptions were limited to 300 characters when decoding, but manifests created from `spago.yaml` used the description string directly without validating its length. This allowed the registry to publish a manifest that it could write to the registry index but package managers could not decode, making the affected package unavailable to consumers.

This PR raises the description limit to 500 characters and introduces a `LimitedString` type that tracks its maximum length at the type level. Manifest descriptions now use `LimitedString 500` and are validated when converting from `spago.yaml` or legacy manifests, so an invalid description cannot be written to the index. The existing 300-character unpublish reasons use the same type, replacing the previous decode-only limited string codec.