### PR TITLE
Implement registry version check script

### DIFF
--- a/.github/workflows/package-set-version-check.yml
+++ b/.github/workflows/package-set-version-check.yml
@@ -1,0 +1,55 @@
+name: Package set version check
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: package-set-version-check
+  cancel-in-progress: false
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    # Planning performs at most 100 incremental compile probes against the
+    # package set, each of which downloads and compiles the proposed set.
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
+
+      - name: Generate compile-verified version check report
+        run: nix run .#package-set-version-checker -- --output version-check.md
+
+      - name: Upload report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-set-version-check
+          path: version-check.md
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Open report issue
+        # The checker exits successfully without writing a report when there
+        # is no package set to check, so only open an issue when the report
+        # file exists.
+        if: ${{ hashFiles('version-check.md') != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --title "Package set version check ($(date --utc +%Y-%m-%d))" \
+            --body-file version-check.md

--- a/SPEC.md
+++ b/SPEC.md
@@ -784,7 +784,7 @@ A package set update is an object with two keys: `compiler`, an optional field t
 ```jsonc
 { // Sets the package set compiler version to 0.15.2
   "compiler": "0.15.2",
-  "packages" {
+  "packages": {
     // Updates the `aff` package to v8.0.0
     "aff": "8.0.0",
     // Removes the `argonaut` package from the package sets altogether
@@ -812,13 +812,15 @@ The suggested new package set can only be released if:
 1. All packages in the set depend only on other packages in the set
 2. All packages in the set can be compiled together
 
+Package set self-containment concerns dependency names, not the version ranges in package manifests. Every dependency name must occur in the package set, but its manifest range need not include the exact version selected by the set. Compiling the exact package versions in the set with the set's exact compiler version is the authoritative validity check.
+
 To verify the package set, we take the following steps:
 
-1. We apply the suggested changes to the package set and verify that the package set is still self-contained. If not, the update is rejected.
+1. We apply all suggested changes to the package set as one exact batch and verify that the package set is still self-contained. If not, the update is rejected.
 2. We install the previous package set and compile it. This ensures we are beginning from a known good state.
 3. We install the new package set (uninstalling any packages that are removed) and compile the package set again. If compilation fails then the update is rejected.
 
-When we have verified the package set is self-contained and all packages compile together then we can release the package set.
+When we have verified the package set is self-contained and all packages compile together then we can release the package set. A submitted package set update is atomic: either its entire exact payload is released or it fails without releasing a subset.
 
 ##### Releasing the Package Set
 
@@ -874,27 +876,25 @@ If documentation publishing fails (for example, due to a transient network error
 
 #### 6.3 Publish to Package Sets
 
-The registry attempts to produce a new package set automatically every day, so long as packages have been uploaded that could be added or updated. No packages are ever dropped from a package set automatically; the only time packages are dropped from the package sets are during manual releases.
+The registry attempts to produce a new package set automatically every day when eligible package versions exist. The latest package set and its compiler version are the starting point for every automatic plan.
 
-Every day, the registry executes the following steps:
+Newer registry versions of packages already in the package set remain candidates until they are included or superseded by the package set itself. They do not cease to be candidates merely because an automatic run could not include them or because time has passed since publication. An automatic plan may coordinate upgrades to several packages and may select an intermediate newer version instead of only the latest release when that produces a valid set.
 
-First, we read the contents of the latest package set release and gather all package versions that have been uploaded to the registry since that release. These package versions are the "batch" of packages that we are considering for automatic inclusion to the next package set.
+Packages absent from the latest package set are proposed as additions while they are recent uploads. The candidate set is recursively expanded with any dependency names absent from the current package set so the planner can consider a self-contained plan; these dependencies are included whenever they were published, but they enter the released set only when a selected upgrade or addition actually requires them.
 
-Second, we filter out any packages where, based on their metadata and manifest files alone, we know they can't be added to the package set. This happens for one of three reasons:
+Every automatic plan must satisfy these constraints:
 
-1. They have a dependency that is neither in the package sets nor in the batch that is up for consideration
-2. They have had multiple releases since the last package set, in which case we only take the highest version
-3. They already have a higher version published in a previous package set
+1. It does not remove a package.
+2. It does not downgrade a package.
+3. It does not change the compiler version.
+4. Every dependency name in the resulting set occurs in that set. Manifest version ranges are ignored for this self-containment check.
+5. The exact resulting package set compiles as a whole with the unchanged, exact compiler version.
 
-Third, we attempt to add the rest of the batch of package versions to the package set. Processing the batch follows these steps:
+The whole-set compiler result is authoritative: manifest version ranges do not prevent an exact selection from being a valid package set, and manifest compatibility alone does not prove that a selection is valid. Each selected plan is submitted and released as one exact atomic package set update according to [Section 5.5 (Update the Package Set)](#55-update-the-package-set).
 
-1. We install the previous package set and compile it.
-2. We attempt to upgrade all package versions from the batch at once in the package set. Once the new versions are installed, we compile the package set. If it succeeds, then we're done.
-3. If we couldn't compile the whole batch, then we order the batch first by their dependencies and then by their upload time. Packages with no dependencies on other packages in the batch go first, and ties are broken by upload time: older uploads go first. Then, we attempt to add packages to the package set one-by-one.
-4. If a package fails to compile with the rest of the package set, then it is filtered from the batch.
-5. Once there are no more packages to consider in the batch, the new package set is ready.
+If an otherwise desirable upgrade requires removing packages, it is not an automatic plan. Registry Trustees handle such cases using the manual intervention process in [Section 9.5 (Package Sets)](#manual-intervention-in-the-package-sets-via-the-package-sets-api).
 
-Fourth, we release the new package set (if we could produce one). Automatic package sets follow the versioning policy described in [Section 5.5 (Update the Package Set)](#releasing-the-package-set).
+The automation reports residual upgrades it could not apply, including compiler evidence. It may report an exact removal-containing payload as compile-verified only after compiling that full payload against the package set it was planned from. Such payloads are advisory and are never submitted automatically; a Registry Trustee must decide whether to apply them. Infrastructure failures and bounded searches must be reported distinctly from package incompatibility.
 
 ## 7. Non-JavaScript Backends
 

--- a/app-e2e/src/Test/E2E/Scripts.purs
+++ b/app-e2e/src/Test/E2E/Scripts.purs
@@ -20,7 +20,10 @@ import Registry.App.Effect.Cache as Cache
 import Registry.App.Effect.Env as Env
 import Registry.App.Effect.GitHub as GitHub
 import Registry.App.Effect.Log as Log
+import Registry.App.Effect.PackageSets as PackageSets
 import Registry.App.Effect.Registry as Registry
+import Registry.App.Effect.Storage as Storage
+import Registry.Foreign.FSExtra as FS.Extra
 import Registry.Foreign.Octokit as Octokit
 import Registry.Location (Location(..))
 import Registry.Operation (AuthenticatedPackageOperation(..))
@@ -140,19 +143,20 @@ spec = do
       jobs <- Client.getJobs
       let packageSetJobs = Array.filter isPackageSetJob jobs
       case Array.head packageSetJobs of
-        Just (PackageSetJob { payload }) ->
-          case payload of
-            Operation.PackageSetUpdate { packages } ->
-              case Map.lookup typeEqualityName packages of
-                Just (Just _) -> pure unit
-                _ -> Assert.fail "Expected type-equality in package set update"
+        Just (PackageSetJob { payload }) -> do
+          let Operation.PackageSetUpdate { packages } = payload
+          case Map.lookup typeEqualityName packages of
+            Just (Just _) -> pure unit
+            _ -> Assert.fail "Expected type-equality in package set update"
         Just _ -> Assert.fail "Expected PackageSetJob but got different job type"
         Nothing -> Assert.fail "Expected package set job to be enqueued"
 
 -- | Common environment for running read-only registry scripts in E2E tests
 type RegistryScriptSetup =
-  { resourceEnv :: Env.ResourceEnv
+  { cache :: FilePath
+  , resourceEnv :: Env.ResourceEnv
   , registryEnv :: Registry.RegistryEnv
+  , workdir :: FilePath
   }
 
 type GitHubScriptSetup =
@@ -171,6 +175,9 @@ setupRegistryScript = do
   resourceEnv <- liftEffect Env.lookupResourceEnv
   registryCacheRef <- liftAff Cache.newCacheRef
   debouncer <- liftAff Registry.newDebouncer
+  let workdir = Path.concat [ stateDir, "scratch" ]
+  let cache = Path.concat [ workdir, ".cache" ]
+  liftAff $ FS.Extra.ensureDirectory cache
   let
     registryEnv :: Registry.RegistryEnv
     registryEnv =
@@ -178,11 +185,11 @@ setupRegistryScript = do
       , pull: Git.Autostash
       , write: Registry.ReadOnly
       , repos: Registry.defaultRepos
-      , workdir: Path.concat [ stateDir, "scratch" ]
+      , workdir
       , debouncer
       , cacheRef: registryCacheRef
       }
-  pure { resourceEnv, registryEnv }
+  pure { cache, resourceEnv, registryEnv, workdir }
 
 setupGitHubScript :: E2E GitHubScriptSetup
 setupGitHubScript = do
@@ -229,12 +236,15 @@ runPackageTransferrerScript = do
 -- | Run the PackageSetUpdater script in Submit mode
 runPackageSetUpdaterScript :: E2E Unit
 runPackageSetUpdaterScript = do
-  { resourceEnv, registryEnv } <- setupRegistryScript
+  { cache, resourceEnv, registryEnv, workdir } <- setupRegistryScript
   result <- liftAff
     $ PackageSetUpdater.runPackageSetUpdater PackageSetUpdater.Submit resourceEnv.registryApiUrl
+    # PackageSets.interpret (PackageSets.handle { workdir })
     # Except.runExcept
     # Registry.interpretRead (Registry.handleRead registryEnv)
+    # Storage.interpret (Storage.handleReadOnly cache)
     # Log.interpret (Log.handleTerminal Quiet)
+    # Env.runResourceEnv resourceEnv
     # Run.runBaseAff'
   case result of
     Left err -> liftAff $ Aff.throwError $ Aff.error $ "PackageSetUpdater failed: " <> err

--- a/app/src/App/API.purs
+++ b/app/src/App/API.purs
@@ -153,7 +153,7 @@ packageSetUpdate :: forall r. PackageSetJobData -> Run (PackageSetUpdateEffects 
 packageSetUpdate details = do
   let Operation.PackageSetUpdate payload = details.payload
 
-  Log.debug $ "Package set update job starting with payload:\n" <> stringifyJson Operation.packageSetUpdateCodec payload
+  Log.debug $ "Package set update job starting with payload:\n" <> stringifyJson Operation.packageSetOperationCodec details.payload
 
   latestPackageSet <- Registry.readLatestPackageSet >>= case _ of
     Nothing -> do
@@ -225,18 +225,13 @@ packageSetUpdate details = do
 
   let changeSet = candidates.accepted <#> maybe Remove Update
   Log.notice "Attempting to build package set update."
-  PackageSets.upgradeSequential latestPackageSet (fromMaybe prevCompiler payload.compiler) changeSet >>= case _ of
-    Nothing ->
-      Except.throw "No packages could be added to the package set. All packages failed to compile."
-    Just { failed, succeeded, result: packageSet } -> do
-      unless (Map.isEmpty failed) do
-        let
-          formatFailed = String.joinWith "\n" $ Array.catMaybes $ flip map (Map.toUnfoldable failed) \(Tuple name change) ->
-            case change of
-              PackageSets.Update version -> Just $ "  - " <> formatPackageVersion name version
-              PackageSets.Remove -> Nothing
-        Log.warn $ "Some packages could not be added to the set:\n" <> formatFailed
-      let commitMessage = PackageSets.commitMessage latestPackageSet succeeded (un PackageSet packageSet).version
+  -- A submitted payload is exact. Sequential probing is useful for planning,
+  -- but must not turn this operation into a partial release.
+  PackageSets.upgradeAtomic latestPackageSet (fromMaybe prevCompiler payload.compiler) changeSet >>= case _ of
+    Left error ->
+      Except.throw $ "Package set update failed to compile atomically. No changes were published.\n\n" <> error
+    Right packageSet -> do
+      let commitMessage = PackageSets.commitMessage latestPackageSet changeSet (un PackageSet packageSet).version
       Registry.writePackageSet packageSet commitMessage
       Log.notice "Built and released a new package set! Now mirroring to the package-sets repo..."
       Registry.mirrorPackageSet packageSet

--- a/app/src/App/Effect/PackageSets.purs
+++ b/app/src/App/Effect/PackageSets.purs
@@ -1,6 +1,5 @@
--- | An effect for upgrading package sets, either in batch mode (all suggested
--- | changes must go in together) or in sequential mode (as many changes as
--- | possible will be added, and changes that would break the set are recorded.)
+-- | An effect for upgrading package sets atomically: all suggested changes
+-- | must compile together or the upgrade is rejected as a whole.
 module Registry.App.Effect.PackageSets where
 
 import Registry.App.Prelude
@@ -15,7 +14,6 @@ import Data.Monoid as Monoid
 import Data.Set as Set
 import Data.String as String
 import Data.Tuple (uncurry)
-import Effect.Ref as Ref
 import Node.FS.Aff as FS.Aff
 import Node.FS.Sync as FS.Sync
 import Node.Path as Path
@@ -44,15 +42,7 @@ derive instance Eq Change
 
 type ChangeSet = Map PackageName Change
 
-type SequentialUpgradeResult =
-  { failed :: ChangeSet
-  , succeeded :: ChangeSet
-  , result :: PackageSet
-  }
-
-data PackageSets a
-  = UpgradeAtomic PackageSet Version ChangeSet (Either String (Either String PackageSet) -> a)
-  | UpgradeSequential PackageSet Version ChangeSet (Either String (Maybe SequentialUpgradeResult) -> a)
+data PackageSets a = UpgradeAtomic PackageSet Version ChangeSet (Either String (Either String PackageSet) -> a)
 
 derive instance Functor PackageSets
 
@@ -67,15 +57,6 @@ _packageSets = Proxy
 -- | unsuccessful changes are returned.
 upgradeAtomic :: forall r. PackageSet -> Version -> ChangeSet -> Run (PACKAGE_SETS + EXCEPT String + r) (Either String PackageSet)
 upgradeAtomic oldSet compiler changes = Run.lift _packageSets (UpgradeAtomic oldSet compiler changes identity) >>= Except.rethrow
-
--- | Upgrade the given package set using the provided compiler version and set
--- | of changes. Any successful change is applied, and any unsuccessful changes
--- | are returned along with the new package set.
-upgradeSequential :: forall r. PackageSet -> Version -> ChangeSet -> Run (PACKAGE_SETS + EXCEPT String + r) (Maybe SequentialUpgradeResult)
-upgradeSequential oldSet compiler changes = do
-  upgradeAtomic oldSet compiler changes >>= case _ of
-    Left _ -> Run.lift _packageSets (UpgradeSequential oldSet compiler changes identity) >>= Except.rethrow
-    Right result -> pure $ Just { failed: Map.empty, succeeded: changes, result }
 
 interpret :: forall r a. (PackageSets ~> Run r) -> Run (PACKAGE_SETS + r) a -> Run r a
 interpret handler = Run.interpret (Run.on _packageSets handler Run.send)
@@ -136,55 +117,6 @@ handle env = case _ of
         newSet <- updatePackageSetMetadata compiler { previous: oldSet, pending } changes
         validatePackageSet newSet
         pure (Right newSet)
-
-  UpgradeSequential oldSet@(PackageSet { packages }) compiler changes reply -> reply <$> Except.runExcept do
-    Log.info $ "Performing sequential upgrade of package set " <> Version.print (un PackageSet oldSet).version
-    index <- Registry.readAllManifests
-
-    let sortedBatch = orderChanges index packages changes
-
-    failRef <- Run.liftEffect $ Ref.new Map.empty
-    successRef <- Run.liftEffect $ Ref.new Map.empty
-    packageSetRef <- Run.liftEffect $ Ref.new oldSet
-
-    for_ sortedBatch \(Tuple name change) -> do
-      currentSet <- Run.liftEffect $ Ref.read packageSetRef
-      attemptPackage compiler currentSet name change >>= case _ of
-        -- If the package could not be processed, then the state of the
-        -- filesystem is rolled back by attemptPackage. We just need to insert
-        -- the package into the failures map.
-        Left compilerError -> do
-          Run.liftEffect $ Ref.modify_ (Map.insert name change) failRef
-          Log.warn $ case change of
-            Remove -> "Could not remove " <> PackageName.print name
-            Update version -> "Could not add or update " <> formatPackageVersion name version
-          case compilerError of
-            MissingCompiler -> Except.throw $ printMissingCompiler compiler
-            UnknownError error -> Except.throw $ printUnknownError error
-            CompilationError errors -> Log.info $ printCompilationError errors
-
-        -- If the package could be processed, then the state of the filesystem
-        -- is stepped and we need to record the success of this package and
-        -- step the package set in memory for the next package.
-        Right newSet -> do
-          Log.debug "Writing successful result and new package set to refs."
-          Run.liftEffect do
-            Ref.modify_ (Map.insert name change) successRef
-            Ref.write newSet packageSetRef
-          Log.info $ case change of
-            Remove -> "Removed " <> PackageName.print name
-            Update version -> "Added or updated " <> formatPackageVersion name version
-
-    failed <- Run.liftEffect $ Ref.read failRef
-    succeeded <- Run.liftEffect $ Ref.read successRef
-    pending <- Run.liftEffect $ Ref.read packageSetRef
-
-    case Map.size succeeded of
-      0 -> pure $ Nothing
-      _ -> do
-        newSet <- updatePackageSetMetadata compiler { previous: oldSet, pending } succeeded
-        validatePackageSet newSet
-        pure $ Just { failed, succeeded, result: newSet }
 
   where
   packagesWorkDir :: FilePath
@@ -296,36 +228,6 @@ handle env = case _ of
             Update version -> Map.insert name version existingSet
           newSet = foldlWithIndex foldFn set.packages changes
         pure $ Right $ PackageSet $ set { packages = newSet }
-
-  -- Attempt to add, update, or remove a package in the package set. This
-  -- operation will be rolled back if the addition fails.
-  --
-  -- NOTE: You must have previously built a package set.
-  attemptPackage :: Version -> PackageSet -> PackageName -> Change -> Run _ (Either CompilerFailure PackageSet)
-  attemptPackage compiler (PackageSet set) package change = do
-    FS.Extra.copy { from: outputWorkDir, to: backupWorkDir, preserveTimestamps: true }
-    let maybeOldVersion = Map.lookup package set.packages
-    for_ maybeOldVersion (removePackage package)
-    case change of
-      Remove -> pure unit
-      Update version -> installPackage package version
-    compileInstalledPackages compiler >>= case _ of
-      Left err -> do
-        Log.info $ case change of
-          Remove -> "Failed to build set without " <> PackageName.print package
-          Update version -> "Failed to build set with " <> formatPackageVersion package version
-        FS.Extra.remove outputWorkDir
-        FS.Extra.copy { from: backupWorkDir, to: outputWorkDir, preserveTimestamps: true }
-        case change of
-          Remove -> pure unit
-          Update version -> removePackage package version
-        for_ maybeOldVersion (installPackage package)
-        pure $ Left err
-      Right _ -> do
-        FS.Extra.remove backupWorkDir
-        pure $ Right $ PackageSet $ case change of
-          Remove -> set { packages = Map.delete package set.packages }
-          Update version -> set { packages = Map.insert package version set.packages }
 
 -- | Computes commit mesage for new package set publication.
 -- | Note: The `PackageSet` argument is the old package set.
@@ -598,31 +500,3 @@ updatePackageSetMetadata compiler { previous, pending: PackageSet pending } chan
   let version = computeNewVersion compiler previous changes
   pure $ PackageSet (pending { compiler = compiler, version = version, published = DateTime.date now })
 
--- | Order a set of changes for sequential processing. Updates are processed in
--- | topological order (dependencies first), then removals are processed in
--- | reverse topological order (dependents first). This ensures:
--- | 1. Dependencies are updated before their dependents
--- | 2. Dependents are removed before their dependencies
--- |
--- | Updates are processed before removals because updates can enable removals
--- | (by removing dependencies on packages being removed), but removals never
--- | enable updates. For example, if A depends on B and both are in the change
--- | set where A is updated (to no longer depend on B) and B is removed, then
--- | A must be updated first so B's removal doesn't fail due to A's dependency.
-orderChanges :: ManifestIndex -> Map PackageName Version -> ChangeSet -> Array (Tuple PackageName Change)
-orderChanges index packages changes = sortedUpdates <> sortedRemovals
-  where
-  sortedPackages = ManifestIndex.toSortedArray ManifestIndex.IgnoreRanges index
-
-  -- Updates should be processed in topological order (dependencies first)
-  -- so that dependencies are updated before their dependents.
-  sortedUpdates = sortedPackages # Array.mapMaybe \(Manifest { name, version }) -> case Map.lookup name changes of
-    Just (Update updateVersion) | version == updateVersion -> Just (Tuple name (Update version))
-    _ -> Nothing
-
-  -- Removals should be processed in reverse topological order (dependents
-  -- first) so that dependents are removed before their dependencies.
-  sortedRemovals = sortedPackages # Array.reverse # Array.mapMaybe \(Manifest { name, version }) ->
-    case Map.lookup name changes, Map.lookup name packages of
-      Just Remove, Just prevVersion | version == prevVersion -> Just (Tuple name Remove)
-      _, _ -> Nothing

--- a/app/src/App/GitHubIssue.purs
+++ b/app/src/App/GitHubIssue.purs
@@ -41,7 +41,7 @@ import Registry.Foreign.JsonRepair as JsonRepair
 import Registry.Foreign.Octokit (GitHubToken, IssueNumber(..), Octokit)
 import Registry.Foreign.Octokit as Octokit
 import Registry.Internal.Format as Internal.Format
-import Registry.Operation (AuthenticatedData, AuthenticatedPackageOperation(..), PackageOperation(..), PackageSetOperation(..))
+import Registry.Operation (AuthenticatedData, AuthenticatedPackageOperation(..), PackageOperation(..), PackageSetOperation)
 import Registry.Operation as Operation
 import Run (AFF, EFFECT, Run)
 import Run as Run
@@ -86,9 +86,9 @@ runGitHubIssue env = do
   run do
     -- Determine endpoint and prepare the JSON payload
     { endpoint, jsonBody } <- case env.operation of
-      Left packageSetOp@(PackageSetUpdate payload) -> do
+      Left packageSetOp -> do
         -- Sign with pacchettibotti if submitter is a trustee
-        request <- signPackageSetIfTrustee packageSetOp payload
+        request <- signPackageSetIfTrustee packageSetOp
         pure
           { endpoint: "/v1/package-sets"
           , jsonBody: JSON.print $ CJ.encode Operation.packageSetUpdateRequestCodec request
@@ -366,7 +366,7 @@ readOperation eventPath = do
       let keys = CJ.Object.keys object
       let hasKeys = all (flip Array.elem keys)
       if hasKeys [ "packages" ] then
-        map (Left <<< PackageSetUpdate) (CJ.decode Operation.packageSetUpdateCodec json)
+        map Left (CJ.decode Operation.packageSetOperationCodec json)
       else if hasKeys [ "name", "ref", "version" ] then
         map (Right <<< Publish) (CJ.decode Operation.publishCodec json)
       else if hasKeys [ "payload", "signature" ] then
@@ -473,10 +473,9 @@ signPacchettiBottiIfTrustee auth = do
 signPackageSetIfTrustee
   :: forall r
    . PackageSetOperation
-  -> Operation.PackageSetUpdateData
   -> Run (GITHUB + PACCHETTIBOTTI_ENV + GITHUB_EVENT_ENV + LOG + EXCEPT String + r) Operation.PackageSetUpdateRequest
-signPackageSetIfTrustee packageSetOp payload = do
-  let rawPayload = JSON.print $ CJ.encode Operation.packageSetUpdateCodec payload
+signPackageSetIfTrustee packageSetOp = do
+  let rawPayload = JSON.print $ CJ.encode Operation.packageSetOperationCodec packageSetOp
   GitHub.listTeamMembers API.packagingTeam >>= case _ of
     Left githubError -> do
       Log.warn $ Array.fold

--- a/app/src/App/PackageSetPlanner.purs
+++ b/app/src/App/PackageSetPlanner.purs
@@ -1,0 +1,480 @@
+-- | Compile-guided planning for package set updates.
+-- |
+-- | The planner probes root selections — packages already in the set plus
+-- | proposed additions, each closed over the absent dependencies it requires
+-- | — by compiling the whole package set, and repairs failures greedily:
+-- |
+-- |  1. Probe every root at its latest version.
+-- |  2. On failure, parse the failing packages out of the compiler output and
+-- |     drop the implicated roots, then retry. Every retry drops at least
+-- |     one root, so this terminates.
+-- |  3. Retry each dropped root individually against the accepted payload,
+-- |     latest version first and then older pending versions round-robin.
+-- |     Step 2 may drop more roots than strictly necessary, and a root whose
+-- |     latest version is incompatible may still have an intermediate one.
+-- |  4. Probe still-blocked roots one interaction component at a time,
+-- |     promoting coordinated groups that only compile together.
+-- |
+-- | The returned `verified` payload is always exactly the change set accepted
+-- | by its most recent successful whole-set compile probe, so it is safe to
+-- | submit as an atomic package set update. Greedy repair is not guaranteed
+-- | to find a maximal payload; whatever it cannot include is reported in
+-- | `blocked` with compiler evidence.
+-- |
+-- | Blocked groups can then be analyzed with `analyzeRemovals`, which
+-- | computes the reverse-dependency closure of the unchanged packages the
+-- | compiler implicated and verifies — again by an exact compile — that
+-- | removing them lets the upgrade through. Compilation keeps exposing
+-- | blockers one at a time, so the analysis expands the closure iteratively
+-- | until the payload compiles or nothing new is learned.
+-- |
+-- | Infrastructure failures (storage, git, a missing compiler) surface via
+-- | `EXCEPT` and are never conflated with compiler incompatibility.
+-- |
+-- | Planning is compute-intensive: every probe downloads and compiles an
+-- | entire package set. The registry server only verifies and publishes
+-- | exact submitted payloads; planning itself runs wherever compute is
+-- | available, currently the package set updater and version checker
+-- | scripts in CI.
+module Registry.App.PackageSetPlanner
+  ( BlockedGroup
+  , Candidates
+  , Plan
+  , Probe
+  , ProbeResult(..)
+  , RemovalAnalysis(..)
+  , RemovalReport
+  , analyzeRemovals
+  , existingPackageCandidates
+  , maxPlanProbes
+  , planUpgrades
+  , probeAtomic
+  ) where
+
+import Registry.App.Prelude
+
+import Data.Array as Array
+import Data.Foldable as Foldable
+import Data.Map as Map
+import Data.Set as Set
+import Data.Set.NonEmpty (NonEmptySet)
+import Data.Set.NonEmpty as NonEmptySet
+import Data.String as String
+import Registry.App.Effect.PackageSets (PACKAGE_SETS)
+import Registry.App.Effect.PackageSets as PackageSets
+import Registry.Manifest (Manifest(..))
+import Registry.ManifestIndex (ManifestIndex)
+import Registry.ManifestIndex as ManifestIndex
+import Registry.Metadata (Metadata(..))
+import Registry.PackageName (PackageName)
+import Registry.PackageName as PackageName
+import Registry.PackageSet (PackageSet(..))
+import Registry.Version (Version)
+import Run (Run)
+import Run.Except (EXCEPT)
+
+-- | Packages eligible for the next package set, each with its pending
+-- | versions. The map makes duplicate candidates unrepresentable, every
+-- | candidate offers at least one pending version, and the set leaves no room
+-- | for duplicate or misordered versions: the maximum is the latest. A
+-- | candidate's current version, when it has one, is the version recorded in
+-- | the package set itself.
+type Candidates = Map PackageName (NonEmptySet Version)
+
+-- | The observable result of compiling one exact proposed package set.
+-- | Infrastructure failures are not represented here: a probe raises them
+-- | via `EXCEPT`, so they can never be mistaken for incompatibility.
+data ProbeResult = Compiles | CompilationFailure String
+
+derive instance Eq ProbeResult
+
+-- | Compile the package set that results from applying the change set to the
+-- | given baseline, reporting whether that exact set compiles.
+type Probe r = PackageSet -> PackageSets.ChangeSet -> Run r ProbeResult
+
+-- | The standard probe, which builds and compiles the proposed package set.
+probeAtomic :: forall r. Probe (PACKAGE_SETS + EXCEPT String + r)
+probeAtomic packageSet changes =
+  PackageSets.upgradeAtomic packageSet (un PackageSet packageSet).compiler changes <#> case _ of
+    Left error -> CompilationFailure error
+    Right _ -> Compiles
+
+-- | The result of compile-guided planning. `verified` is exactly the change
+-- | set most recently accepted by a successful whole-set compile probe.
+-- | Candidates whose latest version could not be included appear in
+-- | `blocked`, grouped by dependency interaction.
+type Plan =
+  { blocked :: Array BlockedGroup
+  , probes :: Int
+  , truncated :: Boolean
+  , verified :: Map PackageName Version
+  }
+
+-- | Latest-version updates that could not be included automatically, along
+-- | with the compiler evidence from probing them together against the
+-- | verified payload. `evidence` is `Nothing` when the probe budget ran out
+-- | before the group was probed. `blockers` are the unchanged packages the
+-- | compiler implicated.
+type BlockedGroup =
+  { blockers :: Array PackageName
+  , evidence :: Maybe String
+  , targets :: Map PackageName Version
+  }
+
+-- | The outcome of removal analysis for a blocked group. Only a verified
+-- | result carries a submittable payload: `updates` is the exact update map
+-- | the successful removal probe compiled — the group's targets together with
+-- | the plan's verified upgrades — so a payload that was never compile-
+-- | verified cannot be mistaken for one that was.
+data RemovalAnalysis
+  = RemovalsVerified { removed :: Set PackageName, updates :: Map PackageName Version }
+  | RemovalsUnverified (Set PackageName)
+  | RemovalsNotAnalyzed String
+
+derive instance Eq RemovalAnalysis
+
+-- | `targets` are the blocked group's latest-version upgrades. `evidence` is
+-- | the combined compiler output of every probe involving the group, or
+-- | `Nothing` when the group was never probed.
+type RemovalReport =
+  { analysis :: RemovalAnalysis
+  , blockers :: Array PackageName
+  , evidence :: Maybe String
+  , targets :: Map PackageName Version
+  }
+
+-- | Probe budget for automatic planning (phases 1 through 4).
+maxPlanProbes :: Int
+maxPlanProbes = 60
+
+-- | Overall probe budget, including removal analysis.
+maxTotalProbes :: Int
+maxTotalProbes = 100
+
+-- | All newer published versions of packages already in the set. Compiler
+-- | metadata and manifest ranges are deliberately not eligibility filters:
+-- | the compiler decides what is compatible.
+existingPackageCandidates :: PackageSet -> Map PackageName Metadata -> Candidates
+existingPackageCandidates (PackageSet packageSet) metadata = packageSet.packages # Map.mapMaybeWithKey \name current -> do
+  Metadata packageMetadata <- Map.lookup name metadata
+  NonEmptySet.fromSet $ Set.filter (_ > current) $ Map.keys packageMetadata.published
+
+-- | The latest version of each candidate.
+latestVersions :: Candidates -> Map PackageName Version
+latestVersions = map NonEmptySet.max
+
+-- | Plan a compile-verified upgrade. The roots — candidates already in the
+-- | package set plus the `seeds` proposed as additions in their own right —
+-- | are the packages the planner tries to upgrade. Any other candidate is
+-- | support: it enters a payload only through the dependency closure of a
+-- | root selection, always at its latest pending version, so a support
+-- | package can never be proposed, blocked, or removed on its own.
+planUpgrades
+  :: forall r
+   . Probe (EXCEPT String + r)
+  -> PackageSet
+  -> ManifestIndex
+  -> Set PackageName
+  -> Candidates
+  -> Run (EXCEPT String + r) Plan
+planUpgrades probe packageSet@(PackageSet set) manifests seeds candidates = do
+  repaired <- repair (latestVersions rootCandidates) 0
+  retried <- if isJust repaired.unattributed then pure repaired else retry repaired
+  componentPhase retried
+  where
+  -- Roots are the independently proposed upgrades; every other candidate is
+  -- support and only ever appears inside a root's dependency closure.
+  rootCandidates = Map.filterWithKey (\name _ -> Map.member name set.packages || Set.member name seeds) candidates
+
+  -- | The exact payload proposing one root selection: the root itself plus
+  -- | every absent package it transitively requires, each at its latest
+  -- | pending version. Pinning support to the latest version keeps every
+  -- | closure consistent, so unioning closures never conflicts. `Nothing`
+  -- | when a required package has no pending version or no manifest, in
+  -- | which case no payload containing this selection can ever compile.
+  rootClosure :: PackageName -> Version -> Maybe (Map PackageName Version)
+  rootClosure rootName rootVersion = go Map.empty [ Tuple rootName rootVersion ]
+    where
+    go acc frontier = case Array.uncons frontier of
+      Nothing -> Just acc
+      Just { head: Tuple name version, tail }
+        | Map.member name acc -> go acc tail
+        | otherwise -> case ManifestIndex.lookup name version manifests of
+            Nothing -> Nothing
+            Just (Manifest manifest) -> do
+              let absent = Set.difference (Map.keys manifest.dependencies) (Map.keys set.packages)
+              support <- traverse (\dep -> Tuple dep <<< NonEmptySet.max <$> Map.lookup dep candidates) (Array.fromFoldable absent)
+              go (Map.insert name version acc) (tail <> support)
+
+  -- The closure of each root selection. Roots whose closure is impossible
+  -- are dropped without spending a probe.
+  closeRoots :: Map PackageName Version -> Map PackageName (Map PackageName Version)
+  closeRoots = Map.mapMaybeWithKey rootClosure
+
+  payloadOf :: Map PackageName (Map PackageName Version) -> Map PackageName Version
+  payloadOf = Map.unions <<< Map.values
+
+  -- Phase 1 and 2: probe all roots at their latest versions (closed over
+  -- support) and greedily drop the roots whose closures the compiler
+  -- implicates.
+  repair rootPayload probes = do
+    let closures = closeRoots rootPayload
+    let payload = payloadOf closures
+    if Map.isEmpty payload then
+      pure { verified: Map.empty, probes, truncated: false, unattributed: Nothing }
+    else if probes >= maxPlanProbes then
+      pure { verified: Map.empty, probes, truncated: true, unattributed: Nothing }
+    else
+      probe packageSet (map PackageSets.Update payload) >>= case _ of
+        Compiles -> pure { verified: payload, probes: probes + 1, truncated: false, unattributed: Nothing }
+        CompilationFailure evidence -> do
+          let offenders = attributeFailure packageSet manifests payload evidence
+          let offendingRoots = Map.keys $ Map.filter (\closure -> not $ Set.isEmpty $ Set.intersection offenders $ Map.keys closure) closures
+          if Set.isEmpty offendingRoots then
+            pure { verified: Map.empty, probes: probes + 1, truncated: false, unattributed: Just evidence }
+          else
+            repair (Foldable.foldr Map.delete rootPayload offendingRoots) (probes + 1)
+
+  -- A root is blocked when its latest version is not in the verified
+  -- payload, even if an intermediate version was accepted.
+  blockedRoots state = Map.filterWithKey (\name versions -> Map.lookup name state.verified /= Just (NonEmptySet.max versions)) rootCandidates
+
+  -- Phase 3: greedy repair may drop more roots than necessary, and a root
+  -- blocked at its latest version may still have a compatible intermediate
+  -- one. Retry each dropped root individually against the accepted payload,
+  -- taking its pending versions newest first and round-robin across roots so
+  -- one root with many versions cannot starve the others.
+  retry state = go state initialQueue
+    where
+    -- Pending versions in descending order (latest first).
+    initialQueue = Map.toUnfoldable (blockedRoots state) <#> \(Tuple name versions) ->
+      Tuple name (Array.reverse $ Array.fromFoldable versions)
+
+    go st queue = case Array.uncons queue of
+      Nothing -> pure st
+      Just { head: Tuple name versions, tail }
+        | st.truncated -> pure st
+        | otherwise -> case Array.uncons versions of
+            Nothing -> go st tail
+            Just { head: version, tail: older }
+              | st.probes >= maxPlanProbes -> pure st { truncated = true }
+              | otherwise -> case rootClosure name version of
+                  Nothing -> go st (tail <> [ Tuple name older ])
+                  Just closure -> do
+                    let payload = Map.union closure st.verified
+                    probe packageSet (map PackageSets.Update payload) >>= case _ of
+                      Compiles -> go (st { verified = payload, probes = st.probes + 1 }) tail
+                      CompilationFailure _ -> go (st { probes = st.probes + 1 }) (tail <> [ Tuple name older ])
+
+  -- Phase 5: probe the remaining blocked roots one interaction component at
+  -- a time. A coordinated group that only compiles together is promoted into
+  -- the verified payload; anything else becomes a blocked group carrying the
+  -- compiler evidence for removal analysis.
+  componentPhase state = do
+    let blocked = blockedRoots state
+    let components = interactionComponents packageSet manifests blocked
+    result <- Array.foldM step (Tuple state []) components
+    case result of
+      Tuple final groups -> pure
+        { blocked: groups
+        , probes: final.probes
+        , truncated: final.truncated
+        , verified: final.verified
+        }
+    where
+    step (Tuple st groups) component = do
+      let rootTargets = latestVersions component
+      let closures = closeRoots rootTargets
+      let unclosable = Set.difference (Map.keys rootTargets) (Map.keys closures)
+      if st.probes >= maxPlanProbes || st.truncated then
+        pure $ Tuple (st { truncated = true }) (groups <> [ { blockers: [], evidence: Nothing, targets: rootTargets } ])
+      else if not (Set.isEmpty unclosable) then do
+        let missing = String.joinWith ", " (map PackageName.print (Array.fromFoldable unclosable))
+        let evidence = "The proposed payload is not self-contained. These members require a package that is outside the proposed set and has no pending version or manifest: " <> missing
+        pure $ Tuple st (groups <> [ { blockers: [], evidence: Just evidence, targets: rootTargets } ])
+      else do
+        let targets = payloadOf closures
+        let payload = Map.union targets st.verified
+        probe packageSet (map PackageSets.Update payload) >>= case _ of
+          Compiles ->
+            pure $ Tuple (st { verified = payload, probes = st.probes + 1 }) groups
+          CompilationFailure evidence -> do
+            let failing = failingPackages (applyUpdates packageSet payload) evidence
+            let blockers = Array.fromFoldable (Set.difference failing (Map.keys payload))
+            pure $ Tuple (st { probes = st.probes + 1 }) (groups <> [ { blockers, evidence: Just evidence, targets } ])
+
+-- | Analyze each blocked group of a plan: compute the reverse-dependency
+-- | closure of the implicated unchanged packages and verify by compiling that
+-- | removing them lets the group's upgrades through. Compilation may expose
+-- | further blockers one at a time, so the closure expands iteratively until
+-- | the exact payload compiles or nothing new is learned.
+analyzeRemovals
+  :: forall r
+   . Probe (EXCEPT String + r)
+  -> PackageSet
+  -> ManifestIndex
+  -> Plan
+  -> Run (EXCEPT String + r) (Array RemovalReport)
+analyzeRemovals probe packageSet manifests plan = map snd $ Array.foldM step (Tuple plan.probes []) plan.blocked
+  where
+  step (Tuple probes reports) group = do
+    Tuple next report <- analyzeGroup probes group
+    pure $ Tuple next (reports <> [ report ])
+
+  analyzeGroup probes group = case group.evidence of
+    Nothing ->
+      pure $ Tuple probes $ report implicated [] $ RemovalsNotAnalyzed "The probe budget was exhausted before this group was probed."
+    Just evidence
+      | Set.isEmpty implicated ->
+          pure $ Tuple probes $ report implicated [ evidence ] $ RemovalsNotAnalyzed "The compiler output did not implicate an unchanged package that could be removed."
+      | otherwise ->
+          expand implicated [ evidence ] probes
+
+    where
+    -- The unchanged packages the compiler implicated when the group was probed.
+    implicated = Set.fromFoldable group.blockers
+
+    -- The full update map every removal probe compiles: the group's targets
+    -- applied on top of the already-verified payload.
+    payload = Map.union group.targets plan.verified
+
+    expand blockers evidences used = do
+      let proposed = applyUpdates packageSet payload
+      case reverseDependencyClosure proposed manifests blockers of
+        Left closureError -> pure $ Tuple used (report blockers evidences (RemovalsNotAnalyzed ("Removal analysis failed: " <> closureError)))
+        Right removals -> do
+          -- If a proposed update transitively depends on a removed package,
+          -- no set containing this group can be self-contained after the
+          -- removals: the proposal is structurally impossible, not merely
+          -- incompatible, so no probe is spent on it.
+          let protected = Set.intersection removals (Map.keys payload)
+          if not (Set.isEmpty protected) then do
+            let names = String.joinWith ", " (map PackageName.print (Array.fromFoldable protected))
+            pure $ Tuple used (report blockers evidences (RemovalsNotAnalyzed ("Removing the implicated packages would also require removing proposed upgrades: " <> names <> ".")))
+          else if used >= maxTotalProbes then
+            pure $ Tuple used (report blockers evidences (RemovalsNotAnalyzed "The probe budget was exhausted before the removal payload could be verified."))
+          else do
+            let removalChanges = Map.fromFoldable $ map (\name -> Tuple name PackageSets.Remove) (Array.fromFoldable removals :: Array _)
+            let changes = Map.union removalChanges (map PackageSets.Update payload)
+            probe packageSet changes >>= case _ of
+              Compiles -> pure $ Tuple (used + 1) (report blockers evidences (RemovalsVerified { removed: removals, updates: payload }))
+              CompilationFailure next -> do
+                let failing = failingPackages proposed next
+                let exposed = Set.difference (Set.difference failing (Map.keys payload)) blockers
+                if Set.isEmpty exposed then
+                  pure $ Tuple (used + 1) (report blockers (evidences <> [ next ]) (RemovalsUnverified removals))
+                else
+                  expand (Set.union blockers exposed) (evidences <> [ next ]) (used + 1)
+
+    report blockers evidences analysis =
+      { analysis
+      , blockers: Array.fromFoldable blockers
+      , evidence: combineCompilerEvidence evidences
+      , targets: group.targets
+      }
+
+-- | Determine which payload members to drop, given the packages implicated by
+-- | compiler output. A failing payload member is dropped directly; a failing
+-- | unchanged package implicates the payload members it transitively depends
+-- | on, since one of them broke it even though the evidence cannot say which.
+attributeFailure :: PackageSet -> ManifestIndex -> Map PackageName Version -> String -> Set PackageName
+attributeFailure packageSet manifests payload evidence = Set.union direct fromCones
+  where
+  applied = applyUpdates packageSet payload
+  failing = failingPackages applied evidence
+  payloadNames = Map.keys payload
+  direct = Set.intersection failing payloadNames
+  unchanged = Set.difference failing payloadNames
+  cones = Foldable.foldl (\acc name -> Set.union acc (dependencyCone applied manifests name)) Set.empty unchanged
+  fromCones = Set.intersection payloadNames cones
+
+-- | The transitive dependency cone of a package, resolved against the exact
+-- | applied package versions. Includes the root.
+dependencyCone :: Map PackageName Version -> ManifestIndex -> PackageName -> Set PackageName
+dependencyCone applied manifests root = go Set.empty [ root ]
+  where
+  go seen frontier = case Array.uncons frontier of
+    Nothing -> seen
+    Just { head, tail }
+      | Set.member head seen -> go seen tail
+      | otherwise -> do
+          let
+            dependencies = case flip (ManifestIndex.lookup head) manifests =<< Map.lookup head applied of
+              Nothing -> []
+              Just (Manifest manifest) -> Array.fromFoldable (Map.keys manifest.dependencies)
+          go (Set.insert head seen) (tail <> dependencies)
+
+-- | Parse the packages implicated by compiler output, matching the exact
+-- | package versions installed for the probe (source paths have the form
+-- | packages/<name>@<version>/...).
+failingPackages :: Map PackageName Version -> String -> Set PackageName
+failingPackages applied evidence = Map.keys (Map.filterWithKey implicated applied)
+  where
+  fileLines = Array.filter (String.contains (String.Pattern "File:")) (String.split (String.Pattern "\n") evidence)
+  implicated name version = do
+    let path = "packages/" <> formatPackageVersion name version <> "/"
+    any (String.contains (String.Pattern path)) fileLines
+
+-- | Group candidates by dependency-name interaction: two candidates are in
+-- | the same component when some relevant manifest mentions both. Components
+-- | can be probed independently of one another.
+interactionComponents :: PackageSet -> ManifestIndex -> Candidates -> Array Candidates
+interactionComponents (PackageSet packageSet) manifests candidates = map candidatesInSet (setsFromGraph graph candidateNames)
+  where
+  candidateNames = Map.keys candidates
+  relevantManifests = Array.catMaybes do
+    Tuple name versions <- Map.toUnfoldable candidates
+    version <- Array.catMaybes ([ Map.lookup name packageSet.packages ] <> map Just (Array.fromFoldable versions))
+    [ ManifestIndex.lookup name version manifests ]
+  baselineManifests = Array.mapMaybe (\(Tuple name version) -> ManifestIndex.lookup name version manifests) (Map.toUnfoldable packageSet.packages)
+  graph = Foldable.foldl addManifest (Map.fromFoldable $ map (\name -> Tuple name Set.empty) (Array.fromFoldable candidateNames)) (baselineManifests <> relevantManifests)
+
+  addManifest edges (Manifest manifest) = do
+    let mentioned = Set.intersection candidateNames (Set.insert manifest.name (Map.keys manifest.dependencies))
+    mentioned # Foldable.foldl
+      (\next name -> Map.alter (Just <<< Set.union (Set.delete name mentioned) <<< fromMaybe Set.empty) name next)
+      edges
+
+  candidatesInSet names = Map.filterKeys (_ `Set.member` names) candidates
+
+setsFromGraph :: Map PackageName (Set PackageName) -> Set PackageName -> Array (Set PackageName)
+setsFromGraph graph = go []
+  where
+  go components remaining = case Set.findMin remaining of
+    Nothing -> components
+    Just seed -> do
+      let component = visit Set.empty [ seed ]
+      go (components <> [ component ]) (Set.difference remaining component)
+
+  visit seen frontier = case Array.uncons frontier of
+    Nothing -> seen
+    Just { head: name, tail: rest }
+      | Set.member name seen -> visit seen rest
+      | otherwise -> do
+          let neighbours = Array.fromFoldable $ fromMaybe Set.empty $ Map.lookup name graph
+          visit (Set.insert name seen) (rest <> neighbours)
+
+applyUpdates :: PackageSet -> Map PackageName Version -> Map PackageName Version
+applyUpdates (PackageSet packageSet) updates = Map.union updates packageSet.packages
+
+-- | The packages that would have to be removed along with the given packages
+-- | to keep the set self-contained: every package that transitively depends
+-- | on a removed package must also be removed.
+reverseDependencyClosure :: Map PackageName Version -> ManifestIndex -> Set PackageName -> Either String (Set PackageName)
+reverseDependencyClosure packages manifests = go
+  where
+  go removals = do
+    dependants <- Set.fromFoldable <<< Array.catMaybes <$> traverse (dependsOn removals) (Map.toUnfoldable packages)
+    let next = Set.union removals dependants
+    if next == removals then pure removals else go next
+
+  dependsOn removals (Tuple name version) = do
+    if Set.member name removals then pure Nothing
+    else case ManifestIndex.lookup name version manifests of
+      Nothing -> Left $ "Missing manifest while computing removal closure: " <> formatPackageVersion name version
+      Just (Manifest manifest) -> pure $ name <$ guard (not $ Set.isEmpty $ Set.intersection removals $ Map.keys manifest.dependencies)
+
+combineCompilerEvidence :: Array String -> Maybe String
+combineCompilerEvidence evidences
+  | Array.null evidences = Nothing
+  | otherwise = Just $ String.joinWith "\n\n--- The next compile probe exposed another blocker ---\n\n" evidences

--- a/app/src/App/Server/Router.purs
+++ b/app/src/App/Server/Router.purs
@@ -20,7 +20,6 @@ import Registry.App.Effect.Db as Db
 import Registry.App.Effect.Env as Env
 import Registry.App.Effect.Log as Log
 import Registry.App.Server.Env (ServerEffects, ServerEnv, jsonCreated, jsonDecoder, jsonOk, runEffects)
-import Registry.Operation (PackageSetOperation(..))
 import Registry.Operation as Operation
 import Run (Run)
 import Run as Run
@@ -165,7 +164,7 @@ router { route, method, body } = HTTPurple.usingCont case route, method of
 
     -- Check if the operation requires authentication (compiler change or package removal)
     let
-      PackageSetUpdate payload = request.payload
+      Operation.PackageSetUpdate payload = request.payload
       didChangeCompiler = isJust payload.compiler
       didRemovePackages = any isNothing payload.packages
       requiresAuth = didChangeCompiler || didRemovePackages

--- a/app/test/App/API.purs
+++ b/app/test/App/API.purs
@@ -15,10 +15,13 @@ import Effect.Ref as Ref
 import Node.FS.Aff as FS.Aff
 import Node.Path as Path
 import Node.Process as Process
+import Registry.API.V1 (JobId(..), PackageSetJobData)
 import Registry.App.API (LicenseValidationError(..), validateLicense)
 import Registry.App.API as API
 import Registry.App.Effect.Env as Env
 import Registry.App.Effect.Log as Log
+import Registry.App.Effect.PackageSets (Change(..))
+import Registry.App.Effect.PackageSets as PackageSets
 import Registry.App.Effect.Pursuit as Pursuit
 import Registry.App.Effect.Registry as Registry
 import Registry.App.Effect.Storage as Storage
@@ -29,7 +32,8 @@ import Registry.Foreign.FastGlob as FastGlob
 import Registry.Foreign.Tmp as Tmp
 import Registry.License as License
 import Registry.Location (Location(..))
-import Registry.Operation (PublishData)
+import Registry.ManifestIndex as ManifestIndex
+import Registry.Operation (PackageSetOperation(..), PackageSetUpdateData, PublishData)
 import Registry.PackageName as PackageName
 import Registry.Test.Assert as Assert
 import Registry.Test.Assert.Run as Assert.Run
@@ -39,6 +43,7 @@ import Run (EFFECT, Run)
 import Run as Run
 import Run.Except as Except
 import Test.Spec as Spec
+import Type.Proxy (Proxy(..))
 
 -- | The environment accessible to each assertion in the test suite, derived
 -- | from the fixtures.
@@ -130,6 +135,9 @@ spec :: Spec.Spec Unit
 spec = do
   Spec.describe "Verifies build plans" do
     checkBuildPlanToResolutions
+
+  Spec.describe "Applies package set updates" do
+    packageSetUpdateSpec
 
   Spec.describe "Parses source manifests" do
     parseSourceManifestSpec
@@ -358,6 +366,130 @@ spec = do
         , storageDir: Path.concat [ testFixtures, "registry-storage" ]
         , githubDir: Path.concat [ testFixtures, "github-packages" ]
         }
+
+type PackageSetUpdateCalls =
+  { atomicChanges :: Array PackageSets.ChangeSet
+  , writes :: Int
+  , mirrors :: Int
+  }
+
+packageSetUpdateSpec :: Spec.Spec Unit
+packageSetUpdateSpec = do
+  Spec.it "does not publish a sequential subset when the exact update fails to compile" do
+    let
+      operation = PackageSetUpdate packageSetUpdateData
+      expectedChanges = packageSetUpdateData.packages <#> maybe Remove Update
+    { calls, result } <- liftEffect $ runPackageSetUpdate operation
+
+    case result of
+      Left error -> error `Assert.shouldSatisfy` String.contains (Pattern "failed to compile atomically")
+      Right _ -> Assert.fail "Expected an atomically failing package set update to fail."
+    calls `Assert.shouldEqual` emptyPackageSetUpdateCalls { atomicChanges = [ expectedChanges ] }
+
+emptyPackageSetUpdateCalls :: PackageSetUpdateCalls
+emptyPackageSetUpdateCalls = { atomicChanges: [], writes: 0, mirrors: 0 }
+
+runPackageSetUpdate
+  :: PackageSetOperation
+  -> Effect { calls :: PackageSetUpdateCalls, result :: Either String Unit }
+runPackageSetUpdate operation = do
+  callsRef <- Ref.new emptyPackageSetUpdateCalls
+  result <- API.packageSetUpdate (packageSetJob operation)
+    # Registry.interpretWrite (handlePackageSetRegistryWrite callsRef)
+    # Registry.interpretRead handlePackageSetRegistryRead
+    # PackageSets.interpret (handlePackageSetCompileFailure callsRef)
+    # Log.interpret (\(Log.Log _ _ next) -> pure next)
+    # Except.runExcept
+    # Run.runBaseEffect
+  calls <- Ref.read callsRef
+  pure { calls, result }
+
+packageSetJob :: PackageSetOperation -> PackageSetJobData
+packageSetJob payload =
+  { jobId: JobId "package-set-update-test"
+  , jobType: Proxy
+  , createdAt: Utils.unsafeDateTime "2026-07-27T00:00:00.000Z"
+  , startedAt: Nothing
+  , finishedAt: Nothing
+  , success: false
+  , logs: []
+  , payload
+  }
+
+packageSetUpdateData :: PackageSetUpdateData
+packageSetUpdateData =
+  { compiler: Nothing
+  , packages: Map.fromFoldable
+      [ Tuple (Utils.unsafePackageName "aff") (Just (Utils.unsafeVersion "2.0.0"))
+      , Tuple (Utils.unsafePackageName "prelude") (Just (Utils.unsafeVersion "2.0.0"))
+      ]
+  }
+
+latestPackageSet :: PackageSet
+latestPackageSet = PackageSet
+  { compiler: Utils.unsafeVersion "0.15.15"
+  , packages: Map.fromFoldable
+      [ Tuple (Utils.unsafePackageName "aff") (Utils.unsafeVersion "1.0.0")
+      , Tuple (Utils.unsafePackageName "prelude") (Utils.unsafeVersion "1.0.0")
+      ]
+  , published: Utils.unsafeDate "2026-07-26"
+  , version: Utils.unsafeVersion "1.0.1"
+  }
+
+packageSetUpdateIndex :: ManifestIndex
+packageSetUpdateIndex = unsafeFromRight $ ManifestIndex.fromSet ManifestIndex.IgnoreRanges $ Set.fromFoldable
+  [ Utils.unsafeManifest "aff" "1.0.0" []
+  , Utils.unsafeManifest "aff" "2.0.0" []
+  , Utils.unsafeManifest "prelude" "1.0.0" []
+  , Utils.unsafeManifest "prelude" "2.0.0" []
+  ]
+
+handlePackageSetCompileFailure
+  :: forall r a
+   . Ref PackageSetUpdateCalls
+  -> PackageSets.PackageSets a
+  -> Run (EFFECT + r) a
+handlePackageSetCompileFailure callsRef = case _ of
+  PackageSets.UpgradeAtomic _ _ changes reply -> do
+    Run.liftEffect $ Ref.modify_ (\calls -> calls { atomicChanges = calls.atomicChanges <> [ changes ] }) callsRef
+    pure $ reply $ Right $ Left "injected multi-package compilation failure"
+
+handlePackageSetRegistryRead
+  :: forall r a
+   . Registry.RegistryRead a
+  -> Run r a
+handlePackageSetRegistryRead = case _ of
+  Registry.ReadManifest name version reply ->
+    pure $ reply $ Right $ ManifestIndex.lookup name version packageSetUpdateIndex
+  Registry.ReadAllManifests reply ->
+    pure $ reply $ Right packageSetUpdateIndex
+  Registry.ReadMetadata _ reply ->
+    pure $ reply $ Right Nothing
+  Registry.ReadAllMetadata reply ->
+    pure $ reply $ Right Map.empty
+  Registry.ReadLatestPackageSet reply ->
+    pure $ reply $ Right $ Just latestPackageSet
+  Registry.ReadAllPackageSets reply ->
+    pure $ reply $ Right $ Map.singleton (un PackageSet latestPackageSet).version latestPackageSet
+
+handlePackageSetRegistryWrite
+  :: forall r a
+   . Ref PackageSetUpdateCalls
+  -> Registry.RegistryWrite a
+  -> Run (EFFECT + r) a
+handlePackageSetRegistryWrite callsRef = case _ of
+  Registry.WriteManifest _ reply ->
+    pure $ reply $ Right unit
+  Registry.DeleteManifest _ _ reply ->
+    pure $ reply $ Right unit
+  Registry.WriteMetadata _ _ reply ->
+    pure $ reply $ Right unit
+  Registry.WritePackageSet _ _ reply -> do
+    Run.liftEffect $ Ref.modify_ (\calls -> calls { writes = calls.writes + 1 }) callsRef
+    pure $ reply $ Right unit
+  Registry.MirrorPackageSet _ reply -> do
+    Run.liftEffect $ Ref.modify_ (\calls -> calls { mirrors = calls.mirrors + 1 }) callsRef
+    pure $ reply $ Right unit
 
 checkBuildPlanToResolutions :: Spec.Spec Unit
 checkBuildPlanToResolutions = do

--- a/app/test/App/Effect/PackageSets.purs
+++ b/app/test/App/Effect/PackageSets.purs
@@ -3,11 +3,8 @@ module Test.Registry.App.Effect.PackageSets (spec) where
 import Registry.App.Prelude
 
 import Data.Map as Map
-import Data.Set as Set
 import Registry.App.Effect.PackageSets (Change(..))
 import Registry.App.Effect.PackageSets as PackageSets
-import Registry.ManifestIndex as ManifestIndex
-import Registry.PackageName as PackageName
 import Registry.Test.Assert as Assert
 import Registry.Test.Utils as Utils
 import Registry.Version as Version
@@ -33,67 +30,6 @@ spec = do
         ]
 
     PackageSets.commitMessage packageSet operations (Utils.unsafeVersion "2.0.0") `Assert.shouldEqual` packageSetCommitMessageNoUpdates
-
-  Spec.describe "orderChanges" do
-    Spec.it "Orders removals in reverse topological order (dependents before dependencies)" do
-      -- Given: foo depends on bar (bar is a dependency of foo)
-      -- When: both are being removed
-      -- Then: foo (dependent) should be removed before bar (dependency)
-      let
-        foo = Utils.unsafePackageName "foo"
-        bar = Utils.unsafePackageName "bar"
-        v1 = Utils.unsafeVersion "1.0.0"
-
-        index = unsafeFromRight $ ManifestIndex.fromSet ManifestIndex.IgnoreRanges $ Set.fromFoldable
-          [ mkManifest bar v1 []
-          , mkManifest foo v1 [ bar ]
-          ]
-
-        packages = Map.fromFoldable
-          [ Tuple bar v1
-          , Tuple foo v1
-          ]
-
-        changes = Map.fromFoldable
-          [ Tuple bar Remove
-          , Tuple foo Remove
-          ]
-
-        result = PackageSets.orderChanges index packages changes
-        names = map fst result
-
-      -- foo (dependent) must come before bar (dependency)
-      names `Assert.shouldEqual` [ foo, bar ]
-
-    Spec.it "Orders updates in topological order (dependencies before dependents)" do
-      -- Given: foo depends on bar (bar is a dependency of foo)
-      -- When: both are being updated
-      -- Then: bar (dependency) should be updated before foo (dependent)
-      let
-        foo = Utils.unsafePackageName "foo"
-        bar = Utils.unsafePackageName "bar"
-        v2 = Utils.unsafeVersion "2.0.0"
-
-        index = unsafeFromRight $ ManifestIndex.fromSet ManifestIndex.IgnoreRanges $ Set.fromFoldable
-          [ mkManifest bar v2 []
-          , mkManifest foo v2 [ bar ]
-          ]
-
-        packages = Map.fromFoldable
-          [ Tuple bar (Utils.unsafeVersion "1.0.0")
-          , Tuple foo (Utils.unsafeVersion "1.0.0")
-          ]
-
-        changes = Map.fromFoldable
-          [ Tuple bar (Update v2)
-          , Tuple foo (Update v2)
-          ]
-
-        result = PackageSets.orderChanges index packages changes
-        names = map fst result
-
-      -- bar (dependency) must come before foo (dependent)
-      names `Assert.shouldEqual` [ bar, foo ]
 
   Spec.describe "extraneousPackageDirs" do
     Spec.it "Returns empty when packages/ matches the target set" do
@@ -133,34 +69,6 @@ spec = do
           [ Tuple (Utils.unsafePackageName "aff") (Utils.unsafeVersion "7.0.0")
           ]
       PackageSets.extraneousPackageDirs target [] `Assert.shouldEqual` []
-
-    Spec.it "Processes updates before removals" do
-      let
-        foo = Utils.unsafePackageName "foo"
-        bar = Utils.unsafePackageName "bar"
-        v1 = Utils.unsafeVersion "1.0.0"
-        v2 = Utils.unsafeVersion "2.0.0"
-
-        index = unsafeFromRight $ ManifestIndex.fromSet ManifestIndex.IgnoreRanges $ Set.fromFoldable
-          [ mkManifest bar v1 []
-          , mkManifest foo v2 []
-          ]
-
-        packages = Map.fromFoldable
-          [ Tuple bar v1
-          , Tuple foo (Utils.unsafeVersion "1.0.0")
-          ]
-
-        changes = Map.fromFoldable
-          [ Tuple bar Remove
-          , Tuple foo (Update v2)
-          ]
-
-        result = PackageSets.orderChanges index packages changes
-        names = map fst result
-
-      -- Updates come before removals
-      names `Assert.shouldEqual` [ foo, bar ]
 
 packageSet :: PackageSet
 packageSet = PackageSet
@@ -212,10 +120,3 @@ Removed packages:
   - assert@6.0.0
 """
 
-mkManifest :: PackageName -> Version -> Array PackageName -> Manifest
-mkManifest name version deps = do
-  let toRange v = ">=" <> Version.print v <> " <" <> Version.print (Version.bumpHighest v)
-  Utils.unsafeManifest
-    (PackageName.print name)
-    (Version.print version)
-    (map (\dep -> Tuple (PackageName.print dep) (toRange (Utils.unsafeVersion "1.0.0"))) deps)

--- a/app/test/App/PackageSetPlanner.purs
+++ b/app/test/App/PackageSetPlanner.purs
@@ -1,0 +1,554 @@
+module Test.Registry.App.PackageSetPlanner (spec) where
+
+import Registry.App.Prelude
+
+import Data.Array as Array
+import Data.Map as Map
+import Data.Set as Set
+import Data.Set.NonEmpty (NonEmptySet)
+import Data.Set.NonEmpty as NonEmptySet
+import Data.String as String
+import Registry.App.Effect.PackageSets (Change(..), ChangeSet)
+import Registry.App.PackageSetPlanner as Planner
+import Registry.Manifest (Manifest)
+import Registry.ManifestIndex (IncludeRanges(..), ManifestIndex)
+import Registry.ManifestIndex as ManifestIndex
+import Registry.PackageName (PackageName)
+import Registry.PackageName as PackageName
+import Registry.PackageSet (PackageSet)
+import Registry.PackageSet as PackageSet
+import Registry.Test.Assert as Assert
+import Registry.Test.Utils as Utils
+import Registry.Version (Version)
+import Registry.Version as Version
+import Run (Run)
+import Run as Run
+import Run.Except (EXCEPT)
+import Run.Except as Except
+import Test.Spec as Spec
+
+spec :: Spec.Spec Unit
+spec = do
+  Spec.describe "compile-guided planning" do
+    Spec.it "keeps every newer existing-package version without compiler-history gating" do
+      let
+        packageSet = mkPackageSet $ Map.singleton (name "example") (version "1.0.0")
+        metadata = Map.fromFoldable
+          [ Utils.unsafeMetadata "example"
+              [ Tuple "1.0.0" [ "0.15.10" ]
+              , Tuple "2.0.0" [ "0.14.0" ]
+              , Tuple "3.0.0" [ "0.13.0" ]
+              ]
+          ]
+        candidates = Planner.existingPackageCandidates packageSet metadata
+
+      candidates `Assert.shouldEqual` Map.fromFoldable [ candidate "example" [ "3.0.0", "2.0.0" ] ]
+
+    Spec.it "verifies all candidates at their latest versions in a single probe" do
+      let
+        packageSet = mkPackageSet $ Map.fromFoldable
+          [ Tuple (name "a") (version "1.0.0")
+          , Tuple (name "b") (version "1.0.0")
+          ]
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "a" "2.0.0" []
+          , Utils.unsafeManifest "b" "2.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "a" [ "2.0.0" ]
+          , candidate "b" [ "2.0.0" ]
+          ]
+        plan = plan' (\_ _ -> pure Planner.Compiles) packageSet manifests candidates
+
+      map _.verified plan `Assert.shouldEqual` Right (versionMap [ Tuple "a" "2.0.0", Tuple "b" "2.0.0" ])
+      map _.blocked plan `Assert.shouldEqual` Right []
+      map _.probes plan `Assert.shouldEqual` Right 1
+
+    Spec.it "treats declared ranges as advisory when the exact set compiles" do
+      let
+        packageSet = mkPackageSet $ Map.fromFoldable
+          [ Tuple (name "dependency") (version "1.0.0")
+          , Tuple (name "legacy") (version "1.0.0")
+          ]
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "dependency" "1.0.0" []
+          , Utils.unsafeManifest "dependency" "2.0.0" []
+          , Utils.unsafeManifest "legacy" "1.0.0" [ Tuple "dependency" ">=3.0.0 <4.0.0" ]
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "dependency" [ "2.0.0" ] ]
+        plan = plan' (\_ _ -> pure Planner.Compiles) packageSet manifests candidates
+
+      map _.verified plan `Assert.shouldEqual` Right (versionMap [ Tuple "dependency" "2.0.0" ])
+
+    Spec.it "attributes failures to the exact selected versions and rescues the rest" do
+      let
+        packageSet = mkPackageSet $ Map.fromFoldable
+          [ Tuple (name "a") (version "1.0.0")
+          , Tuple (name "b") (version "1.0.0")
+          ]
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "a" "2.0.0" []
+          , Utils.unsafeManifest "b" "2.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "a" [ "2.0.0" ]
+          , candidate "b" [ "2.0.0" ]
+          ]
+        -- The evidence names the selected version a@2.0.0, not the baseline
+        -- version a@1.0.0, so attribution must resolve against the payload.
+        probe _ changes =
+          if Map.lookup (name "a") changes == Just (Update (version "2.0.0")) then
+            pure $ Planner.CompilationFailure (fileError "a" "2.0.0")
+          else pure Planner.Compiles
+        plan = plan' probe packageSet manifests candidates
+
+      map _.verified plan `Assert.shouldEqual` Right (versionMap [ Tuple "b" "2.0.0" ])
+      map (map _.targets <<< _.blocked) plan `Assert.shouldEqual` Right [ versionMap [ Tuple "a" "2.0.0" ] ]
+
+    Spec.it "implicates payload members through the dependency cone of a failing unchanged package" do
+      let
+        packageSet = mkPackageSet $ Map.fromFoldable
+          [ Tuple (name "lib") (version "1.0.0")
+          , Tuple (name "consumer") (version "1.0.0")
+          , Tuple (name "other") (version "1.0.0")
+          ]
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "lib" "1.0.0" []
+          , Utils.unsafeManifest "lib" "2.0.0" []
+          , Utils.unsafeManifest "consumer" "1.0.0" [ Tuple "lib" ">=1.0.0 <3.0.0" ]
+          , Utils.unsafeManifest "other" "1.0.0" []
+          , Utils.unsafeManifest "other" "2.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "lib" [ "2.0.0" ]
+          , candidate "other" [ "2.0.0" ]
+          ]
+        -- The compiler implicates the unchanged `consumer`, so the planner
+        -- must drop the payload member `consumer` depends on: `lib`.
+        probe _ changes =
+          if Map.lookup (name "lib") changes == Just (Update (version "2.0.0")) then
+            pure $ Planner.CompilationFailure (fileError "consumer" "1.0.0")
+          else pure Planner.Compiles
+        plan = plan' probe packageSet manifests candidates
+
+      map _.verified plan `Assert.shouldEqual` Right (versionMap [ Tuple "other" "2.0.0" ])
+      map (map _.targets <<< _.blocked) plan `Assert.shouldEqual` Right [ versionMap [ Tuple "lib" "2.0.0" ] ]
+
+    Spec.it "fails closed when compiler evidence implicates no candidate" do
+      let
+        packageSet = mkPackageSet $ Map.singleton (name "example") (version "1.0.0")
+        manifests = manifestIndex [ Utils.unsafeManifest "example" "2.0.0" [] ]
+        candidates = Map.fromFoldable
+          [ candidate "example" [ "2.0.0" ] ]
+        plan = plan' (\_ _ -> pure $ Planner.CompilationFailure "mysterious failure without file paths") packageSet manifests candidates
+
+      -- Incompatibility is a result, not an error: the plan is empty but Right.
+      map _.verified plan `Assert.shouldEqual` Right Map.empty
+      map (map _.blockers <<< _.blocked) plan `Assert.shouldEqual` Right [ [] ]
+
+    Spec.it "falls back to a compatible intermediate version when the latest fails" do
+      let
+        packageSet = mkPackageSet $ Map.singleton (name "example") (version "1.0.0")
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "example" "2.0.0" []
+          , Utils.unsafeManifest "example" "3.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "example" [ "3.0.0", "2.0.0" ] ]
+        probe _ changes =
+          if Map.lookup (name "example") changes == Just (Update (version "3.0.0")) then
+            pure $ Planner.CompilationFailure (fileError "example" "3.0.0")
+          else pure Planner.Compiles
+        plan = plan' probe packageSet manifests candidates
+
+      map _.verified plan `Assert.shouldEqual` Right (versionMap [ Tuple "example" "2.0.0" ])
+      -- The latest version remains reported as blocked.
+      map (map _.targets <<< _.blocked) plan `Assert.shouldEqual` Right [ versionMap [ Tuple "example" "3.0.0" ] ]
+
+    Spec.it "promotes a coordinated group that only compiles together" do
+      let
+        packageSet = mkPackageSet $ Map.fromFoldable
+          [ Tuple (name "x") (version "1.0.0")
+          , Tuple (name "y") (version "1.0.0")
+          , Tuple (name "z") (version "1.0.0")
+          ]
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "x" "2.0.0" []
+          , Utils.unsafeManifest "y" "2.0.0" [ Tuple "x" ">=2.0.0 <3.0.0" ]
+          , Utils.unsafeManifest "z" "2.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "x" [ "2.0.0" ]
+          , candidate "y" [ "2.0.0" ]
+          , candidate "z" [ "2.0.0" ]
+          ]
+        -- `z` fails with evidence that sweeps up `x` and `y`, and `x` and `y`
+        -- fail individually, so only probing their interaction component
+        -- together can recover the coordinated upgrade.
+        probe _ changes = do
+          let updated package = Map.lookup (name package) changes == Just (Update (version "2.0.0"))
+          if updated "z" then
+            pure $ Planner.CompilationFailure $ String.joinWith "\n" [ fileError "z" "2.0.0", fileError "x" "2.0.0", fileError "y" "2.0.0" ]
+          else if updated "x" /= updated "y" then
+            pure $ Planner.CompilationFailure (fileError (if updated "x" then "x" else "y") "2.0.0")
+          else pure Planner.Compiles
+        plan = plan' probe packageSet manifests candidates
+
+      map _.verified plan `Assert.shouldEqual` Right (versionMap [ Tuple "x" "2.0.0", Tuple "y" "2.0.0" ])
+      map (map _.targets <<< _.blocked) plan `Assert.shouldEqual` Right [ versionMap [ Tuple "z" "2.0.0" ] ]
+
+    Spec.it "drops payload members whose dependencies are outside the proposed set without probing" do
+      let
+        packageSet = mkPackageSet $ Map.singleton (name "parent") (version "1.0.0")
+        -- `missing` has a manifest in the index, but is neither in the
+        -- package set nor proposed by the payload.
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "parent" "2.0.0" [ Tuple "missing" ">=1.0.0 <2.0.0" ]
+          , Utils.unsafeManifest "missing" "1.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "parent" [ "2.0.0" ] ]
+        plan = plan' (\_ _ -> pure Planner.Compiles) packageSet manifests candidates
+
+      map _.verified plan `Assert.shouldEqual` Right Map.empty
+      map _.probes plan `Assert.shouldEqual` Right 0
+      case map (map _.evidence <<< _.blocked) plan of
+        Right [ Just evidence ] -> String.contains (String.Pattern "outside the proposed set") evidence `Assert.shouldEqual` true
+        _ -> Assert.fail "Expected one unclosed blocked group with evidence."
+
+    Spec.it "truncates the search when the probe budget runs out" do
+      let
+        packageSet = mkPackageSet $ Map.singleton (name "example") (version "1.0.0")
+        versions = map (\major -> version (show major <> ".0.0")) (Array.range 2 100)
+        manifests = manifestIndex $ map (\v -> Utils.unsafeManifest "example" (Version.print v) []) versions
+        candidates = Map.singleton (name "example") (versionSet versions)
+        probe _ changes = case Map.lookup (name "example") changes of
+          Just (Update selected) -> pure $ Planner.CompilationFailure (fileError "example" (Version.print selected))
+          _ -> pure Planner.Compiles
+        plan = plan' probe packageSet manifests candidates
+
+      map _.truncated plan `Assert.shouldEqual` Right true
+      map _.verified plan `Assert.shouldEqual` Right Map.empty
+
+    Spec.it "keeps a support addition only when a selected version requires it" do
+      let
+        -- `extra` is a support candidate: it is eligible only because the
+        -- fallback root@2.0.0 depends on it. The latest root@3.0.0 does not.
+        packageSet = mkPackageSet $ Map.singleton (name "root") (version "1.0.0")
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "root" "2.0.0" [ Tuple "extra" ">=1.0.0 <2.0.0" ]
+          , Utils.unsafeManifest "root" "3.0.0" []
+          , Utils.unsafeManifest "extra" "1.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "root" [ "3.0.0", "2.0.0" ]
+          , candidate "extra" [ "1.0.0" ]
+          ]
+        planWith probe = Run.extract $ Except.runExcept $ Planner.planUpgrades probe packageSet manifests Set.empty candidates
+
+      -- When the latest root compiles it does not need `extra`, so the
+      -- closure never proposes the addition and the verified payload is
+      -- exactly what was compiled.
+      let latestPlan = planWith (\_ _ -> pure Planner.Compiles)
+      map _.verified latestPlan `Assert.shouldEqual` Right (versionMap [ Tuple "root" "3.0.0" ])
+
+      -- When the planner falls back to root@2.0.0, its `extra` dependency is
+      -- genuinely required and stays in the payload.
+      let
+        fallbackProbe _ changes =
+          if Map.lookup (name "root") changes == Just (Update (version "3.0.0")) then
+            pure $ Planner.CompilationFailure (fileError "root" "3.0.0")
+          else pure Planner.Compiles
+      map _.verified (planWith fallbackProbe) `Assert.shouldEqual`
+        Right (versionMap [ Tuple "root" "2.0.0", Tuple "extra" "1.0.0" ])
+
+    Spec.it "never blocks or analyzes a support candidate no selected root requires" do
+      let
+        -- `sup` is eligible only because the fallback root@2.0.0 requires it,
+        -- and adding it breaks the set. Since the selected root@3.0.0 does
+        -- not need it, `sup` must never be probed, blocked, or recommended.
+        packageSet = mkPackageSet $ Map.singleton (name "root") (version "1.0.0")
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "root" "2.0.0" [ Tuple "sup" ">=1.0.0 <2.0.0" ]
+          , Utils.unsafeManifest "root" "3.0.0" []
+          , Utils.unsafeManifest "sup" "1.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "root" [ "3.0.0", "2.0.0" ]
+          , candidate "sup" [ "1.0.0" ]
+          ]
+        probe _ changes =
+          if Map.member (name "sup") changes then
+            pure $ Planner.CompilationFailure (fileError "sup" "1.0.0")
+          else pure Planner.Compiles
+        plan = Run.extract $ Except.runExcept $ Planner.planUpgrades probe packageSet manifests Set.empty candidates
+
+      map _.verified plan `Assert.shouldEqual` Right (versionMap [ Tuple "root" "3.0.0" ])
+      map _.blocked plan `Assert.shouldEqual` Right []
+      map _.probes plan `Assert.shouldEqual` Right 1
+
+    Spec.it "does not propose removals that would also remove proposed upgrades" do
+      let
+        -- `target`'s upgrade transitively depends on the very package the
+        -- compiler implicates, so removing the blocker can never yield a
+        -- self-contained set that still contains the upgrade.
+        packageSet = mkPackageSet $ Map.fromFoldable
+          [ Tuple (name "target") (version "1.0.0")
+          , Tuple (name "blocker") (version "1.0.0")
+          ]
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "target" "1.0.0" []
+          , Utils.unsafeManifest "target" "2.0.0" [ Tuple "blocker" ">=1.0.0 <2.0.0" ]
+          , Utils.unsafeManifest "blocker" "1.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "target" [ "2.0.0" ] ]
+        probe _ changes =
+          if Map.lookup (name "target") changes == Just (Update (version "2.0.0")) then
+            pure $ Planner.CompilationFailure (fileError "blocker" "1.0.0")
+          else pure Planner.Compiles
+        results = analyze' probe packageSet manifests candidates
+
+      case results of
+        Right [ report ] -> case report.analysis of
+          Planner.RemovalsNotAnalyzed reason ->
+            String.contains (String.Pattern "target") reason `Assert.shouldEqual` true
+          Planner.RemovalsVerified _ -> Assert.fail "Expected RemovalsNotAnalyzed, got RemovalsVerified"
+          Planner.RemovalsUnverified _ -> Assert.fail "Expected RemovalsNotAnalyzed, got RemovalsUnverified"
+        other -> Assert.fail $ "Expected exactly one removal report, got: " <> show (map Array.length other)
+
+    Spec.it "does not turn infrastructure failures into compatibility results" do
+      let
+        packageSet = mkPackageSet $ Map.singleton (name "example") (version "1.0.0")
+        manifests = manifestIndex [ Utils.unsafeManifest "example" "2.0.0" [] ]
+        candidates = Map.fromFoldable
+          [ candidate "example" [ "2.0.0" ] ]
+        plan = plan' (\_ _ -> Except.throw "storage unavailable") packageSet manifests candidates
+
+      plan `Assert.shouldEqual` Left "storage unavailable"
+
+    Spec.it "extends a removal proposal when compilation reveals another blocker" do
+      let
+        packageSet = mkPackageSet $ Map.fromFoldable
+          [ Tuple (name "target") (version "1.0.0")
+          , Tuple (name "blocked-a") (version "1.0.0")
+          , Tuple (name "blocked-b") (version "1.0.0")
+          , Tuple (name "unrelated") (version "1.0.0")
+          ]
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "target" "1.0.0" []
+          , Utils.unsafeManifest "target" "2.0.0" []
+          , Utils.unsafeManifest "blocked-a" "1.0.0" []
+          , Utils.unsafeManifest "blocked-b" "1.0.0" []
+          , Utils.unsafeManifest "unrelated" "1.0.0" []
+          , Utils.unsafeManifest "unrelated" "2.0.0" []
+          ]
+        candidates = Map.fromFoldable
+          [ candidate "target" [ "2.0.0" ]
+          , candidate "unrelated" [ "2.0.0" ]
+          ]
+        probe _ changes
+          | Map.lookup (name "target") changes /= Just (Update (version "2.0.0")) = pure Planner.Compiles
+          | Map.lookup (name "blocked-a") changes /= Just Remove = pure $ Planner.CompilationFailure (fileError "blocked-a" "1.0.0")
+          | Map.lookup (name "blocked-b") changes /= Just Remove = pure $ Planner.CompilationFailure (fileError "blocked-b" "1.0.0")
+          | otherwise = pure Planner.Compiles
+        results = analyze' probe packageSet manifests candidates
+
+      case results of
+        Right [ report ] -> do
+          -- The removal probe compiled the blocked target together with the
+          -- verified `unrelated` upgrade, so both must appear in the exact
+          -- update map recommended for submission.
+          report.analysis `Assert.shouldEqual` Planner.RemovalsVerified
+            { removed: Set.fromFoldable [ name "blocked-a", name "blocked-b" ]
+            , updates: versionMap [ Tuple "target" "2.0.0", Tuple "unrelated" "2.0.0" ]
+            }
+          report.targets `Assert.shouldEqual` versionMap [ Tuple "target" "2.0.0" ]
+          map (String.contains (String.Pattern "blocked-b@1.0.0")) report.evidence `Assert.shouldEqual` Just true
+        other -> Assert.fail $ "Expected exactly one removal report, got: " <> show (map Array.length other)
+
+    Spec.it "reserves the removal-analysis budget when probing blocked components" do
+      let
+        letters = String.split (String.Pattern "") "abcdefgh"
+        pkgNames = Array.take 50 do
+          a <- letters
+          b <- letters
+          pure ("pkg-" <> a <> b)
+        packageSet = mkPackageSet $ Map.fromFoldable $ map (\pkg -> Tuple (name pkg) (version "1.0.0")) pkgNames
+        manifests = manifestIndex $ map (\pkg -> Utils.unsafeManifest pkg "2.0.0" []) pkgNames
+        candidates = Map.fromFoldable $ map (\pkg -> candidate pkg [ "2.0.0" ]) pkgNames
+        -- Every probe fails with evidence naming every updated package, so
+        -- the all-at-once probe drops everything, individual rescues fail,
+        -- and the component phase faces one component per candidate: more
+        -- than the planning budget allows.
+        probe _ changes = do
+          let
+            errors = Map.toUnfoldable changes # Array.mapMaybe \(Tuple pkg change) -> case change of
+              Update selected -> Just (fileError (PackageName.print pkg) (Version.print selected))
+              _ -> Nothing
+          pure $ Planner.CompilationFailure (String.joinWith "\n" errors)
+        plan = plan' probe packageSet manifests candidates
+
+      -- Phases 1 through 5 stop at the planning budget, leaving the rest of
+      -- the total budget in reserve for removal analysis.
+      map _.probes plan `Assert.shouldEqual` Right Planner.maxPlanProbes
+      map _.truncated plan `Assert.shouldEqual` Right true
+      map (Array.length <<< _.blocked) plan `Assert.shouldEqual` Right 50
+
+  Spec.describe "the Elmish package-set-79 scenario" do
+    let fixture = elmishFixture
+    let plan = plan' elmishOracle fixture.packageSet fixture.manifests fixture.candidates
+    let removals = analyze' elmishOracle fixture.packageSet fixture.manifests fixture.candidates
+
+    Spec.it "automatically finds the intermediate elmish-html upgrade" do
+      map _.verified plan `Assert.shouldEqual` Right (versionMap [ Tuple "elmish-html" "0.11.1" ])
+
+    Spec.it "recognizes the coordinated elmish + elmish-html upgrade blocked by elmish-hooks" do
+      map (map _.targets <<< _.blocked) plan `Assert.shouldEqual`
+        Right [ versionMap [ Tuple "elmish" "0.14.0", Tuple "elmish-html" "0.12.0" ] ]
+      map (map _.blockers <<< _.blocked) plan `Assert.shouldEqual` Right [ [ name "elmish-hooks" ] ]
+
+    Spec.it "verifies the exact removal closure without removing unaffected packages" do
+      case removals of
+        Right [ report ] -> do
+          -- The exact compiled update map: the blocked coordinated targets
+          -- override the intermediate elmish-html upgrade from the verified
+          -- payload. Unaffected packages like elmish-enzyme must not appear
+          -- in the removals.
+          report.analysis `Assert.shouldEqual` Planner.RemovalsVerified
+            { removed: Set.fromFoldable [ name "elmish-hooks", name "elmish-time-machine" ]
+            , updates: versionMap [ Tuple "elmish" "0.14.0", Tuple "elmish-html" "0.12.0" ]
+            }
+          map (String.contains (String.Pattern "elmish-hooks@0.11.0")) report.evidence `Assert.shouldEqual` Just true
+        other -> Assert.fail $ "Expected exactly one removal report, got: " <> show (map Array.length other)
+
+-- | Run the planner with a mock probe, treating every candidate as a
+-- | deliberately proposed root.
+plan'
+  :: (PackageSet -> ChangeSet -> Run (EXCEPT String + ()) Planner.ProbeResult)
+  -> PackageSet
+  -> ManifestIndex
+  -> Planner.Candidates
+  -> Either String Planner.Plan
+plan' probe packageSet manifests candidates =
+  Run.extract $ Except.runExcept $ Planner.planUpgrades probe packageSet manifests (Map.keys candidates) candidates
+
+-- | Run the planner and removal analysis with a mock probe.
+analyze'
+  :: (PackageSet -> ChangeSet -> Run (EXCEPT String + ()) Planner.ProbeResult)
+  -> PackageSet
+  -> ManifestIndex
+  -> Planner.Candidates
+  -> Either String (Array Planner.RemovalReport)
+analyze' probe packageSet manifests candidates =
+  Run.extract $ Except.runExcept do
+    plan <- Planner.planUpgrades probe packageSet manifests (Map.keys candidates) candidates
+    Planner.analyzeRemovals probe packageSet manifests plan
+
+type ElmishFixture =
+  { candidates :: Planner.Candidates
+  , manifests :: ManifestIndex
+  , packageSet :: PackageSet
+  }
+
+elmishFixture :: ElmishFixture
+elmishFixture = do
+  let
+    packages = Map.fromFoldable
+      [ Tuple (name "elmish") (version "0.13.0")
+      , Tuple (name "elmish-enzyme") (version "0.1.1")
+      , Tuple (name "elmish-hooks") (version "0.11.0")
+      , Tuple (name "elmish-html") (version "0.10.0")
+      , Tuple (name "elmish-testing-library") (version "0.3.2")
+      , Tuple (name "elmish-time-machine") (version "0.4.2")
+      , Tuple (name "whine-core") (version "0.0.34")
+      ]
+    packageSet = PackageSet.PackageSet
+      { version: version "79.0.0"
+      , compiler: version "0.15.15"
+      , published: Utils.unsafeDate "2026-07-27"
+      , packages
+      }
+    manifests = manifestIndex
+      [ Utils.unsafeManifest "elmish" "0.13.0" []
+      , Utils.unsafeManifest "elmish" "0.14.0" []
+      , Utils.unsafeManifest "elmish-html" "0.10.0" [ Tuple "elmish" ">=0.10.0 <0.14.0" ]
+      , Utils.unsafeManifest "elmish-html" "0.11.1" [ Tuple "elmish" ">=0.13.0 <0.14.0" ]
+      , Utils.unsafeManifest "elmish-html" "0.12.0" [ Tuple "elmish" ">=0.14.0 <0.15.0" ]
+      , Utils.unsafeManifest "elmish-hooks" "0.11.0" [ Tuple "elmish" ">=0.13.0 <0.14.0" ]
+      , Utils.unsafeManifest "elmish-time-machine" "0.4.2"
+          [ Tuple "elmish" ">=0.13.0 <0.14.0"
+          , Tuple "elmish-hooks" ">=0.11.0 <0.12.0"
+          , Tuple "elmish-html" ">=0.9.0 <0.11.0"
+          ]
+      , Utils.unsafeManifest "elmish-enzyme" "0.1.1" [ Tuple "elmish" ">=0.8.0 <0.14.0" ]
+      , Utils.unsafeManifest "elmish-testing-library" "0.3.2" [ Tuple "elmish" ">=0.8.0 <0.14.0" ]
+      , Utils.unsafeManifest "whine-core" "0.0.34" []
+      ]
+    candidates = Map.fromFoldable
+      [ candidate "elmish" [ "0.14.0" ]
+      , candidate "elmish-html" [ "0.12.0", "0.11.1" ]
+      ]
+  { candidates, manifests, packageSet }
+
+-- | An oracle reproducing the compiler behavior of package set 79: the
+-- | elmish@0.14.0 upgrade breaks the unchanged elmish-hooks, elmish-html's
+-- | latest version requires the new elmish, and only removing elmish-hooks
+-- | (and its dependant elmish-time-machine) lets the coordinated upgrade
+-- | compile.
+elmishOracle :: PackageSet -> ChangeSet -> Run (EXCEPT String + ()) Planner.ProbeResult
+elmishOracle _ changes = do
+  let removed package = Map.lookup (name package) changes == Just Remove
+  let updatedTo package selected = Map.lookup (name package) changes == Just (Update (version selected))
+  let
+    hooksError = String.joinWith "\n"
+      [ "Error 1 of 1"
+      , "  Module: Elmish.Hooks"
+      , "  File: scratch/package-sets/packages/elmish-hooks@0.11.0/src/Elmish/Hooks.purs"
+      , "  Message: Unknown value fork"
+      ]
+  let
+    htmlError = String.joinWith "\n"
+      [ "Error 1 of 1"
+      , "  Module: Elmish.HTML"
+      , "  File: scratch/package-sets/packages/elmish-html@0.12.0/src/Elmish/HTML.purs"
+      ]
+  if removed "elmish-hooks" && removed "elmish-time-machine" then pure Planner.Compiles
+  else if updatedTo "elmish" "0.14.0" then pure $ Planner.CompilationFailure hooksError
+  else if updatedTo "elmish-html" "0.12.0" then pure $ Planner.CompilationFailure htmlError
+  else pure Planner.Compiles
+
+candidate :: String -> Array String -> Tuple PackageName (NonEmptySet Version)
+candidate packageName versions = Tuple (name packageName) (versionSet (map version versions))
+
+versionSet :: Array Version -> NonEmptySet Version
+versionSet versions = Utils.fromJust "Expected non-empty candidate versions." (NonEmptySet.fromFoldable versions)
+
+versionMap :: Array (Tuple String String) -> Map PackageName Version
+versionMap = Map.fromFoldable <<< map (bimap name version)
+
+fileError :: String -> String -> String
+fileError packageName packageVersion = String.joinWith "\n"
+  [ "Error 1 of 1"
+  , "  File: packages/" <> packageName <> "@" <> packageVersion <> "/src/Main.purs"
+  , "  Message: Unknown value"
+  ]
+
+manifestIndex :: Array Manifest -> ManifestIndex
+manifestIndex manifests = Utils.fromRight "Could not build planner test manifest index." $
+  ManifestIndex.fromSet IgnoreRanges (Set.fromFoldable manifests)
+
+mkPackageSet :: Map PackageName Version -> PackageSet
+mkPackageSet packages = PackageSet.PackageSet
+  { version: version "1.0.0"
+  , compiler: version "0.15.10"
+  , published: Utils.unsafeDate "2024-01-01"
+  , packages
+  }
+
+name :: String -> PackageName
+name = Utils.unsafePackageName
+
+version :: String -> Version
+version = Utils.unsafeVersion

--- a/app/test/Main.purs
+++ b/app/test/Main.purs
@@ -17,6 +17,7 @@ import Test.Registry.App.Legacy.LenientVersion as Test.Legacy.LenientVersion
 import Test.Registry.App.Legacy.Manifest as Test.Legacy.Manifest
 import Test.Registry.App.Legacy.PackageSet as Test.Legacy.PackageSet
 import Test.Registry.App.Manifest.SpagoYaml as Test.Manifest.SpagoYaml
+import Test.Registry.App.PackageSetPlanner as Test.PackageSetPlanner
 import Test.Registry.App.Server.MatrixBuilder as Test.Server.MatrixBuilder
 import Test.Spec as Spec
 import Test.Spec.Reporter.Console (consoleReporter)
@@ -52,6 +53,9 @@ main = runSpecAndExitProcess' config [ consoleReporter ] do
 
   Spec.describe "Registry.App.Manifest" do
     Spec.describe "SpagoYaml" Test.Manifest.SpagoYaml.spec
+
+  Spec.describe "Registry.App.PackageSetPlanner" do
+    Test.PackageSetPlanner.spec
 
   Spec.describe "Registry.App.Server" do
     Spec.describe "MatrixBuilder" Test.Server.MatrixBuilder.spec

--- a/app/test/Test/Assert/Run.purs
+++ b/app/test/Test/Assert/Run.purs
@@ -287,9 +287,6 @@ handlePackageSetsMock = case _ of
   -- FIXME: Actually reply with a package set with a pure upgrade
   UpgradeAtomic _packageSet _compilerVersion _changeSet reply -> do
     pure $ reply $ Right $ Left ""
-  -- FIXME: Actually reply with a package sequential upgrade result
-  UpgradeSequential packageSet _compilerVersion changeSet reply ->
-    pure $ reply $ Right $ Just { failed: changeSet, succeeded: changeSet, result: packageSet }
 
 type StorageMockEnv =
   { storage :: FilePath

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -62,6 +62,10 @@ let
       module = "Registry.Scripts.PackageTransferrer";
       description = "Check for moved packages and submit transfer jobs";
     };
+    package-set-version-checker = {
+      module = "Registry.Scripts.PackageSetVersionChecker";
+      description = "Report pending package set upgrades, compile-verified";
+    };
     verify-integrity = {
       module = "Registry.Scripts.VerifyIntegrity";
       description = "Verify registry and registry-index consistency";

--- a/scripts/spago.yaml
+++ b/scripts/spago.yaml
@@ -25,3 +25,9 @@ package:
     - registry-lib
     - run
     - strings
+  test:
+    main: Test.Registry.Scripts.Main
+    dependencies:
+      - registry-test-utils
+      - spec
+      - spec-node

--- a/scripts/src/PackageSetUpdater.purs
+++ b/scripts/src/PackageSetUpdater.purs
@@ -1,5 +1,5 @@
--- | This script checks for packages recently uploaded to the registry and
--- | submits package set update jobs to add them to the package set.
+-- | This script plans a compile-verified package set upgrade and submits it
+-- | to the registry API as one exact, atomic package set update.
 -- |
 -- | Run via Nix:
 -- |   nix run .#package-set-updater -- --dry-run   # Log what would be submitted
@@ -16,29 +16,43 @@ import ArgParse.Basic as Arg
 import Codec.JSON.DecodeError as CJ.DecodeError
 import Data.Array as Array
 import Data.Codec.JSON as CJ
+import Data.DateTime (DateTime)
 import Data.DateTime as DateTime
+import Data.Foldable as Foldable
 import Data.Map as Map
+import Data.Set as Set
+import Data.Set.NonEmpty as NonEmptySet
+import Data.String as String
 import Data.Time.Duration (Hours(..))
 import Effect.Aff as Aff
 import Effect.Class.Console as Console
 import Fetch (Method(..))
 import Fetch as Fetch
 import JSON as JSON
+import Node.Path as Path
 import Node.Process as Process
 import Registry.API.V1 as V1
 import Registry.App.CLI.Git as Git
 import Registry.App.Effect.Cache as Cache
+import Registry.App.Effect.Env (RESOURCE_ENV)
 import Registry.App.Effect.Env as Env
 import Registry.App.Effect.Log (LOG)
 import Registry.App.Effect.Log as Log
+import Registry.App.Effect.PackageSets (PACKAGE_SETS)
 import Registry.App.Effect.PackageSets as PackageSets
 import Registry.App.Effect.Registry (REGISTRY_READ)
 import Registry.App.Effect.Registry as Registry
+import Registry.App.Effect.Storage (STORAGE)
+import Registry.App.Effect.Storage as Storage
+import Registry.App.PackageSetPlanner as Planner
+import Registry.Foreign.FSExtra as FS.Extra
+import Registry.Manifest (Manifest(..))
+import Registry.ManifestIndex (ManifestIndex)
+import Registry.ManifestIndex as ManifestIndex
+import Registry.Metadata (Metadata(..))
 import Registry.Operation (PackageSetOperation(..))
 import Registry.Operation as Operation
-import Registry.PackageName as PackageName
 import Registry.PackageSet (PackageSet(..))
-import Registry.Version as Version
 import Run (AFF, EFFECT, Run)
 import Run as Run
 import Run.Except (EXCEPT)
@@ -62,7 +76,7 @@ main :: Effect Unit
 main = launchAff_ do
   args <- Array.drop 2 <$> liftEffect Process.argv
 
-  let description = "Check for recent uploads and submit package set update jobs to the registry API."
+  let description = "Plan a compile-verified package set upgrade and submit it to the registry API."
   mode <- case Arg.parseArgs "package-set-updater" description parser args of
     Left err -> Console.log (Arg.printArgError err) *> liftEffect (Process.exit' 1)
     Right command -> pure command
@@ -70,6 +84,8 @@ main = launchAff_ do
   Env.loadEnvFile ".env"
   resourceEnv <- Env.lookupResourceEnv
 
+  let cache = Path.concat [ scratchDir, ".cache" ]
+  FS.Extra.ensureDirectory cache
   registryCacheRef <- Cache.newCacheRef
 
   debouncer <- Registry.newDebouncer
@@ -87,8 +103,11 @@ main = launchAff_ do
       }
 
   runPackageSetUpdater mode resourceEnv.registryApiUrl
+    # PackageSets.interpret (PackageSets.handle { workdir: scratchDir })
     # Except.runExcept
     # Registry.interpretRead (Registry.handleRead registryEnv)
+    # Storage.interpret (Storage.handleReadOnly cache)
+    # Env.runResourceEnv resourceEnv
     # Log.interpret (Log.handleTerminal Normal)
     # Run.runBaseAff'
     >>= case _ of
@@ -97,101 +116,110 @@ main = launchAff_ do
         liftEffect $ Process.exit' 1
       Right _ -> pure unit
 
-type PackageSetUpdaterEffects = (REGISTRY_READ + LOG + EXCEPT String + AFF + EFFECT + ())
+type PackageSetUpdaterEffects = (REGISTRY_READ + PACKAGE_SETS + STORAGE + RESOURCE_ENV + LOG + EXCEPT String + AFF + EFFECT + ())
 
 runPackageSetUpdater :: Mode -> URL -> Run PackageSetUpdaterEffects Unit
 runPackageSetUpdater mode registryApiUrl = do
-  Log.info "Package Set Updater: checking for recent uploads..."
+  Log.info "Package Set Updater: planning package set upgrades..."
 
-  -- Get the current package set
-  latestPackageSet <- Registry.readLatestPackageSet >>= case _ of
-    Nothing -> do
-      Log.warn "No package set found, skipping package set updates"
-      pure Nothing
-    Just set -> pure (Just set)
-
-  for_ latestPackageSet \packageSet -> do
-    let currentPackages = (un PackageSet packageSet).packages
-
-    -- Find packages uploaded in the last 24 hours
-    recentUploads <- findRecentUploads (Hours 24.0)
-    let
-      -- Filter out packages already in the set at the same or newer version
-      newOrUpdated = recentUploads # Map.filterWithKey \name version ->
-        case Map.lookup name currentPackages of
-          Nothing -> true -- new package
-          Just currentVersion -> version > currentVersion -- upgrade
-
-    if Map.isEmpty newOrUpdated then
-      Log.info "No new packages for package set update."
-    else do
-      Log.info $ "Found " <> show (Map.size newOrUpdated) <> " candidates to validate"
-
-      -- Pre-validate candidates to filter out packages with missing dependencies
-      manifestIndex <- Registry.readAllManifests
-      let candidates = PackageSets.validatePackageSetCandidates manifestIndex packageSet (map Just newOrUpdated)
-
-      unless (Map.isEmpty candidates.rejected) do
-        Log.info $ "Some packages are not eligible for the package set:\n" <> PackageSets.printRejections candidates.rejected
-
-      -- Only include accepted packages (filter out removals, keep only updates)
-      let accepted = Map.catMaybes candidates.accepted
-
-      if Map.isEmpty accepted then
-        Log.info "No packages passed validation for package set update."
+  Registry.readLatestPackageSet >>= case _ of
+    Nothing -> Log.warn "No package set found, skipping package set updates."
+    Just packageSet -> do
+      now <- nowUTC
+      metadata <- Registry.readAllMetadata
+      manifests <- Registry.readAllManifests
+      let additions = recentAdditionSeeds now (Hours 24.0) packageSet metadata
+      let candidates = plannerCandidates packageSet metadata manifests additions
+      if Map.isEmpty candidates then
+        Log.info "No package set candidates have usable manifests; nothing to do."
       else do
-        Log.info $ "Validated " <> show (Map.size accepted) <> " packages for package set update"
+        Log.info $ "Compile-planning upgrades for " <> show (Map.size candidates) <> " candidate packages..."
+        plan <- Planner.planUpgrades Planner.probeAtomic packageSet manifests (Map.keys additions) candidates
+        when plan.truncated do
+          Log.warn "The planner exhausted its probe budget. The verified payload below still compiled exactly, but it may not include every possible upgrade."
+        if Map.isEmpty plan.verified then
+          Log.info "No upgrades could be compile-verified; nothing to submit."
+        else do
+          let
+            operation = PackageSetUpdate
+              { compiler: Nothing
+              , packages: map Just plan.verified
+              }
+            formatted = Map.toUnfoldable plan.verified <#> \(Tuple name version) ->
+              "  - " <> formatPackageVersion name version
+          case mode of
+            DryRun ->
+              Log.info $ "[DRY RUN] Would submit verified package set updates:\n" <> String.joinWith "\n" formatted
+            Submit -> do
+              let
+                request :: Operation.PackageSetUpdateRequest
+                request =
+                  { payload: operation
+                  , rawPayload: JSON.print $ CJ.encode Operation.packageSetOperationCodec operation
+                  , signature: Nothing
+                  }
+              Log.info $ "Submitting verified package set updates:\n" <> String.joinWith "\n" formatted
+              result <- Run.liftAff $ submitPackageSetJob (registryApiUrl <> "/v1/package-sets") request
+              case result of
+                Left err -> Except.throw $ "Failed to submit package set job: " <> err
+                Right { jobId } -> do
+                  Log.info $ "Submitted package set job " <> unwrap jobId <> "; waiting for publication..."
+                  Run.liftAff (pollPackageSetJob registryApiUrl jobId) >>= case _ of
+                    Left err -> Except.throw err
+                    Right _ -> Log.notice $ "Package set job " <> unwrap jobId <> " completed successfully."
 
-        -- Create a package set update payload
-        let
-          payload :: Operation.PackageSetUpdateData
-          payload =
-            { compiler: Nothing -- Use current compiler
-            , packages: map Just accepted -- Just version = add/update
-            }
+-- | Packages that are not in the package set but were uploaded within the
+-- | window, at their latest published version. These seed addition
+-- | candidates; packages already in the set are always candidates for every
+-- | pending newer version, no matter when it was published.
+recentAdditionSeeds :: DateTime -> Hours -> PackageSet -> Map PackageName Metadata -> Map PackageName Version
+recentAdditionSeeds now limit (PackageSet packageSet) = Map.mapMaybeWithKey \name (Metadata metadata) -> do
+  guard $ not $ Map.member name packageSet.packages
+  let recent = Array.filter (\(Tuple _ { publishedTime }) -> between (Hours 0.0) limit (DateTime.diff now publishedTime)) (Map.toUnfoldable metadata.published)
+  Array.last $ Array.sort $ map fst recent
 
-        case mode of
-          DryRun -> do
-            Log.info $ "[DRY RUN] Would submit package set update with packages:"
-            for_ (Map.toUnfoldable accepted :: Array _) \(Tuple name version) ->
-              Log.info $ "  - " <> PackageName.print name <> "@" <> Version.print version
+-- | Assemble planner candidates: existing packages contribute every newer
+-- | published release, and both existing upgrades and addition seeds are
+-- | expanded with any dependency names absent from the current package set so
+-- | the planner can consider a self-contained plan. Recency gates which
+-- | additions are independently proposed (the seeds), not which dependencies
+-- | may satisfy a candidate: a dependency required by an eligible candidate is
+-- | pulled in no matter when it was published. The planner includes such
+-- | support packages only at their latest version, and only in payloads whose
+-- | roots actually require them. Versions without an indexed manifest are
+-- | excluded because the planner cannot reason about their dependencies.
+-- | Declared ranges and compiler publication metadata are deliberately not
+-- | gates: the compiler decides what is compatible.
+plannerCandidates :: PackageSet -> Map PackageName Metadata -> ManifestIndex -> Map PackageName Version -> Planner.Candidates
+plannerCandidates packageSet@(PackageSet set) metadata manifests additionSeeds =
+  Map.union existingCandidates (close seeds)
+  where
+  hasManifest name version = isJust $ ManifestIndex.lookup name version manifests
 
-          Submit -> do
-            let
-              rawPayload = JSON.print $ CJ.encode Operation.packageSetUpdateCodec payload
+  existingCandidates = Planner.existingPackageCandidates packageSet metadata # Map.mapMaybeWithKey \name versions ->
+    NonEmptySet.fromSet $ Set.filter (hasManifest name) $ NonEmptySet.toSet versions
 
-              request :: Operation.PackageSetUpdateRequest
-              request =
-                { payload: PackageSetUpdate payload
-                , rawPayload
-                , signature: Nothing
-                }
+  existingDependencies = Array.concatMap dependenciesOf (Map.toUnfoldable existingCandidates)
 
-            Log.info $ "Submitting package set update..."
-            result <- Run.liftAff $ submitPackageSetJob (registryApiUrl <> "/v1/package-sets") request
-            case result of
-              Left err -> do
-                Log.error $ "Failed to submit package set job: " <> err
-              Right { jobId } -> do
-                Log.info $ "Submitted package set job " <> unwrap jobId
+  seeds = additionSeeds # Map.mapMaybeWithKey \name version -> do
+    guard $ not (Map.member name set.packages) && hasManifest name version
+    pure $ NonEmptySet.singleton version
 
--- | Find the latest version of each package uploaded within the time limit
-findRecentUploads :: Hours -> Run PackageSetUpdaterEffects (Map PackageName Version)
-findRecentUploads limit = do
-  allMetadata <- Registry.readAllMetadata
-  now <- nowUTC
+  close selected = do
+    let dependencies = existingDependencies <> Array.concatMap dependenciesOf (Map.toUnfoldable selected)
+    let missing = Array.filter (\name -> not (Map.member name set.packages) && not (Map.member name selected)) dependencies
+    let next = Foldable.foldl addLatestVersion selected missing
+    if next == selected then selected else close next
 
-  let
-    getLatestRecentVersion :: Metadata -> Maybe Version
-    getLatestRecentVersion (Metadata metadata) = do
-      let
-        recentVersions = Array.catMaybes $ flip map (Map.toUnfoldable metadata.published)
-          \(Tuple version { publishedTime }) ->
-            if (DateTime.diff now publishedTime) <= limit then Just version else Nothing
-      Array.last $ Array.sort recentVersions
+  dependenciesOf (Tuple name versions) = Array.fromFoldable versions # Array.concatMap \selected ->
+    case ManifestIndex.lookup name selected manifests of
+      Nothing -> []
+      Just (Manifest manifest) -> Array.fromFoldable $ Map.keys manifest.dependencies
 
-  pure $ Map.fromFoldable $ Array.catMaybes $ flip map (Map.toUnfoldable allMetadata) \(Tuple name metadata) ->
-    map (Tuple name) $ getLatestRecentVersion metadata
+  addLatestVersion selected name = fromMaybe selected do
+    Metadata packageMetadata <- Map.lookup name metadata
+    latest <- Set.findMax $ Set.filter (hasManifest name) $ Map.keys packageMetadata.published
+    pure $ Map.insert name (NonEmptySet.singleton latest) selected
 
 -- | Submit a package set job to the registry API
 submitPackageSetJob :: String -> Operation.PackageSetUpdateRequest -> Aff (Either String V1.JobCreatedResponse)
@@ -210,5 +238,55 @@ submitPackageSetJob url request = do
         case JSON.parse responseBody >>= \json -> lmap CJ.DecodeError.print (CJ.decode V1.jobCreatedResponseCodec json) of
           Left err -> pure $ Left $ "Failed to parse response: " <> err
           Right r -> pure $ Right r
+      else
+        pure $ Left $ "HTTP " <> show response.status <> ": " <> responseBody
+
+-- | Wait for the server-side exact recompile and publication to finish. The
+-- | script must not report success merely because a durable job was queued,
+-- | and the server allows jobs up to 90 minutes, so we poll a little longer
+-- | than that.
+pollPackageSetJob :: String -> V1.JobId -> Aff (Either String Unit)
+pollPackageSetJob registryApiUrl jobId = go 1 0
+  where
+  maxAttempts = 1200
+  maxConsecutiveErrors = 5
+  interval = Aff.Milliseconds 5_000.0
+  url = registryApiUrl <> "/v1/jobs/" <> unwrap jobId <> "?level=NOTICE"
+
+  go attempt consecutiveErrors
+    | attempt > maxAttempts =
+        pure $ Left $ "Package set job " <> unwrap jobId <> " did not finish within 100 minutes."
+    | otherwise = do
+        result <- fetchPackageSetJob url
+        case result of
+          Left error
+            | consecutiveErrors + 1 >= maxConsecutiveErrors ->
+                pure $ Left $ "Could not poll package set job " <> unwrap jobId <> " after " <> show maxConsecutiveErrors <> " consecutive errors: " <> error
+            | otherwise -> do
+                Aff.delay interval
+                go (attempt + 1) (consecutiveErrors + 1)
+          Right job -> do
+            let info = V1.jobInfo job
+            case info.finishedAt of
+              Nothing -> do
+                Aff.delay interval
+                go (attempt + 1) 0
+              Just _ | info.success ->
+                pure $ Right unit
+              Just _ -> do
+                let logs = Foldable.foldMap (\line -> "\n" <> line.message) info.logs
+                pure $ Left $ "Package set job " <> unwrap jobId <> " failed:" <> logs
+
+fetchPackageSetJob :: String -> Aff (Either String V1.Job)
+fetchPackageSetJob url = do
+  result <- Aff.attempt $ Fetch.fetch url { method: GET }
+  case result of
+    Left err -> pure $ Left $ "Network error: " <> Aff.message err
+    Right response -> do
+      responseBody <- response.text
+      if response.status >= 200 && response.status < 300 then
+        case JSON.parse responseBody >>= \json -> lmap CJ.DecodeError.print (CJ.decode V1.jobCodec json) of
+          Left err -> pure $ Left $ "Failed to parse package set job: " <> err
+          Right job -> pure $ Right job
       else
         pure $ Left $ "HTTP " <> show response.status <> ": " <> responseBody

--- a/scripts/src/PackageSetVersionChecker.purs
+++ b/scripts/src/PackageSetVersionChecker.purs
@@ -1,0 +1,234 @@
+-- | Compile-verified report of pending package set upgrades.
+-- |
+-- | This script plans upgrades over every registry version newer than its
+-- | version in the latest package set, exactly as the package set updater
+-- | would, and reports the results as Markdown:
+-- |
+-- |  - upgrades that compile and can be submitted automatically, and
+-- |  - upgrades that cannot be applied automatically because they require
+-- |    removing packages from the set, with compile-verified removal payloads
+-- |    that a Registry Trustee can review and submit.
+-- |
+-- | Packages that have never appeared in a package set are not independently
+-- | proposed by this report, though one may be included when a proposed
+-- | upgrade depends on it; discovering those packages is tracked as separate
+-- | follow-up work. Upgrades that would require downgrading a package in the
+-- | set are likewise not analyzed: the registry API rejects downgrades, so
+-- | supporting them needs its own analysis and authenticated submission path.
+-- |
+-- | Run via Nix:
+-- |   nix run .#package-set-version-checker                        # Print the report
+-- |   nix run .#package-set-version-checker -- --output report.md  # Also write it to a file
+module Registry.Scripts.PackageSetVersionChecker where
+
+import Registry.App.Prelude
+
+import ArgParse.Basic (ArgParser)
+import ArgParse.Basic as Arg
+import Data.Array as Array
+import Data.DateTime (DateTime)
+import Data.Map as Map
+import Data.Set as Set
+import Data.String as String
+import Effect.Class.Console as Console
+import Node.FS.Aff as FS.Aff
+import Node.Path as Path
+import Node.Process as Process
+import Registry.App.CLI.Git as Git
+import Registry.App.Effect.Cache as Cache
+import Registry.App.Effect.Env (RESOURCE_ENV)
+import Registry.App.Effect.Env as Env
+import Registry.App.Effect.Log (LOG)
+import Registry.App.Effect.Log as Log
+import Registry.App.Effect.PackageSets (PACKAGE_SETS)
+import Registry.App.Effect.PackageSets as PackageSets
+import Registry.App.Effect.Registry (REGISTRY_READ)
+import Registry.App.Effect.Registry as Registry
+import Registry.App.Effect.Storage (STORAGE)
+import Registry.App.Effect.Storage as Storage
+import Registry.App.PackageSetPlanner (Plan, RemovalAnalysis(..), RemovalReport)
+import Registry.App.PackageSetPlanner as Planner
+import Registry.Foreign.FSExtra as FS.Extra
+import Registry.Internal.Codec as Internal.Codec
+import Registry.Operation (PackageSetOperation(..))
+import Registry.Operation as Operation
+import Registry.PackageName as PackageName
+import Registry.PackageSet (PackageSet(..))
+import Registry.Scripts.PackageSetUpdater as PackageSetUpdater
+import Registry.Version as Version
+import Run (AFF, EFFECT, Run)
+import Run as Run
+import Run.Except (EXCEPT)
+import Run.Except as Except
+
+parser :: ArgParser (Maybe FilePath)
+parser = Arg.argument [ "--output" ] "Also write the Markdown report to this file." # Arg.optional
+
+main :: Effect Unit
+main = launchAff_ do
+  args <- Array.drop 2 <$> liftEffect Process.argv
+
+  let description = "Report pending package set upgrades, compile-verified."
+  output <- case Arg.parseArgs "package-set-version-checker" description parser args of
+    Left err -> Console.log (Arg.printArgError err) *> liftEffect (Process.exit' 1)
+    Right parsed -> pure parsed
+
+  Env.loadEnvFile ".env"
+  resourceEnv <- Env.lookupResourceEnv
+
+  let cache = Path.concat [ scratchDir, ".cache" ]
+  FS.Extra.ensureDirectory cache
+  registryCacheRef <- Cache.newCacheRef
+
+  debouncer <- Registry.newDebouncer
+
+  let
+    registryEnv :: Registry.RegistryEnv
+    registryEnv =
+      { jobId: Nothing
+      , pull: Git.Autostash
+      , write: Registry.ReadOnly
+      , repos: Registry.defaultRepos
+      , workdir: scratchDir
+      , debouncer
+      , cacheRef: registryCacheRef
+      }
+
+  runVersionCheck
+    # PackageSets.interpret (PackageSets.handle { workdir: scratchDir })
+    # Except.runExcept
+    # Registry.interpretRead (Registry.handleRead registryEnv)
+    # Storage.interpret (Storage.handleReadOnly cache)
+    # Env.runResourceEnv resourceEnv
+    # Log.interpret (Log.handleTerminal Normal)
+    # Run.runBaseAff'
+    >>= case _ of
+      Left err -> do
+        Console.error $ "Error: " <> err
+        liftEffect $ Process.exit' 1
+      Right Nothing ->
+        Console.log "No package set found; no report was generated."
+      Right (Just results) -> do
+        generatedAt <- nowUTC
+        let markdown = renderReport generatedAt results
+        Console.log markdown
+        for_ output \path -> FS.Aff.writeTextFile UTF8 path (markdown <> "\n")
+
+type VersionCheckEffects = (REGISTRY_READ + PACKAGE_SETS + STORAGE + RESOURCE_ENV + LOG + EXCEPT String + AFF + EFFECT + ())
+
+type CheckResults =
+  { packageSet :: PackageSet
+  , plan :: Plan
+  , removals :: Array RemovalReport
+  }
+
+runVersionCheck :: Run VersionCheckEffects (Maybe CheckResults)
+runVersionCheck = do
+  Log.info "Registry Version Check: planning pending package set upgrades..."
+  Registry.readLatestPackageSet >>= case _ of
+    Nothing -> do
+      Log.warn "No package set found, skipping version check."
+      pure Nothing
+    Just packageSet -> do
+      metadata <- Registry.readAllMetadata
+      manifests <- Registry.readAllManifests
+      let candidates = PackageSetUpdater.plannerCandidates packageSet metadata manifests Map.empty
+      Log.info $ "Compile-planning upgrades for " <> show (Map.size candidates) <> " candidate packages..."
+      plan <- Planner.planUpgrades Planner.probeAtomic packageSet manifests Set.empty candidates
+      removals <- Planner.analyzeRemovals Planner.probeAtomic packageSet manifests plan
+      pure $ Just { packageSet, plan, removals }
+
+-- | Render the version check results as a Markdown report suitable for a
+-- | GitHub issue.
+renderReport :: DateTime -> CheckResults -> String
+renderReport generatedAt { packageSet: PackageSet set, plan, removals } = String.joinWith "\n" $ Array.concat
+  [ [ "# Package set version check"
+    , ""
+    , "Package set: `" <> Version.print set.version <> "` (PureScript `" <> Version.print set.compiler <> "`)"
+    , "Generated: `" <> Internal.Codec.formatIso8601 generatedAt <> "`"
+    , ""
+    ]
+  , if not plan.truncated then []
+    else
+      [ "⚠️ The planner exhausted its probe budget, so this report may be incomplete. Verified results below still compiled exactly."
+      , ""
+      ]
+  , automaticSection
+  , manualSection
+  ]
+  where
+  automaticSection = Array.concat
+    [ [ "## Verified automatic upgrades", "" ]
+    , if Map.isEmpty plan.verified then
+        [ "No pending upgrades could be compile-verified for automatic submission.", "" ]
+      else Array.concat
+        [ map renderUpgrade (Map.toUnfoldable plan.verified)
+        , [ ""
+          , "This exact payload compiled as a whole set and is eligible for automatic submission. The package set updater (`nix run .#package-set-updater -- --submit`) replans against the latest package set before submitting, so its payload may differ if the registry has moved on:"
+          , ""
+          , payloadFence plan.verified Set.empty
+          , ""
+          ]
+        ]
+    ]
+
+  renderUpgrade (Tuple name version) = do
+    let from = maybe "new" Version.print (Map.lookup name set.packages)
+    "- `" <> PackageName.print name <> "`: `" <> from <> "` → `" <> Version.print version <> "`"
+
+  manualSection = Array.concat
+    [ [ "## Upgrades requiring manual intervention", "" ]
+    , if Array.null removals then
+        [ "All pending upgrades were included in the automatic payload. Nothing requires trustee attention." ]
+      else Array.concatMap renderRemoval removals
+    ]
+
+  renderRemoval report = Array.concat
+    [ [ "### " <> String.joinWith ", " (map (\(Tuple name version) -> "`" <> formatPackageVersion name version <> "`") (Map.toUnfoldable report.targets))
+      , ""
+      ]
+    , case report.analysis of
+        RemovalsVerified { removed, updates } ->
+          [ "Removing " <> printNames removed <> " lets these upgrades compile. This exact payload — the upgrades above together with every verified automatic upgrade — was compile-verified against package set `" <> Version.print set.version <> "` and can be submitted by a Registry Trustee:"
+          , ""
+          , payloadFence updates removed
+          ]
+        RemovalsUnverified removedPackages ->
+          [ "Removing " <> printNames removedPackages <> " was suggested by compiler output, but the resulting set did not compile. Do not submit this without further investigation."
+          ]
+        RemovalsNotAnalyzed reason ->
+          [ "No removal payload could be recommended: " <> reason ]
+    , if Array.null report.blockers then []
+      else [ "", "Blocked by: " <> printNames (Set.fromFoldable report.blockers) ]
+    , case report.evidence of
+        Nothing -> [ "" ]
+        Just evidence ->
+          [ ""
+          , "<details><summary>Compiler evidence</summary>"
+          , ""
+          , "```"
+          , evidence
+          , "```"
+          , ""
+          , "</details>"
+          , ""
+          ]
+    ]
+
+  printNames :: Set PackageName -> String
+  printNames names = String.joinWith ", " $ map (\name -> "`" <> PackageName.print name <> "`") (Array.fromFoldable names)
+
+  payloadFence :: Map PackageName Version -> Set PackageName -> String
+  payloadFence updates removedPackages = do
+    let
+      removalChanges :: Map PackageName (Maybe Version)
+      removalChanges = Map.fromFoldable $ map (\name -> Tuple name Nothing) (Array.fromFoldable removedPackages :: Array PackageName)
+      operation = PackageSetUpdate
+        { compiler: Nothing
+        , packages: Map.union removalChanges (map Just updates)
+        }
+    String.joinWith "\n"
+      [ "```json"
+      , printJson Operation.packageSetOperationCodec operation
+      , "```"
+      ]

