### PR TITLE
Retain Dhall schemas in server closure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -261,7 +261,12 @@
         };
 
         registry =
-          { lib, modulesPath, ... }:
+          {
+            lib,
+            modulesPath,
+            pkgs,
+            ...
+          }:
           let
             host = "registry.purescript.org";
           in
@@ -283,9 +288,9 @@
                     # the state directory, unless there are viable defaults.
                     inherit
                       DHALL_PRELUDE
-                      DHALL_TYPES
                       GIT_TERMINAL_PROMPT
                       ;
+                    DHALL_TYPES = "${pkgs.registry-server}/bin/types";
                   };
                 };
                 system.stateVersion = "24.05";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -233,7 +233,12 @@ in
     description = "PureScript Registry API server";
     src = ../app;
     spagoLock = app;
-    extraInstall = "cp -r ${../db} $out/bin/db";
+    # Keep runtime schemas in the server closure rather than relying on a
+    # separately referenced source path in the deployed environment.
+    extraInstall = ''
+      cp -r ${../db} $out/bin/db
+      cp -r ${../types} $out/bin/types
+    '';
   }) { };
 
   registry-github-importer = prev.callPackage (buildRegistryPackage {

--- a/nix/registry-server.nix
+++ b/nix/registry-server.nix
@@ -16,8 +16,10 @@ let
     mkdir -p ${cfg.stateDir}/db
 
     set -o allexport
-    source ${envFile}
     [ -f ${cfg.stateDir}/.env ] && source ${cfg.stateDir}/.env
+    # Deployment-managed values must override state-dir values. Otherwise a
+    # stale non-secret setting such as DHALL_TYPES can survive a deployment.
+    source ${envFile}
     set +o allexport
 
     export DATABASE_URL="sqlite:${cfg.stateDir}/db/registry.sqlite3"

--- a/nix/test/smoke.nix
+++ b/nix/test/smoke.nix
@@ -27,6 +27,7 @@ else
     envVars = testConfig.testEnv;
     stateDir = "/var/lib/registry-server";
     repoFixturesDir = "${stateDir}/repo-fixtures";
+    dhallTypes = "${pkgs.registry-server}/bin/types";
   in
   pkgs.testers.nixosTest {
     name = "registry-smoke";
@@ -60,6 +61,13 @@ else
 
       # Check that the service is still running (didn't crash)
       registry.succeed("systemctl is-active server.service")
+
+      # A stale state-dir value must not override deployment-managed schema paths.
+      pid = registry.succeed("systemctl show --value --property MainPID server.service").strip()
+      registry.succeed(
+          f"tr '\\0' '\\n' < /proc/{pid}/environ | grep -Fx 'DHALL_TYPES=${dhallTypes}'"
+      )
+      registry.succeed("test -f ${dhallTypes}/v1/Manifest.dhall")
 
       # Give the job executor a moment to start and potentially fail
       time.sleep(2)
@@ -96,6 +104,8 @@ else
           RemainAfterExit = true;
         };
         script = ''
+          mkdir -p ${stateDir}
+          echo 'DHALL_TYPES=/defunct/types' > ${stateDir}/.env
           ${testConfig.setupGitFixtures}/bin/setup-git-fixtures ${repoFixturesDir}
         '';
       };
@@ -108,6 +118,7 @@ else
         inherit stateDir;
         envVars = envVars // {
           REPO_FIXTURES_DIR = repoFixturesDir;
+          DHALL_TYPES = dhallTypes;
         };
       };
     };


### PR DESCRIPTION
[Publish job `6c1efe17-ed9a-470d-a329-68609ae598b6`](https://www.purescript.org/registry-dev/#/jobs/6c1efe17-ed9a-470d-a329-68609ae598b6), reported in [purescript/registry#565](https://github.com/purescript/registry/issues/565#issuecomment-5593183597), failed while validating a `purs.json` manifest because `DHALL_TYPES` pointed at a missing Nix-store path.

The deployment generated an env file containing `DHALL_TYPES=/nix/store/...-source/types`, but that env file did not retain the schema source as a Nix store reference. After garbage collection removed the source tree, the running server retained a dangling path and `json-to-dhall` could no longer read `types/v1/Manifest.dhall`.