### PR TITLE
Add indexes for non-primary-key job queries

### DIFF
--- a/db/migrations/20260721231201_add_indexes_for_non_primary_key_queries.sql
+++ b/db/migrations/20260721231201_add_indexes_for_non_primary_key_queries.sql
@@ -1,0 +1,25 @@
+-- migrate:up
+
+-- For duplicate detection in publish jobs
+CREATE INDEX IF NOT EXISTS idx_publish_jobs_name_version
+ON publish_jobs (packageName, packageVersion);
+
+-- For duplicate detection in unpublish jobs
+CREATE INDEX IF NOT EXISTS idx_unpublish_jobs_name_version
+ON unpublish_jobs (packageName, packageVersion);
+
+-- For duplicate detection in transfer jobs
+CREATE INDEX IF NOT EXISTS idx_transfer_jobs_name
+ON transfer_jobs (packageName);
+
+-- For job selection performance
+CREATE INDEX IF NOT EXISTS idx_job_info_pending
+ON job_info (createdAt)
+WHERE finishedAt IS NULL AND startedAt IS NULL;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS idx_publish_jobs_name_version;
+DROP INDEX IF EXISTS idx_unpublish_jobs_name_version;
+DROP INDEX IF EXISTS idx_transfer_jobs_name;
+DROP INDEX IF EXISTS idx_job_info_pending;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -54,9 +54,19 @@ CREATE TABLE logs (
   message TEXT NOT NULL,
   timestamp TEXT NOT NULL
 );
+CREATE INDEX idx_publish_jobs_name_version
+ON publish_jobs (packageName, packageVersion);
+CREATE INDEX idx_unpublish_jobs_name_version
+ON unpublish_jobs (packageName, packageVersion);
+CREATE INDEX idx_transfer_jobs_name
+ON transfer_jobs (packageName);
+CREATE INDEX idx_job_info_pending
+ON job_info (createdAt)
+WHERE finishedAt IS NULL AND startedAt IS NULL;
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20230711143615'),
   ('20230711143803'),
   ('20240914170550'),
-  ('20240914171030');
+  ('20240914171030'),
+  ('20260721231201');


### PR DESCRIPTION
Closes #731 by adding indexes for the non primary-key queries used by job dupe detection and pending job selection:

- `publish_jobs (packageName, packageVersion)`
- `unpublish_jobs (packageName, packageVersion)`
- `transfer_jobs (packageName)`
- `job_info (createdAt)`, restricted to pending jobs

I verified the migration against a fresh SQLite database, including rollback and re-application. `EXPLAIN QUERY PLAN` confirms that SQLite uses each new index for its corresponding query. The regenerated `db/schema.sql` matches dbmate’s generated schema.