### PR TITLE
Add job IDs to registry commit messages

### DIFF
--- a/app-e2e/src/Test/E2E/Scripts.purs
+++ b/app-e2e/src/Test/E2E/Scripts.purs
@@ -174,7 +174,8 @@ setupScript = do
   let
     registryEnv :: Registry.RegistryEnv
     registryEnv =
-      { pull: Git.Autostash
+      { jobId: Nothing
+      , pull: Git.Autostash
       , write: Registry.ReadOnly
       , repos: Registry.defaultRepos
       , workdir: Path.concat [ stateDir, "scratch" ]

--- a/app/src/App/Effect/Registry.purs
+++ b/app/src/App/Effect/Registry.purs
@@ -21,6 +21,7 @@ import Effect.Ref as Ref
 import JSON as JSON
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
+import Registry.API.V1 (JobId)
 import Registry.App.CLI.Git (GitResult)
 import Registry.App.CLI.Git as Git
 import Registry.App.Effect.Cache (class MemoryEncodable, Cache, CacheRef, MemoryEncoding(..))
@@ -184,7 +185,8 @@ data WriteMode = ReadOnly | CommitAs Git.Committer
 derive instance Eq WriteMode
 
 type RegistryEnv =
-  { repos :: Repos
+  { jobId :: Maybe JobId
+  , repos :: Repos
   , workdir :: FilePath
   , pull :: Git.PullMode
   , write :: WriteMode
@@ -672,12 +674,13 @@ handle env = Cache.interpret _registryCache (Cache.handleMemory env.cacheRef) <<
     let repoKey = commitKeyToRepoKey commitKey
     let address = repoAddress repoKey
     let formatted = address.owner <> "/" <> address.repo
+    let messageWithJobId = appendJobIdToCommitMessage env.jobId message
     case env.write of
       ReadOnly -> do
         Log.info $ "Skipping commit to repo " <> formatted <> " because write mode is 'ReadOnly'."
         pure $ Right Git.NoChange
       CommitAs committer -> do
-        result <- Git.gitCommit { committer, address, commit: commitKeyToPaths commitKey, message } (repoPath repoKey)
+        result <- Git.gitCommit { committer, address, commit: commitKeyToPaths commitKey, message: messageWithJobId } (repoPath repoKey)
         pure result
 
   -- | Push the repository at the given key, recording whether the push had any
@@ -738,6 +741,11 @@ handle env = Cache.interpret _registryCache (Cache.handleMemory env.cacheRef) <<
             "Failed to push tags in local checkout " <> cwd <> ": " <> error
           if String.contains (String.Pattern "Everything up-to-date") output then pure Git.NoChange else pure Git.Changed
         pure result
+
+appendJobIdToCommitMessage :: Maybe JobId -> String -> String
+appendJobIdToCommitMessage maybeJobId message = case maybeJobId of
+  Nothing -> message
+  Just jobId -> message <> "\n\nJob ID: " <> unwrap jobId
 
 -- | Given the file path of a local manifest index on disk, read its contents.
 readManifestIndexFromDisk :: forall r. FilePath -> Run (LOG + EXCEPT String + AFF + EFFECT + r) ManifestIndex

--- a/app/src/App/Effect/Registry.purs
+++ b/app/src/App/Effect/Registry.purs
@@ -670,17 +670,18 @@ handle env = Cache.interpret _registryCache (Cache.handleMemory env.cacheRef) <<
 
   -- | Commit the file(s) indicated by the commit key with a commit message.
   commit :: CommitKey -> String -> Run _ (Either String GitResult)
-  commit commitKey message = do
-    let repoKey = commitKeyToRepoKey commitKey
-    let address = repoAddress repoKey
-    let formatted = address.owner <> "/" <> address.repo
-    let messageWithJobId = appendJobIdToCommitMessage env.jobId message
+  commit commitKey message' = do
+    let
+      repoKey = commitKeyToRepoKey commitKey
+      address = repoAddress repoKey
+      formatted = address.owner <> "/" <> address.repo
+      message = appendJobIdToCommitMessage env.jobId message'
     case env.write of
       ReadOnly -> do
         Log.info $ "Skipping commit to repo " <> formatted <> " because write mode is 'ReadOnly'."
         pure $ Right Git.NoChange
       CommitAs committer -> do
-        result <- Git.gitCommit { committer, address, commit: commitKeyToPaths commitKey, message: messageWithJobId } (repoPath repoKey)
+        result <- Git.gitCommit { committer, address, commit: commitKeyToPaths commitKey, message } (repoPath repoKey)
         pure result
 
   -- | Push the repository at the given key, recording whether the push had any

--- a/app/src/App/Server/Env.purs
+++ b/app/src/App/Server/Env.purs
@@ -147,7 +147,8 @@ runEffects env operation = Aff.attempt do
     # PackageSets.interpret (PackageSets.handle { workdir: scratchDir })
     # Registry.interpret
         ( Registry.handle
-            { repos: Registry.defaultRepos
+            { jobId: env.jobId
+            , repos: Registry.defaultRepos
             , pull: Git.ForceClean
             , write: writeMode
             , workdir: scratchDir

--- a/app/test/App/Effect/Registry.purs
+++ b/app/test/App/Effect/Registry.purs
@@ -6,6 +6,7 @@ import Data.Map as Map
 import Effect.Aff as Aff
 import Effect.Ref as Ref
 import Node.Path as Path
+import Registry.API.V1 (JobId(..))
 import Registry.App.CLI.Git as Git
 import Registry.App.Effect.Cache as Cache
 import Registry.App.Effect.GitHub (GITHUB, GitHub)
@@ -29,6 +30,12 @@ import Test.Spec as Spec
 
 spec :: Spec.Spec Unit
 spec = do
+  Spec.it "appends the executing job ID to commit messages" do
+    let message = "Update metadata for prelude"
+    Registry.appendJobIdToCommitMessage Nothing message `Assert.shouldEqual` message
+    Registry.appendJobIdToCommitMessage (Just (JobId "job-123")) message `Assert.shouldEqual`
+      "Update metadata for prelude\n\nJob ID: job-123"
+
   -- This test exercises the Registry.handle to verify that readMetadata does
   -- not poison the AllMetadata cache: i.e. a single-package read must not seed
   -- the cache with a singleton map that readAllMetadata would mistake for the
@@ -63,7 +70,8 @@ spec = do
       cacheRef <- liftEffect Cache.newCacheRef
       let
         env =
-          { repos:
+          { jobId: Nothing
+          , repos:
               { registry: { owner: "test", repo: "test" }
               , manifestIndex: { owner: "test", repo: "test" }
               , legacyPackageSets: { owner: "test", repo: "test" }

--- a/scripts/src/DailyImporter.purs
+++ b/scripts/src/DailyImporter.purs
@@ -89,7 +89,8 @@ main = launchAff_ do
   let
     registryEnv :: Registry.RegistryEnv
     registryEnv =
-      { pull: Git.Autostash
+      { jobId: Nothing
+      , pull: Git.Autostash
       , write: Registry.ReadOnly
       , repos: Registry.defaultRepos
       , workdir: scratchDir

--- a/scripts/src/PackageSetUpdater.purs
+++ b/scripts/src/PackageSetUpdater.purs
@@ -87,7 +87,8 @@ main = launchAff_ do
   let
     registryEnv :: Registry.RegistryEnv
     registryEnv =
-      { pull: Git.Autostash
+      { jobId: Nothing
+      , pull: Git.Autostash
       , write: Registry.ReadOnly
       , repos: Registry.defaultRepos
       , workdir: scratchDir

--- a/scripts/src/PackageTransferrer.purs
+++ b/scripts/src/PackageTransferrer.purs
@@ -92,7 +92,8 @@ main = launchAff_ do
   let
     registryEnv :: Registry.RegistryEnv
     registryEnv =
-      { pull: Git.Autostash
+      { jobId: Nothing
+      , pull: Git.Autostash
       , write: Registry.ReadOnly
       , repos: Registry.defaultRepos
       , workdir: scratchDir

--- a/scripts/src/VerifyIntegrity.purs
+++ b/scripts/src/VerifyIntegrity.purs
@@ -67,7 +67,8 @@ main = launchAff_ do
   let
     registryEnv :: Registry.RegistryEnv
     registryEnv =
-      { write: Registry.ReadOnly
+      { jobId: Nothing
+      , write: Registry.ReadOnly
       , pull: Git.Autostash
       , repos: Registry.defaultRepos
       , workdir: scratchDir


### PR DESCRIPTION
Commit messages produced by jobs now end with:

```text
Job ID: <job-id>
```

This makes it possible to identify which registry job produced a commit in the registry, registry-index, or legacy package-sets repository.

Closes #743.