--- a/scripts/test/Main.purs
+++ b/scripts/test/Main.purs
@@ -1,0 +1,171 @@
+module Test.Registry.Scripts.Main (main) where
+
+import Registry.App.Prelude
+
+import Data.Array as Array
+import Data.DateTime (DateTime)
+import Data.Map as Map
+import Data.Set as Set
+import Data.String as String
+import Data.Time.Duration (Hours(..))
+import Registry.App.PackageSetPlanner as Planner
+import Registry.Manifest (Manifest)
+import Registry.ManifestIndex (IncludeRanges(..), ManifestIndex)
+import Registry.ManifestIndex as ManifestIndex
+import Registry.Metadata (Metadata)
+import Registry.Metadata as Metadata
+import Registry.PackageName (PackageName)
+import Registry.PackageSet (PackageSet)
+import Registry.PackageSet as PackageSet
+import Registry.Scripts.PackageSetUpdater as PackageSetUpdater
+import Registry.Scripts.PackageSetVersionChecker as PackageSetVersionChecker
+import Registry.Test.Assert as Assert
+import Registry.Test.Utils as Utils
+import Registry.Version (Version)
+import Test.Spec as Spec
+import Test.Spec.Reporter.Console (consoleReporter)
+import Test.Spec.Runner.Node (runSpecAndExitProcess)
+
+main :: Effect Unit
+main = runSpecAndExitProcess [ consoleReporter ] do
+  Spec.describe "PackageSetUpdater candidate selection" do
+    Spec.it "seeds additions from recent uploads of packages not in the set" do
+      let
+        oldTime = Utils.unsafeDateTime "2023-12-30T00:00:00.000Z"
+        now = Utils.unsafeDateTime "2024-01-02T00:00:00.000Z"
+        metadata = Map.fromFoldable
+          [ Utils.unsafeMetadata "prelude" [ Tuple "1.0.0" [ "0.15.10" ], Tuple "2.0.0" [ "0.15.10" ] ]
+          , withPublishedTime oldTime $ Utils.unsafeMetadata "old-upload" [ Tuple "1.0.0" [ "0.15.10" ] ]
+          , Utils.unsafeMetadata "new-package" [ Tuple "1.0.0" [ "0.15.10" ] ]
+          ]
+        packageSet = mkPackageSet $ Map.singleton (name "prelude") (version "1.0.0")
+
+      -- `prelude` is excluded because it is already in the set: pending
+      -- upgrades of set members are always planner candidates and never
+      -- expire. `old-upload` is excluded because it is not a recent upload.
+      PackageSetUpdater.recentAdditionSeeds now (Hours 24.0) packageSet metadata
+        `Assert.shouldEqual` Map.singleton (name "new-package") (version "1.0.0")
+
+    Spec.it "uses all newer existing versions and closes recent additions by dependency name" do
+      let
+        packageSet = mkPackageSet $ Map.singleton (name "existing") (version "1.0.0")
+        metadata = Map.fromFoldable
+          [ Utils.unsafeMetadata "existing" [ Tuple "1.0.0" [ "0.1.0" ], Tuple "2.0.0" [ "0.1.0" ], Tuple "3.0.0" [ "0.1.0" ] ]
+          , Utils.unsafeMetadata "recent" [ Tuple "1.0.0" [ "0.1.0" ] ]
+          , Utils.unsafeMetadata "closure-dep" [ Tuple "1.0.0" [ "0.1.0" ], Tuple "2.0.0" [ "0.1.0" ] ]
+          , Utils.unsafeMetadata "upgrade-dep" [ Tuple "1.0.0" [ "0.1.0" ] ]
+          ]
+        manifests = manifestIndex
+          [ Utils.unsafeManifest "existing" "2.0.0" []
+          , Utils.unsafeManifest "existing" "3.0.0" [ Tuple "upgrade-dep" ">=99.0.0 <100.0.0" ]
+          , Utils.unsafeManifest "recent" "1.0.0" [ Tuple "closure-dep" ">=99.0.0 <100.0.0" ]
+          , Utils.unsafeManifest "closure-dep" "1.0.0" []
+          , Utils.unsafeManifest "closure-dep" "2.0.0" []
+          , Utils.unsafeManifest "upgrade-dep" "1.0.0" []
+          ]
+        recent = Map.singleton (name "recent") (version "1.0.0")
+        candidates = PackageSetUpdater.plannerCandidates packageSet metadata manifests recent
+        byName = map (Array.reverse <<< Array.fromFoldable) candidates
+
+      Map.lookup (name "existing") byName `Assert.shouldEqual` Just [ version "3.0.0", version "2.0.0" ]
+      Map.lookup (name "recent") byName `Assert.shouldEqual` Just [ version "1.0.0" ]
+      -- Support packages are only ever used at their latest version, so only
+      -- that version is a candidate.
+      Map.lookup (name "closure-dep") byName `Assert.shouldEqual` Just [ version "2.0.0" ]
+      -- `upgrade-dep` is not a recent upload and has never been in a set, but
+      -- the `existing` upgrade requires it, so the closure includes it:
+      -- recency only gates which additions are seeded, never dependencies.
+      Map.lookup (name "upgrade-dep") byName `Assert.shouldEqual` Just [ version "1.0.0" ]
+
+  Spec.describe "PackageSetVersionChecker report" do
+    Spec.it "renders an actionable version check report" do
+      -- A plan and removal analysis matching the Elmish package-set-79
+      -- scenario, whose planner behavior is tested end-to-end in
+      -- Test.Registry.App.PackageSetPlanner. Here we only test rendering.
+      let
+        packageSet = PackageSet.PackageSet
+          { version: version "79.0.0"
+          , compiler: version "0.15.15"
+          , published: Utils.unsafeDate "2026-07-27"
+          , packages: Map.fromFoldable
+              [ Tuple (name "elmish") (version "0.13.0")
+              , Tuple (name "elmish-hooks") (version "0.11.0")
+              , Tuple (name "elmish-html") (version "0.10.0")
+              , Tuple (name "elmish-time-machine") (version "0.4.2")
+              , Tuple (name "whine-core") (version "0.0.34")
+              ]
+          }
+        hooksEvidence = String.joinWith "\n"
+          [ "Error 1 of 1"
+          , "  Module: Elmish.Hooks"
+          , "  File: scratch/package-sets/packages/elmish-hooks@0.11.0/src/Elmish/Hooks.purs"
+          , "  Message: Unknown value fork"
+          ]
+        blockedTargets = versionMap [ Tuple "elmish" "0.14.0", Tuple "elmish-html" "0.12.0" ]
+        -- The verified payload includes an upgrade unrelated to the blocked
+        -- group; the removal probe compiled it too, so the trustee payload
+        -- must carry it.
+        verified = versionMap [ Tuple "elmish-html" "0.11.1", Tuple "whine-core" "0.0.35" ]
+        plan =
+          { blocked: [ { blockers: [ name "elmish-hooks" ], evidence: Just hooksEvidence, targets: blockedTargets } ]
+          , probes: 10
+          , truncated: false
+          , verified
+          }
+        removals =
+          [ { analysis: Planner.RemovalsVerified
+                { removed: Set.fromFoldable [ name "elmish-hooks", name "elmish-time-machine" ]
+                , updates: Map.union blockedTargets verified
+                }
+            , blockers: [ name "elmish-hooks" ]
+            , evidence: Just hooksEvidence
+            , targets: blockedTargets
+            }
+          ]
+        generatedAt = Utils.unsafeDateTime "2026-07-27T12:00:00.000Z"
+        markdown = PackageSetVersionChecker.renderReport generatedAt { packageSet, plan, removals }
+        shouldMention excerpt = String.contains (String.Pattern excerpt) markdown `Assert.shouldEqual` true
+
+      -- The automatic payload and its submission command.
+      shouldMention "`elmish-html`: `0.10.0` → `0.11.1`"
+      shouldMention "\"elmish-html\": \"0.11.1\""
+      shouldMention "nix run .#package-set-updater -- --submit"
+      -- The trustee removal payload.
+      shouldMention "\"elmish-hooks\": null"
+      shouldMention "\"elmish-time-machine\": null"
+      shouldMention "\"elmish\": \"0.14.0\""
+      shouldMention "\"elmish-html\": \"0.12.0\""
+      -- The compiler evidence that motivated the removal.
+      shouldMention "elmish-hooks@0.11.0/src"
+      -- The trustee payload is the exact compiled update map, so it includes
+      -- the verified `whine-core` upgrade even though it is unrelated to the
+      -- blocked group.
+      case Array.index (String.split (String.Pattern "## Upgrades requiring manual intervention") markdown) 1 of
+        Nothing -> Assert.fail "Expected a manual intervention section."
+        Just manualSection -> String.contains (String.Pattern "\"whine-core\": \"0.0.35\"") manualSection `Assert.shouldEqual` true
+
+versionMap :: Array (Tuple String String) -> Map PackageName Version
+versionMap = Map.fromFoldable <<< map (bimap name version)
+
+manifestIndex :: Array Manifest -> ManifestIndex
+manifestIndex manifests = Utils.fromRight "Could not build scripts test manifest index." $
+  ManifestIndex.fromSet IgnoreRanges (Set.fromFoldable manifests)
+
+mkPackageSet :: Map PackageName Version -> PackageSet
+mkPackageSet packages = PackageSet.PackageSet
+  { version: version "1.0.0"
+  , compiler: version "0.15.10"
+  , published: Utils.unsafeDate "2024-01-01"
+  , packages
+  }
+
+withPublishedTime :: forall a. DateTime -> Tuple a Metadata -> Tuple a Metadata
+withPublishedTime publishedTime (Tuple package (Metadata.Metadata metadata)) =
+  Tuple package $ Metadata.Metadata $ metadata
+    { published = map (_ { publishedTime = publishedTime }) metadata.published }
+
+name :: String -> PackageName
+name = Utils.unsafePackageName
+
+version :: String -> Version
+version = Utils.unsafeVersion

