### PR TITLE
Fix required fields in publish payload error

### DIFF
--- a/app-e2e/src/Test/E2E/GitHubIssue.purs
+++ b/app-e2e/src/Test/E2E/GitHubIssue.purs
@@ -48,6 +48,7 @@ spec = do
     Spec.it "posts error comment when issue body contains invalid JSON" do
       requests <- runWorkflow Fixtures.invalidJsonIssueEvent
       assertComment "malformed" requests
+      assertComment "Publish: { name, ref, compiler?, version, location?, resolutions? }" requests
       assertOpen requests
 
 -- Constants

--- a/app/src/App/GitHubIssue.purs
+++ b/app/src/App/GitHubIssue.purs
@@ -360,7 +360,7 @@ readOperation eventPath = do
           , ""
           , "Expected one of:"
           , "  - Package set update: { packages, compiler? }"
-          , "  - Publish: { name, ref, compiler, version, location?, resolutions? }"
+          , "  - Publish: { name, ref, compiler?, version, location?, resolutions? }"
           , "  - Authenticated (unpublish/transfer): { payload, signature }"
           ]
 


### PR DESCRIPTION
Closes #749 (the registry-dev portion).

The malformed GitHub issue payload error incorrectly described `compiler` as a required publish field. This updates the advertised payload shape to mark `compiler` as optional while continuing to show `version` as required.

The existing malformed-payload E2E test now asserts the corrected publish payload guidance.

The separate `purescript/registry` README correction described in #749 is implemented in https://github.com/purescript/registry/pull/559