### PR TITLE
Clarify package name character restrictions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -227,9 +227,9 @@ This section contains schemas for `PackageName`, `Version`, `Range`, `Location`,
 
 Packages are uniquely identified by their `PackageName`. No two packages in the registry can share the same name. A package name represented as a `string`, with the following restrictions:
 
-- Must be no more than 50 characters long
-- Must contain only letters and digits, optionally separated by hyphens
-- Must begin with a letter or digit
+- Must be no more than 150 characters long
+- Must contain only lowercase ASCII letters (`a`–`z`) and ASCII digits (`0`–`9`), optionally separated by hyphens
+- Must begin with a lowercase ASCII letter or ASCII digit
 - Cannot contain consecutive hyphens
 - Cannot begin with `purescript-`
 

--- a/lib/src/PackageName.purs
+++ b/lib/src/PackageName.purs
@@ -32,7 +32,6 @@ import Parsing as Parsing
 import Parsing.Combinators as Parsing.Combinators
 import Parsing.Combinators.Array as Parsing.Combinators.Array
 import Parsing.String as Parsing.String
-import Parsing.String.Basic as Parsing.String.Basic
 
 -- | Strip the "purescript-" prefix from a package name, if present.
 -- |
@@ -99,7 +98,9 @@ parser = do
     Parsing.fail prefixErr
 
   let
-    acceptedChars = Parsing.Combinators.choice [ Parsing.String.Basic.lower, Parsing.String.Basic.digit ] <|> Parsing.fail charErr
+    asciiLower = Parsing.String.satisfy \char -> char >= 'a' && char <= 'z'
+    asciiDigit = Parsing.String.satisfy \char -> char >= '0' && char <= '9'
+    acceptedChars = Parsing.Combinators.choice [ asciiLower, asciiDigit ] <|> Parsing.fail charErr
     chunk1 = Parsing.Combinators.Array.many1 acceptedChars
 
   -- A "chunk" is a lowercase alphanumeric word delimited by dashes

--- a/lib/test/Registry/PackageName.purs
+++ b/lib/test/Registry/PackageName.purs
@@ -61,6 +61,9 @@ valid =
 
   -- blessed purescript-prefixed packages
   , "purescript-compiler-backend-utilities"
+
+  -- maximum-length package name
+  , String.joinWith "" $ Array.replicate 150 "a"
   ]
 
 invalid :: Array (Tuple String String)
@@ -70,15 +73,24 @@ invalid = do
   let prefixErr = "Package names should not begin with 'purescript-'"
   let endErr = "Package name should end with a lower case char or digit"
   let manyDashesErr = "Package names cannot contain consecutive dashes"
+  let lengthErr = "Package name cannot be longer than 150 characters"
   let expectedEOF = "Expected EOF"
 
   [ "-a" /\ startErr
   , "double--dash" /\ manyDashesErr
+  , "Uppercase" /\ startErr
   , "BIGLETTERS" /\ startErr
+  , "upperCase" /\ midErr
+  , "éclair" /\ startErr
+  , "café" /\ midErr
+  , "β-reduction" /\ startErr
+  , "١package" /\ startErr
+  , "package١" /\ midErr
   , "some space" /\ midErr
   , "a-" /\ endErr
   , "" /\ startErr
   , "🍝" /\ startErr
   , "abc-🍝-abc" /\ expectedEOF
   , "purescript-aff" /\ prefixErr
+  , String.joinWith "" (Array.replicate 151 "a") /\ lengthErr
   ]


### PR DESCRIPTION
Closes #682.

Package names are now explicitly documented as using lowercase ASCII letters (`a`–`z`) and ASCII digits (`0`–`9`).

`Parsing.String.Basic.lower` and `digit` are Unicode-aware, so the implementation previously accepted names such as `éclair` and `β-reduction`. The parser now checks the ASCII ranges directly.

The package-name tests now cover:

- Uppercase ASCII letters
- Non-ASCII letters and digits
- The maximum-length boundary

This also resolves the spec’s 50-vs-150 discrepancy in favor of 150 characters. The original 50-character limit was raised intentionally in #689 to support real Spago workspace names, but `SPEC.md` was not updated.