--- a/spago.lock
+++ b/spago.lock
@@ -291,7 +291,11 @@
           ]
         },
         "test": {
-          "dependencies": []
+          "dependencies": [
+            "registry-test-utils",
+            "spec",
+            "spec-node"
+          ]
         }
       },
       "registry-test-utils": {


### PR DESCRIPTION
Closes #426 by adding a `.#version-check` script to report registry versions newer than the versions in the latest package set. This reuses the package set updater candidate traversal instead of being brand-new.

I ran the script against package set `77.13.1` and found 19 pending versions. Not all of them can compile together, but 14 of them do, and that's submitted as [purescript/registry#560](https://github.com/purescript/registry/issues/560).

Five versions were intentionally left out:

- `barlow-lens@1.0.0` breaks `morello@0.4.0`, which uses the old Barlow API and declares `<0.10.0`.
- `elmish@0.14.0` breaks `elmish-hooks@0.11.0`; meanwhile, `elmish-html@0.12.0` requires Elmish 0.14, so neither Elmish candidate can move until the dependent packages are compatible.
- `hyrule@2.4.0` removes modules still imported by `bolson@0.3.9`, `deku@0.9.24`, and `ocarina@1.5.4`.
- `node-child-process@12.0.0` changes the exit API and breaks `dotenv@4.0.3` and `node-execa@5.0.0`.

So this is the point of the script: surface upgrades that automatic daily updates could not accept so maintainers can identify and submit a compatible coordinated batch.