### PR TITLE
Replace Garnix with GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,34 +32,22 @@ jobs:
           SYSTEM: x86_64-linux
         run: |
           checks=$(nix eval --json ".#checks.$SYSTEM" --apply builtins.attrNames)
-          packages=$(nix eval --json ".#packages.$SYSTEM" --apply builtins.attrNames)
-          dev_shells=$(nix eval --json ".#devShells.$SYSTEM" --apply builtins.attrNames)
 
           matrix=$(jq --compact-output --null-input \
             --arg system "$SYSTEM" \
             --argjson checks "$checks" \
-            --argjson packages "$packages" \
-            --argjson devShells "$dev_shells" \
             '
-              def entries($kind; $prefix; $names):
-                $names | map({
-                  kind: $kind,
-                  name: .,
-                  output: "\($prefix).\($system).\(.)"
-                });
-
               {
-                include: (
-                  entries("check"; "checks"; $checks)
-                  + entries("package"; "packages"; $packages)
-                  + entries("devShell"; "devShells"; $devShells)
-                )
+                include: ($checks | map({
+                  name: .,
+                  output: "checks.\($system).\(.)"
+                }))
               }
             ')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   build:
-    name: ${{ matrix.kind }} ${{ matrix.name }} [x86_64-linux]
+    name: check ${{ matrix.name }} [x86_64-linux]
     needs: evaluate
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   evaluate:
@@ -65,8 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # Avoid throttling GitHub's cache API while still running independent checks in parallel.
-      max-parallel: 4
       matrix: ${{ fromJSON(needs.evaluate.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # Avoid throttling GitHub's cache API while still running independent checks in parallel.
+      max-parallel: 4
       matrix: ${{ fromJSON(needs.evaluate.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  evaluate:
+    name: Evaluate flake
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
+      - run: nix flake show
+      - name: Generate build matrix
+        id: matrix
+        env:
+          SYSTEM: x86_64-linux
+        run: |
+          checks=$(nix eval --json ".#checks.$SYSTEM" --apply builtins.attrNames)
+          packages=$(nix eval --json ".#packages.$SYSTEM" --apply builtins.attrNames)
+          dev_shells=$(nix eval --json ".#devShells.$SYSTEM" --apply builtins.attrNames)
+
+          matrix=$(jq --compact-output --null-input \
+            --arg system "$SYSTEM" \
+            --argjson checks "$checks" \
+            --argjson packages "$packages" \
+            --argjson devShells "$dev_shells" \
+            '
+              def entries($kind; $prefix; $names):
+                $names | map({
+                  kind: $kind,
+                  name: .,
+                  output: "\($prefix).\($system).\(.)"
+                });
+
+              {
+                include: (
+                  entries("check"; "checks"; $checks)
+                  + entries("package"; "packages"; $packages)
+                  + entries("devShell"; "devShells"; $devShells)
+                )
+              }
+            ')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: ${{ matrix.kind }} ${{ matrix.name }} [x86_64-linux]
+    needs: evaluate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.evaluate.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
+      - run: nix build --print-build-logs ".#${{ matrix.output }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,20 +12,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup SSH keys and known_hosts
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
           ssh-add - <<< "${{ secrets.PACCHETTIBOTTI_SSH_KEY }}"
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v4
+        uses: DeterminateSystems/determinate-nix-action@v3
 
       - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v2
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
 
       - name: Deploy with Colmena
         env:

--- a/nix/registry-server.nix
+++ b/nix/registry-server.nix
@@ -76,8 +76,6 @@ in
       gc.automatic = true;
       settings = {
         auto-optimise-store = true;
-        substituters = [ "https://cache.garnix.io" ];
-        trusted-public-keys = [ "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=" ];
       };
     };
 


### PR DESCRIPTION
Garnix CI is done, so I have swapped us over to GitHub Actions:

- replace Garnix with free GitHub Actions CI using Determinate Nix
- derive independent jobs from all `x86_64-linux` flake checks
- remove the retired Garnix cache from the deployed NixOS configuration
- modernize the deployment workflow actions